### PR TITLE
fix(ci): repair tier-update.yml YAML block-scalar break (fails on every push)

### DIFF
--- a/.github/workflows/tier-update.yml
+++ b/.github/workflows/tier-update.yml
@@ -84,8 +84,7 @@ jobs:
             git config user.name "asb-skill-collections-bot"
             git config user.email "bot@holobiomicslab.cnrs.fr"
             git add contributors.jsonld
-            git commit -m "chore(tier): auto-update contributor tiers after review merge
-
-Driver: scripts/tier_update.py · Spec §9.6"
+            git commit -m "chore(tier): auto-update contributor tiers after review merge" \
+              -m "Driver: scripts/tier_update.py · Spec §9.6"
             git push origin main
           fi


### PR DESCRIPTION
Fixes tier-update.yml, which fails on EVERY push to main (22 consecutive failures).

Root cause: the commit-message body line 'Driver: scripts/tier_update.py ...' sat at column 0 inside the run: | block, terminating the YAML block scalar mid-script. That leaked a stray top-level 'Driver' key and truncated the step (dropping the git push / fi), so GitHub's workflow validator rejected the file at evaluation -> a failed run on every push, regardless of the paths: filter (the filter is never even reached).

Fix: use two -m flags on properly-indented lines (identical subject+body commit). Verified the workflow now parses with top-level keys {name, on, permissions, jobs} only and the run: block is intact through git push / fi.

Generated with Claude Code