### PR TITLE
docs: literature sources, inclusion criteria & paper-contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,6 +51,60 @@ evidence provenance, and FAIR metadata completeness.
 2. Include: domain name, short description, 3-5 seed papers (DOIs), proposed Lead Curator.
 3. After maintainer go-ahead, open a PR adding `staged-collections/<domain>/v1/`.
 
+## Propose or annotate a paper
+
+ASB-Skills are distilled from peer-reviewed **method papers**. Before proposing,
+skim the inclusion criteria in [`governance/SOURCES.md`](../governance/SOURCES.md)
+so your suggestion self-screens. Anyone may suggest or annotate a paper; **a
+maintainer always makes the final merge decision** (you cannot self-merge), and
+COI/tier rules are unchanged.
+
+There are three ways to contribute a paper:
+
+### 1. Suggest via an issue (lightest)
+
+Open a **Propose a paper** issue using the
+[`propose-paper`](ISSUE_TEMPLATE/propose-paper.md) template. Fill in the DOI,
+target collection, self-reported access tier, and a concrete rationale. A curator
+runs the checklist (DOI resolves on Crossref; access verified via Unpaywall; not
+already in the collection's `corpus.yaml`; not retracted; thematic fit), and a
+maintainer adds the accepted paper to `collections/<slug>/v<N>/corpus.yaml`.
+
+### 2. Suggest via a pull request (Enveda-style, low-friction)
+
+Prefer a PR? Add the paper directly to the target
+`collections/<slug>/v<N>/corpus.yaml` under `papers:`, using the
+`asb-corpus/1.0` schema, with `status: hold` (pending curator review):
+
+```yaml
+- name: ToolOrMethodName
+  doi: 10.xxxx/xxxxx
+  title: Full paper title
+  category: <category from the review-series taxonomy>
+  repo_url: owner/repo            # or full URL to code/data
+  status: hold                    # maintainer flips to "included" after review
+  wave: next
+  access:
+    type: gold-oa                 # CI (verify-paper.yml) verifies this
+    is_oa: true
+```
+
+On the PR, `verify-paper.yml` checks access/OA and `validate.yml` checks the
+schema. A maintainer reviews scientific fit against
+[`governance/SOURCES.md`](../governance/SOURCES.md) and merges, flipping
+`status` to `included`.
+
+### 3. Annotate an existing or proposed paper
+
+Improve a paper already in (or proposed to) the corpus by either:
+- a small PR editing that paper's `corpus.yaml` entry, or
+- a structured comment on the open `propose-paper` issue.
+
+**Annotatable fields:** `category` (refine to the review-series taxonomy),
+`repo_url`, and free-text rationale/fit/tags. **Not annotatable** (maintainer/CI-
+owned): `doi`, the `access` block, and `status` — these are set by verification
+and curation, not by annotation.
+
 ## Tier progression
 
 | Tier | Requirement |

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Prefer a PR? Add the paper directly to the target
   category: <category from the review-series taxonomy>
   repo_url: owner/repo            # or full URL to code/data
   status: hold                    # maintainer flips to "included" after review
-  wave: next
+  wave: <curation batch — maintainer-assigned>
   access:
     type: gold-oa                 # CI (verify-paper.yml) verifies this
     is_oa: true

--- a/.github/ISSUE_TEMPLATE/propose-paper.md
+++ b/.github/ISSUE_TEMPLATE/propose-paper.md
@@ -25,9 +25,11 @@ labels: ["propose-paper", "needs-triage"]
 ## Access tier (self-reported, CI will verify)
 
 - [ ] **Open-access** — explicit CC / open license
-- [ ] **Hybrid** — paywalled with quotation rights (default for most journals)
+- [ ] **Hybrid** — paywalled with quotation rights
 - [ ] **Closed** — paywalled, no open abstract
 - [ ] Don't know — let CI determine
+
+> **Note:** v0 is **open-access only** — Hybrid/Closed proposals are deferred to v1 and will not pass CI. See [`CONTENT_POLICY.md` §3](../../governance/CONTENT_POLICY.md).
 
 ## Rationale
 

--- a/.github/ISSUE_TEMPLATE/propose-paper.md
+++ b/.github/ISSUE_TEMPLATE/propose-paper.md
@@ -5,6 +5,11 @@ title: "Propose: <DOI or short title>"
 labels: ["propose-paper", "needs-triage"]
 ---
 
+> 📚 **Before filing:** check the inclusion criteria in
+> [`governance/SOURCES.md`](../../governance/SOURCES.md) so your proposal
+> self-screens. Both the scientific gate (SOURCES) and the legal/OA gate
+> (CONTENT_POLICY) apply.
+
 ## Paper
 
 - **DOI:** <!-- e.g. 10.1186/s13321-024-00878-1 -->

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ API generation costs for this collection were sponsored by **CNRS** and
 **Université Côte d'Azur**. Built with the AgenticScienceBuilder pipeline and
 grounded with Perspicacité (Holobiomics Lab).
 
+## 📚 Sources & provenance
+
+Skills are distilled from peer-reviewed **method papers** anchored to the
+computational metabolomics review series (Misra → Enveda). See
+[`governance/SOURCES.md`](governance/SOURCES.md) for the source inventory and the
+scientific inclusion criteria, and [`governance/CONTENT_POLICY.md`](governance/CONTENT_POLICY.md)
+for the legal/open-access policy.
+
+**Suggest or annotate a paper:** see
+[Contributing → Propose or annotate a paper](.github/CONTRIBUTING.md#propose-or-annotate-a-paper).
+
 ## License
 
 Dual-licensed, by layer (see [LICENSING.md](LICENSING.md)):

--- a/governance/CONTENT_POLICY.md
+++ b/governance/CONTENT_POLICY.md
@@ -12,6 +12,10 @@ This policy establishes the legal and operational boundaries for ingesting, stor
 
 **Core principle:** ASB transforms copyrighted source papers into independently-authored structured artifacts (benchmarks, skills, capsules) grounded in facts and methods (not copyrightable) and attributable to their sources via DOIs and fair use. All public releases are legally defensible on fair-use grounds and explicitly license-compliant.
 
+> **Scientific gate:** this policy is the *legal* gate. The *scientific* gate —
+> where source papers come from and what makes them eligible — is documented in
+> [`SOURCES.md`](SOURCES.md). Both gates apply to every paper.
+
 ---
 
 ## 2. Three-Tier Content Model

--- a/governance/SOURCES.md
+++ b/governance/SOURCES.md
@@ -1,0 +1,104 @@
+# Scientific Sources & Inclusion Criteria
+
+**Status:** v0 · **Date:** 2026-06-22 · **Scope:** the *scientific* gate for ASB-Skill source papers.
+
+> This document complements [`CONTENT_POLICY.md`](CONTENT_POLICY.md). **CONTENT_POLICY governs the *legal* gate** (open-access status, licensing, transformation bounds). **This document governs the *scientific* gate** (where a paper comes from and what makes it eligible). **Both gates apply to every paper** before it enters a collection's corpus.
+
+## 1. Why this document
+
+ASB-Skills are distilled from peer-reviewed **method papers**. To keep the corpus
+principled and auditable, every source paper is anchored to a recognized field
+inventory and screened against explicit scientific criteria — separately from,
+and in addition to, the open-access/legal checks in `CONTENT_POLICY.md`.
+
+## 2. Anchoring literature — the computational metabolomics review series
+
+Our universe of candidate methods is anchored to the **computational metabolomics
+review series**, a periodically updated inventory of the field's tools and
+methods, in two eras:
+
+**Misra-led era (~2014/2015–2020).** The annual "metabolomics tools & resources
+updates" review series.
+
+<!-- BEGIN Task-1 citations: Misra series -->
+The annual "metabolomics tools & resources updates" review series by **B.B. Misra**
+(with **J.J.J. van der Hooft** on the 2015 edition, per the Enveda repository's own
+attribution). It periodically inventoried computational metabolomics methods,
+tools, databases, and resources across roughly 2014/2015–2020.
+
+- Named anchors cited by the Enveda repo: **Misra (2021)** and **Misra & van der Hooft (2015)**.
+- Exact per-edition titles, venues, years, and DOIs:
+  <!-- TO VERIFY via Perspicacité / Crossref — not recalled from memory -->
+<!-- END Task-1 citations: Misra series -->
+
+**Enveda-continued era (2021–2025).** [`github.com/enveda/computational-metabolomics-review`](https://github.com/enveda/computational-metabolomics-review)
+— a curated inventory of computational metabolomics tools/software/databases
+(`tools_list.tsv`; 40+ categories spanning annotation, GC-MS/LC-MS/NMR/imaging-MS/
+ion-mobility, lipidomics, exposomics, multiomics, …). **License: GPL-3.0.** It
+explicitly continues Misra (2021) and Misra–van der Hooft (2015). Associated
+peer-reviewed paper:
+
+<!-- BEGIN Task-1 citation: Enveda paper -->
+**Domingo-Fernández D. et al.** (Enveda Biosciences). Computational metabolomics
+review / tools inventory. *Analytical Chemistry*, **2026** (forthcoming).
+DOI: <!-- TO VERIFY (paper forthcoming) -->
+Repository: https://github.com/enveda/computational-metabolomics-review
+(License **GPL-3.0**; `tools_list.tsv`; 40+ categories; continues Misra 2021 and
+Misra & van der Hooft 2015).
+<!-- END Task-1 citation: Enveda paper -->
+
+**Tools vs. method papers.** The review series curates *tools/software*; ASB-Skills
+distill *peer-reviewed method papers*. The provenance chain is:
+
+> review series enumerates a method/tool → its peer-reviewed method paper is the
+> inclusion candidate → curation (legal + scientific gates) → `corpus.yaml` →
+> skills.
+
+We cite these reviews as **named upstream sources of candidate methods**. We do
+not import their lists automatically, and we add no per-paper provenance field
+(provenance is documented here, at the corpus level).
+
+## 3. Scientific inclusion criteria
+
+A source paper is **eligible** when it meets all of:
+
+1. **Method/tool-introducing** — it introduces a method, algorithm, tool, or
+   resource (not a pure application or biological-result paper).
+2. **Reproducible artifact** — it has a public code repository, dataset, or
+   executable workflow that enables an agent task / benchmark.
+3. **Thematic fit** — it fits a target collection's scope.
+4. **Adoption or foundational signal** — it is widely used, foundational, or
+   captures rare/valuable expertise.
+5. **Traceable to the field inventory** — it is consistent with the
+   computational-metabolomics review-series taxonomy (or an analogous curated
+   inventory for non-metabolomics collections).
+6. **Current** — not retracted, and not fully superseded by a later method that
+   replaces it.
+
+## 4. Exclusion criteria
+
+A paper is **excluded** when any of:
+
+- No method/tool/resource (pure application or result-only).
+- No reproducible artifact (no code/data/workflow to ground an agent task).
+- Out of the target collection's scope.
+- Retracted (Crossref / Retraction Watch).
+- Fails the **legal gate** in `CONTENT_POLICY.md` (paywalled/closed/unknown
+  access, or a restrictive license). See [`OPEN_ACCESS_POLICY.md`](OPEN_ACCESS_POLICY.md).
+
+## 5. How the corpus derives from sources
+
+Each collection's source-of-truth is `collections/<slug>/v<N>/corpus.yaml`
+(`schema: asb-corpus/1.0`). It records a corpus-level `source:` line and, per
+paper, a `category` aligned to the review-series taxonomy plus an `access` block
+(verified per `CONTENT_POLICY.md`). The pipeline is:
+
+> review-series / proposal → candidate method paper → curation (this document's
+> scientific gate **and** CONTENT_POLICY's legal gate) → `corpus.yaml` entry →
+> distilled skills.
+
+## 6. Contributing & related policies
+
+- **Suggest or annotate a paper:** see [CONTRIBUTING → "Propose or annotate a paper"](../.github/CONTRIBUTING.md#propose-or-annotate-a-paper).
+- **Legal/provenance policy:** [`CONTENT_POLICY.md`](CONTENT_POLICY.md).
+- **Open-access verification:** [`OPEN_ACCESS_POLICY.md`](OPEN_ACCESS_POLICY.md).


### PR DESCRIPTION
## What

Documents (1) **where the source scientific literature comes from** and the **scientific inclusion criteria** for ASB-Skills, and (2) **how the community suggests and annotates papers** — connecting the repo's existing machinery rather than rebuilding it. Documentation-only (no code, no new workflows).

## Changes

- **`governance/SOURCES.md`** (new) — the *scientific* gate, complementing `CONTENT_POLICY.md` (the *legal/OA* gate). Anchors the corpus to the **Misra → Enveda computational-metabolomics review series** (`enveda/computational-metabolomics-review`, GPL-3.0; Domingo-Fernández et al. 2026, *Anal. Chem.*, forthcoming), with the tools-vs-method-papers provenance chain and explicit inclusion/exclusion criteria.
- **`.github/CONTRIBUTING.md`** — new "Propose or annotate a paper" section: issue path (existing `propose-paper` template), Enveda-style direct `corpus.yaml` PR path (`status: hold` → maintainer flips to `included`), and an annotation path (annotatable: `category`/`repo_url`/notes; maintainer/CI-owned: `doi`/`access`/`status`).
- **Cross-links** — README "Sources & provenance" section; a one-line self-screen note + OA-only caveat in `propose-paper.md`; a `SOURCES.md` ↔ `CONTENT_POLICY.md` cross-reference.

## Notes

- Citations carry `<!-- TO VERIFY -->` markers: Perspicacité (the lab's citation tool) was unreachable/unwired during authoring, so only Enveda-README-sourced facts are asserted; the specific Misra-series DOIs are to be verified via Perspicacité in a follow-up. The markers are self-documenting.
- Provenance stays **doc-level** (no new per-paper `corpus.yaml` field); Enveda is cited as a named upstream only (no automation).
- All internal cross-links verified resolving; existing test suite unaffected (112 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)