### PR TITLE
fix(grounding): graceful kb degradation when Perspicacite is unreachable

### DIFF
--- a/collections/metabolomics/v2/bin/perspicacite_kb_bind.py
+++ b/collections/metabolomics/v2/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/ce-ms/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/ce-ms/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/direct-infusion/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/direct-infusion/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/gc-ms/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/gc-ms/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/ion-mobility/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/ion-mobility/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/lc-ms/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/lc-ms/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/ms-generic/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/ms-generic/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/ms-imaging/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/ms-imaging/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/packs/metabolomics/nmr/bin/perspicacite_kb_bind.py
+++ b/packs/metabolomics/nmr/bin/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/scripts/perspicacite_kb_bind.py
+++ b/scripts/perspicacite_kb_bind.py
@@ -129,6 +129,11 @@ def prepare_kb(slug: str, doi: str, desc: str) -> dict:
         if e.code not in (400, 409):
             status["error"] = f"create {e.code}"
             return status
+    except Exception as e:
+        # connection refused / DNS / timeout — Perspicacité unreachable. Degrade
+        # gracefully (the kb backend is optional; callers fall back to `local`).
+        status["error"] = f"perspicacite unreachable: {str(e)[:160]}"
+        return status
     try:
         resp = _http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
         status["ingested"] = True

--- a/tests/test_perspicacite_kb_bind_local.py
+++ b/tests/test_perspicacite_kb_bind_local.py
@@ -26,3 +26,14 @@ def test_clone_repo_invokes_git(tmp_path):
     assert kb.clone_repo("https://github.com/a/b", tmp_path / "r", _run=fake_run) is True
     assert calls and calls[0][0] == "git" and "clone" in calls[0]
     assert "--" in calls[0]
+
+
+def test_prepare_kb_graceful_when_server_unreachable(monkeypatch):
+    import urllib.error
+    def boom(*a, **k):
+        raise urllib.error.URLError("Connection refused")
+    monkeypatch.setattr(kb, "_http", boom)
+    status = kb.prepare_kb("asb-paper-x", "10.x/y", "ASB grounding KB")
+    assert isinstance(status, dict)
+    assert status.get("created") is False
+    assert "unreachable" in (status.get("error") or "")


### PR DESCRIPTION
Follow-up to #5. Found while testing the reinstalled LC-MS pack with Perspicacite offline: the kb 'prepare' path crashed with an unhandled connection error (URLError) instead of degrading, because the KB-create step caught only HTTPError. This catches connection errors and returns a graceful 'unreachable' manifest, matching the 'local' backend (which already works with no server). Adds a regression test and re-vendors the fixed binder into all 9 units. 86 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)