### PR TITLE
Operationalize pipelines: ship commands, promotion, grounding, embedding similarity graph

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -323,3 +323,9 @@ jobs:
       # -- Gate: Community-skill proposals ------
       - name: Proposals gate
         run: python -m scripts.check_proposals collections/metabolomics/v2
+
+      # -- Gate: Related-skills referential integrity ------
+      # Vacuously passes until a maintainer runs the embedding precompute
+      # (pip install '.[embed]' && python -m scripts.build_related_skills).
+      - name: Related-skills gate
+        run: python -m scripts.check_related_skills collections/metabolomics/v2

--- a/collections/metabolomics/v2/commands/propose-skill.md
+++ b/collections/metabolomics/v2/commands/propose-skill.md
@@ -49,14 +49,24 @@ Steps:
    **warn** that the skill may overlap an existing one and suggest **annotating or
    merging** into that skill (via `CONTRIBUTING.md`) rather than adding a duplicate.
 
-4. **Ground (optional, best-effort) — this is where Perspicacité fits.** If a
-   Perspicacité server is reachable, use it to look for a supporting paper for the
-   skill's claims, the same way `/ground` does (`scripts/perspicacite_kb_bind.py`,
-   the real per-DOI KB API). If a strong supporting paper is found, attach its DOI
-   under `derived_from` and flag the skill as a `literature_upgrade_candidate`.
-   This is optional — a community skill is **not** required to derive from a paper.
-   If Perspicacité is unavailable, proceed ungrounded and say so. (Matching in
-   step 3 is lexical and never needs a server; Perspicacité is used only here.)
+4. **Ground (optional, best-effort) — this is where Perspicacité fits.** Propose a
+   **candidate source DOI** for the skill's claims (from the contributor, the tool's
+   own paper, or a literature search), then verify it executably against the real
+   per-DOI KB API with `scripts/ground_skill.py` — it ensures the
+   `asb-paper-<doi-slug>` KB and asks `/api/chat` whether the paper *supports* the
+   skill, returning a structured `{supported, confidence, evidence}` verdict:
+   ```bash
+   python -m scripts.ground_skill --doi "<candidate-DOI>" \
+       --skill-md "<normalized-SKILL.md>"
+   ```
+   This **never fails the flow**: if Perspicacité is unreachable (or the paper does
+   not support the claims) it returns `{"supported": false, "confidence": "low"}` and
+   you proceed **ungrounded** — say so. A community skill is **not** required to
+   derive from a paper. Only when the verdict is `supported: true` with
+   `confidence` ∈ {`high`, `medium`} (and you've eyeballed the returned `evidence`
+   quote), attach the DOI under `derived_from` and flag
+   `metadata.literature_upgrade_candidate: true`; otherwise leave both unset. (Matching
+   in step 3 is lexical and never needs a server; Perspicacité is used only here.)
 
 5. **Tier it `community` / `hold`.** Assemble the schema-correct frontmatter:
    `provenance_tier: community` (so the `related_skills` key is present — empty list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ asbb = "scripts.asbb_cli:main"
 hf = [
     "huggingface_hub>=0.23",
 ]
+# Embedding similarity graph (scripts.build_related_skills). The model is loaded
+# lazily — the module imports fine without this extra; only the real precompute
+# needs it.
+embed = [
+    "sentence-transformers>=2.2",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ hf = [
 embed = [
     "sentence-transformers>=2.2",
 ]
+embed-openai = [
+    "openai>=1.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov",

--- a/scripts/build_grounding_bundle.py
+++ b/scripts/build_grounding_bundle.py
@@ -123,6 +123,15 @@ def build_unit(unit_dir, collection_dir, bind_script):
     shutil.copyfile(bind_script, unit_dir / "bin" / "perspicacite_kb_bind.py"); written.append("bin/perspicacite_kb_bind.py")
     (unit_dir / "commands").mkdir(exist_ok=True)
     (unit_dir / "commands" / "ground.md").write_text(render_ground_command()); written.append("commands/ground.md")
+    # ship the contribution commands (propose-skill, synthesize-meta-skill, …)
+    # verbatim alongside the rendered ground.md
+    src_cmds = collection_dir / "commands"
+    if src_cmds.is_dir():
+        for md in sorted(src_cmds.glob("*.md")):
+            if md.name == "ground.md":
+                continue  # ground.md is always the rendered version, not the collection copy
+            shutil.copyfile(md, unit_dir / "commands" / md.name)
+            written.append(f"commands/{md.name}")
     (unit_dir / "GROUNDING.md").write_text(render_grounding_doc(unit_dir.name)); written.append("GROUNDING.md")
     pj_path = unit_dir / ".claude-plugin" / "plugin.json"
     if not pj_path.is_file():

--- a/scripts/build_related_skills.py
+++ b/scripts/build_related_skills.py
@@ -5,13 +5,20 @@ builds a *semantic* similarity graph from sentence-transformer embeddings of eac
 skill's :func:`skill_match.skill_doc` text, and writes the resulting top-N
 neighbour lists into ``skills_index.json`` + ``kb_bundle.json``.
 
+Two backends, one injectable interface (``embedder_for``):
+
+* **local** — pinned MiniLM (``sentence-transformers``, ``[embed]`` extra):
+  lightweight, offline, no key.
+* **openai** — ``text-embedding-3-large`` (``openai``, ``[embed-openai]`` extra):
+  the advanced backend, the *same* model Perspicacité uses (3072-dim); needs
+  ``OPENAI_API_KEY``. The CLI defaults to this when a key is present, else local.
+
 Design constraints (see the operationalize-pipelines plan):
 
-* **Optional dependency.** The embedding model lives behind the ``[embed]`` extra
-  (``sentence-transformers``). :func:`default_embedder` imports it *lazily* — only
-  when called — so this module imports fine without the extra, and the pure
-  graph/IO helpers (:func:`related_map`, :func:`embed_skills`, :func:`build`) work
-  with any injected embedder.
+* **Optional dependencies, lazy import.** Both backend builders import their
+  package *inside* the function, so this module imports fine without either extra,
+  and the pure graph/IO helpers (:func:`related_map`, :func:`embed_skills`,
+  :func:`build`) work with any injected embedder.
 * **No live model/network in tests.** Every entry point takes an injected
   ``embedder`` (a ``callable(list[str]) -> list[list[float]]``); only the CLI
   reaches for :func:`default_embedder`.
@@ -65,6 +72,62 @@ def default_embedder():
         return [[float(x) for x in v] for v in vecs]
 
     return embed
+
+
+_OPENAI_MODEL = "text-embedding-3-large"
+
+
+def openai_embedder(model=_OPENAI_MODEL, *, batch_size=256):
+    """Return ``embed(texts) -> list[list[float]]`` backed by the OpenAI
+    embeddings API (``text-embedding-3-large`` by default — the *same* model
+    Perspicacité uses, 3072-dim). Reads ``OPENAI_API_KEY`` from the environment.
+
+    ``openai`` is imported here, *not* at module import time, so this module loads
+    without it; calling without the package or a key raises with guidance.
+    """
+    try:
+        from openai import OpenAI
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "openai_embedder requires the optional 'embed-openai' extra: "
+            "pip install '.[embed-openai]'  (openai)"
+        ) from e
+    import os
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("openai_embedder requires OPENAI_API_KEY in the environment")
+    client = OpenAI()
+
+    def embed(texts):
+        texts = list(texts)
+        out: list[list[float]] = []
+        for i in range(0, len(texts), batch_size):
+            resp = client.embeddings.create(model=model, input=texts[i : i + batch_size])
+            out.extend([list(d.embedding) for d in resp.data])
+        return out
+
+    return embed
+
+
+def embedder_for(backend, **kwargs):
+    """Resolve a backend name to an embedder.
+
+    ``local`` — pinned MiniLM (offline, no key, lightweight);
+    ``openai`` — ``text-embedding-3-large`` (advanced, Perspicacité-aligned, needs
+    ``OPENAI_API_KEY``).
+    """
+    if backend == "local":
+        return default_embedder()
+    if backend == "openai":
+        return openai_embedder(**kwargs)
+    raise ValueError(f"unknown embedder backend {backend!r} (use 'local' or 'openai')")
+
+
+def default_backend():
+    """Prefer the advanced OpenAI backend when a key is present, else lightweight local."""
+    import os
+
+    return "openai" if os.environ.get("OPENAI_API_KEY") else "local"
 
 
 def embed_skills(skills_index, *, embedder):
@@ -191,12 +254,19 @@ def main(argv=None) -> int:
         "--threshold", type=float, default=DEFAULT_THRESHOLD,
         help=f"minimum cosine similarity (default {DEFAULT_THRESHOLD})",
     )
+    ap.add_argument(
+        "--backend", choices=("local", "openai"), default=None,
+        help="embedder: 'local' (MiniLM, offline) or 'openai' (text-embedding-3-large). "
+             "Default: openai when OPENAI_API_KEY is set, else local.",
+    )
     a = ap.parse_args(argv)
 
-    # default_embedder (the live model) is reached only here, never in build's
+    # A live embedder (model / API) is constructed only here, never in build's
     # importable path or in tests.
-    res = build(a.collection, embedder=None, top_n=a.top_n, threshold=a.threshold)
-    print(json.dumps(res, indent=2))
+    backend = a.backend or default_backend()
+    res = build(a.collection, embedder=embedder_for(backend), top_n=a.top_n,
+                threshold=a.threshold)
+    print(json.dumps({"backend": backend, **res}, indent=2))
     return 0
 
 

--- a/scripts/build_related_skills.py
+++ b/scripts/build_related_skills.py
@@ -1,0 +1,204 @@
+"""Embedding similarity graph — precompute ``related_skills`` per skill (Task B4).
+
+A complement to the lexical ``skill_match`` core: instead of TF-IDF cosine, this
+builds a *semantic* similarity graph from sentence-transformer embeddings of each
+skill's :func:`skill_match.skill_doc` text, and writes the resulting top-N
+neighbour lists into ``skills_index.json`` + ``kb_bundle.json``.
+
+Design constraints (see the operationalize-pipelines plan):
+
+* **Optional dependency.** The embedding model lives behind the ``[embed]`` extra
+  (``sentence-transformers``). :func:`default_embedder` imports it *lazily* — only
+  when called — so this module imports fine without the extra, and the pure
+  graph/IO helpers (:func:`related_map`, :func:`embed_skills`, :func:`build`) work
+  with any injected embedder.
+* **No live model/network in tests.** Every entry point takes an injected
+  ``embedder`` (a ``callable(list[str]) -> list[list[float]]``); only the CLI
+  reaches for :func:`default_embedder`.
+* **Idempotent, indent-preserving writes.** Reuses
+  ``propagate_license_tiers.detect_indent`` and writes a file only when its
+  serialization changes.
+* **No git/gh side effects, no ``Date.now``.**
+
+The real 5,865-skill precompute (``pip install '.[embed]'`` then
+``python -m scripts.build_related_skills --collection collections/metabolomics/v2``)
+is a maintainer operation. Until it is run, ``related_skills`` is absent and the
+``check_related_skills`` gate passes vacuously — which is correct.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+
+from scripts.propagate_license_tiers import detect_indent
+from scripts.skill_match import skill_doc
+
+# Pinned model: small, fast, widely cached. Behind the [embed] extra.
+_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+# Defaults for the similarity graph.
+DEFAULT_TOP_N = 8
+DEFAULT_THRESHOLD = 0.3
+
+
+def default_embedder():
+    """Return ``embed(texts) -> list[list[float]]`` backed by a pinned model.
+
+    ``sentence-transformers`` is imported here, *not* at module import time, so
+    this module loads without the ``[embed]`` extra. Calling this function
+    without the extra installed raises ``ImportError`` with install guidance.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "default_embedder requires the optional 'embed' extra: "
+            "pip install '.[embed]'  (sentence-transformers)"
+        ) from e
+
+    model = SentenceTransformer(_MODEL_NAME)
+
+    def embed(texts):
+        # convert_to_numpy=False keeps a plain list-of-lists return shape.
+        vecs = model.encode(list(texts), convert_to_numpy=False)
+        return [[float(x) for x in v] for v in vecs]
+
+    return embed
+
+
+def embed_skills(skills_index, *, embedder):
+    """Embed each skill's document text into a ``{slug: vector}`` map.
+
+    Text per skill is :func:`skill_match.skill_doc` (name + description + tools +
+    EDAM topics + techniques). ``embedder`` is a ``callable(list[str]) ->
+    list[list[float]]`` (injected — never the live model in tests). Entries
+    without a ``slug`` are skipped.
+    """
+    entries = [e for e in (skills_index or []) if e.get("slug")]
+    if not entries:
+        return {}
+    docs = [skill_doc(e) for e in entries]
+    vectors = embedder(docs)
+    return {e["slug"]: list(v) for e, v in zip(entries, vectors)}
+
+
+def _cosine(a, b) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    if dot == 0.0:
+        return 0.0
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def related_map(vectors, *, top_n=DEFAULT_TOP_N, threshold=DEFAULT_THRESHOLD):
+    """Cosine top-N neighbour graph from a ``{slug: vector}`` map. Pure.
+
+    For each slug, returns the ``top_n`` other slugs with the highest cosine
+    similarity that is strictly above ``threshold``, excluding self. Ties in
+    similarity are broken by slug ascending (deterministic output). Returns
+    ``{slug: [slug, ...]}``.
+    """
+    slugs = sorted(vectors)
+    out: dict[str, list[str]] = {}
+    for s in slugs:
+        vs = vectors[s]
+        scored = []
+        for other in slugs:
+            if other == s:
+                continue
+            sim = _cosine(vs, vectors[other])
+            if sim > threshold:
+                scored.append((sim, other))
+        # highest similarity first; tie-break by slug ascending.
+        scored.sort(key=lambda p: (-p[0], p[1]))
+        out[s] = [slug for _, slug in scored[:top_n]]
+    return out
+
+
+def _load_json(path):
+    raw = path.read_text(encoding="utf-8")
+    return json.loads(raw), detect_indent(raw)
+
+
+def _write_json_if_changed(path, obj, indent) -> bool:
+    """Write ``obj`` only when the serialization differs. Returns True if written."""
+    new = json.dumps(obj, indent=indent, ensure_ascii=False)
+    if path.exists() and path.read_text(encoding="utf-8") == new:
+        return False
+    path.write_text(new, encoding="utf-8")
+    return True
+
+
+def build(collection_dir, *, embedder=None, top_n=DEFAULT_TOP_N,
+          threshold=DEFAULT_THRESHOLD) -> dict:
+    """Compute + write the ``related_skills`` graph for a collection.
+
+    Embeds every skill in ``skills_index.json`` (via ``embedder``, defaulting to
+    :func:`default_embedder` when none is injected), builds the cosine top-N
+    graph, and writes each neighbour list into both the ``skills_index.json``
+    entry and the matching ``kb_bundle.json['skills'][slug]`` record. Writes are
+    indent-preserving and idempotent (a file unchanged in content is not
+    rewritten). Returns ``{"count": int, "written": bool}``.
+    """
+    if embedder is None:
+        embedder = default_embedder()
+
+    d = pathlib.Path(collection_dir)
+    si_path = d / "skills_index.json"
+    kb_path = d / "kb_bundle.json"
+
+    si, si_indent = _load_json(si_path)
+    kb, kb_indent = _load_json(kb_path)
+
+    vectors = embed_skills(si, embedder=embedder)
+    rel = related_map(vectors, top_n=top_n, threshold=threshold)
+
+    for entry in si:
+        slug = entry.get("slug")
+        if slug in rel:
+            entry["related_skills"] = rel[slug]
+
+    kb_skills = kb.get("skills")
+    if isinstance(kb_skills, dict):
+        for slug, neighbours in rel.items():
+            rec = kb_skills.get(slug)
+            if isinstance(rec, dict):
+                rec["related_skills"] = neighbours
+
+    wrote_si = _write_json_if_changed(si_path, si, si_indent)
+    wrote_kb = _write_json_if_changed(kb_path, kb, kb_indent)
+
+    return {"count": len(rel), "written": bool(wrote_si or wrote_kb)}
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection", required=True,
+        help="collection root (skills_index.json + kb_bundle.json)",
+    )
+    ap.add_argument(
+        "--top-n", type=int, default=DEFAULT_TOP_N,
+        help=f"neighbours per skill (default {DEFAULT_TOP_N})",
+    )
+    ap.add_argument(
+        "--threshold", type=float, default=DEFAULT_THRESHOLD,
+        help=f"minimum cosine similarity (default {DEFAULT_THRESHOLD})",
+    )
+    a = ap.parse_args(argv)
+
+    # default_embedder (the live model) is reached only here, never in build's
+    # importable path or in tests.
+    res = build(a.collection, embedder=None, top_n=a.top_n, threshold=a.threshold)
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_related_skills.py
+++ b/scripts/check_related_skills.py
@@ -1,0 +1,81 @@
+"""CI gate: every ``related_skills`` reference resolves to a real skill.
+
+The embedding similarity graph (scripts.build_related_skills) writes a
+``related_skills`` neighbour list onto each ``skills_index.json`` entry. This gate
+checks referential integrity: every slug listed in any entry's ``related_skills``
+must itself be a slug present in ``skills_index.json``.
+
+The field is *optional* — it is absent until a maintainer runs the
+embedding precompute (``pip install '.[embed]'`` then
+``python -m scripts.build_related_skills``). A collection with no
+``related_skills`` anywhere (the default real-data state) yields no violations,
+so the gate passes vacuously, which is correct.
+
+``main`` exits 1 on any dangling reference, 0 otherwise. Mirrors
+scripts/check_proposals.py and scripts/check_provenance_tiers.py.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def check_collection(collection_dir) -> list[str]:
+    d = pathlib.Path(collection_dir)
+    violations: list[str] = []
+
+    si_path = d / "skills_index.json"
+    if not si_path.is_file():
+        return violations
+
+    si = json.loads(si_path.read_text(encoding="utf-8"))
+    if isinstance(si, dict):
+        si = si.get("skills") or si.get("entries") or []
+    if not isinstance(si, list):
+        return violations
+
+    known = {e.get("slug") for e in si if isinstance(e, dict)}
+
+    for entry in si:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("slug")
+        related = entry.get("related_skills")
+        if related is None:
+            continue
+        if not isinstance(related, list):
+            violations.append(
+                f"skills_index {slug!r}: related_skills is not a list"
+            )
+            continue
+        for ref in related:
+            if ref not in known:
+                violations.append(
+                    f"skills_index {slug!r}: related_skills {ref!r} "
+                    f"not in skills_index.json"
+                )
+
+    return violations
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        print("usage: check_related_skills <collection_dir> [...]", file=sys.stderr)
+        return 2
+    failed = False
+    for col in argv:
+        v = check_collection(col)
+        if v:
+            failed = True
+            print(f"FAIL {col}:")
+            for x in v:
+                print(f"  - {x}")
+        else:
+            print(f"OK   {col}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ground_skill.py
+++ b/scripts/ground_skill.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""ground_skill — executable, best-effort literature grounding for a skill claim.
+
+The *propose-skill* flow (``commands/propose-skill.md`` step 4) lets a contributor
+propose a candidate source DOI for a community skill. This module turns that into
+an executable check: it ensures the canonical per-paper KB
+(``asb-paper-<doi-slug>`` — the SAME slug the build + binder use, see
+:func:`scripts.perspicacite_kb_bind.kb_slug`) exists in a running Perspicacité
+instance, then asks — over ``/api/chat`` scoped to that KB — whether the paper
+**supports the skill's claims**, and parses a structured verdict + evidence quote.
+
+Design contract (mirrors the binder's generate-on-use + graceful-degrade rails):
+
+* :func:`verify_doi_support` **never raises**. Any error — unreachable server,
+  malformed reply, missing answer — degrades to
+  ``{supported: False, confidence: "low", evidence: ""}`` (plus the ``doi``).
+* The HTTP client is **injected** (``http``), a callable matching
+  ``perspicacite_kb_bind._http(method, path, body=None, timeout=...)``. Tests pass
+  a mock; the CLI uses the real ``_http``. No live network in importable code.
+* No git/gh side effects. No ``Date.now``.
+
+A *supportive* verdict at ``high``/``medium`` confidence is the signal the command
+uses to attach ``derived_from`` + ``metadata.literature_upgrade_candidate: true``.
+
+Examples
+--------
+    python -m scripts.ground_skill --doi 10.1021/acs.jnatprod.7b00737 \
+        --skill-md path/to/SKILL.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+from scripts.perspicacite_kb_bind import _http as _real_http
+from scripts.perspicacite_kb_bind import kb_slug
+
+UNSUPPORTED = {"supported": False, "confidence": "low", "evidence": ""}
+
+VALID_CONFIDENCE = ("high", "medium", "low")
+
+_PROMPT = (
+    "You are grounding a candidate skill against a single source paper. Using ONLY "
+    "the retrieved passages from this paper, decide whether the paper SUPPORTS the "
+    "claims/methods of the skill below.\n\n"
+    "Reply in EXACTLY this structured form:\n"
+    "VERDICT: SUPPORTED or NOT_SUPPORTED\n"
+    "CONFIDENCE: high, medium, or low\n"
+    'EVIDENCE: a short verbatim quote from the paper (or "" if none)\n\n'
+    "Skill:\n{skill}\n"
+)
+
+
+def _ensure_kb(slug: str, doi: str, http) -> None:
+    """Best-effort create+ingest the per-DOI KB via the injected ``http``.
+
+    Mirrors :func:`scripts.perspicacite_kb_bind.prepare_kb` but uses the injected
+    client so it stays network-free under test. Swallows every error — grounding is
+    best-effort and the chat call degrades on its own if the KB is absent.
+    """
+    try:
+        stats = http("GET", f"/api/kb/{slug}/stats", timeout=30)
+        if isinstance(stats, dict) and (stats.get("chunk_count") or 0) > 0:
+            return  # already present
+    except Exception:
+        pass  # 404 / unreachable — fall through to (re)create
+    try:
+        http("POST", "/api/kb",
+             {"name": slug, "description": f"ASB grounding KB ({doi})"}, timeout=60)
+    except Exception:
+        pass  # 400/409 already-exists, or unreachable
+    try:
+        http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
+    except Exception:
+        pass
+
+
+def _answer_text(resp) -> str:
+    """Pull the assistant answer out of a /api/chat response (binder's shape)."""
+    if isinstance(resp, dict):
+        ans = resp.get("answer") or resp.get("response") or resp.get("content")
+        if isinstance(ans, str):
+            return ans
+        if ans is not None:
+            return json.dumps(ans)
+    if isinstance(resp, str):
+        return resp
+    return ""
+
+
+def _parse_verdict(text: str) -> dict:
+    """Parse the structured VERDICT/CONFIDENCE/EVIDENCE reply.
+
+    Tolerant: missing/garbled fields degrade to unsupported+low rather than raise.
+    """
+    if not text:
+        return dict(UNSUPPORTED)
+    m_verdict = re.search(r"VERDICT\s*:\s*(SUPPORTED|NOT[_\s-]?SUPPORTED)", text, re.I)
+    if not m_verdict:
+        return dict(UNSUPPORTED)
+    supported = m_verdict.group(1).upper().replace(" ", "_").replace("-", "_") == "SUPPORTED"
+
+    conf = "low"
+    m_conf = re.search(r"CONFIDENCE\s*:\s*(high|medium|low)", text, re.I)
+    if m_conf:
+        conf = m_conf.group(1).lower()
+    elif supported:
+        conf = "medium"  # supported but unspecified confidence -> conservative medium
+
+    evidence = ""
+    m_ev = re.search(r"EVIDENCE\s*:\s*(.+)", text, re.I | re.S)
+    if m_ev:
+        evidence = m_ev.group(1).strip().strip('"').strip()
+
+    if not supported:
+        # never advertise high confidence for a negative verdict downstream
+        conf = "low" if conf == "high" else conf
+
+    return {"supported": supported, "confidence": conf, "evidence": evidence}
+
+
+def verify_doi_support(skill_text: str, doi: str, *, http=None, prepare: bool = True) -> dict:
+    """Ask whether ``doi``'s paper supports ``skill_text``'s claims. Never raises.
+
+    Parameters
+    ----------
+    skill_text : str
+        The skill's claims/body (e.g. its SKILL.md text) to ground.
+    doi : str
+        Candidate source DOI; its KB is ``asb-paper-<doi-slug>``.
+    http : callable, optional
+        ``http(method, path, body=None, timeout=...)`` (the binder's ``_http``
+        shape). Defaults to the real Perspicacité client.
+    prepare : bool
+        When True, best-effort create+ingest the KB before querying.
+
+    Returns
+    -------
+    dict
+        ``{doi, supported: bool, confidence: "high"|"medium"|"low", evidence: str}``.
+        On any failure: ``{doi, supported: False, confidence: "low", evidence: ""}``.
+    """
+    if http is None:
+        http = _real_http
+    result = dict(UNSUPPORTED)
+    result["doi"] = doi
+    try:
+        slug = kb_slug(doi)
+        if prepare:
+            _ensure_kb(slug, doi, http)
+        payload = {
+            "query": _PROMPT.format(skill=skill_text or ""),
+            "kb_names": [slug],
+            "mode": "paper",
+            "stream": False,
+        }
+        resp = http("POST", "/api/chat", payload, timeout=600)
+        parsed = _parse_verdict(_answer_text(resp))
+        parsed["doi"] = doi
+        return parsed
+    except Exception:
+        # Unreachable / unexpected — best-effort grounding degrades, never raises.
+        return result
+
+
+def main(argv=None, *, http=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--doi", required=True, help="candidate source DOI to ground against")
+    ap.add_argument("--skill-md", required=True,
+                    help="path to the SKILL.md whose claims to verify")
+    a = ap.parse_args(argv)
+
+    try:
+        from pathlib import Path
+        skill_text = Path(a.skill_md).read_text(encoding="utf-8")
+    except Exception as e:  # missing/unreadable file is a real CLI error
+        print(json.dumps({"error": f"cannot read --skill-md: {str(e)[:160]}"}, indent=2))
+        return 1
+
+    out = verify_doi_support(skill_text, a.doi, http=http)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ground_skill.py
+++ b/scripts/ground_skill.py
@@ -39,8 +39,6 @@ from scripts.perspicacite_kb_bind import kb_slug
 
 UNSUPPORTED = {"supported": False, "confidence": "low", "evidence": ""}
 
-VALID_CONFIDENCE = ("high", "medium", "low")
-
 _PROMPT = (
     "You are grounding a candidate skill against a single source paper. Using ONLY "
     "the retrieved passages from this paper, decide whether the paper SUPPORTS the "

--- a/scripts/promote_proposals.py
+++ b/scripts/promote_proposals.py
@@ -173,6 +173,7 @@ def promote(collection_dir, slugs, *, date: str, dry_run: bool = False) -> dict:
 
     promoted: list[str] = []
     skipped: list[str] = []
+    promoted_tools: list = []  # (slug, tools_used) — for used_by_skills back-links
 
     for slug in slugs:
         proposal_md = d / "proposals" / "skills" / slug / "SKILL.md"
@@ -206,6 +207,7 @@ def promote(collection_dir, slugs, *, date: str, dry_run: bool = False) -> dict:
         si.append(_index_entry(slug, fm))
         existing_slugs.add(slug)
         kb.setdefault("skills", {})[slug] = _kb_record(fm)
+        promoted_tools.append((slug, (fm.get("metadata") or {}).get("tools_used") or []))
 
         # --- re-stamp the SKILL.md to match the index (idempotent) ----------- #
         tier = (fm.get("metadata") or {}).get("provenance_tier")
@@ -215,8 +217,34 @@ def promote(collection_dir, slugs, *, date: str, dry_run: bool = False) -> dict:
     if not dry_run and promoted:
         _write_json_if_changed(si_path, si, si_indent)
         _write_json_if_changed(kb_path, kb, kb_indent)
+        _link_used_by_skills(d / "tools_index.json", promoted_tools)
 
     return {"promoted": promoted, "skipped": skipped}
+
+
+def _link_used_by_skills(tools_path, promoted_tools) -> None:
+    """Keep the tool catalog's inverse index in sync after promotion.
+
+    The forward ``tools_used`` is carried verbatim from the proposal frontmatter
+    (curated by the matcher / synthesis); this adds each promoted skill to those
+    tools' ``used_by_skills`` so the bidirectional link is consistent — without a
+    full DOI re-derive (``enrich_tools_index``), which would drop curated
+    community/synthetic links whose skills carry no matching corpus DOI.
+    Idempotent: a slug already present is left untouched.
+    """
+    if not promoted_tools or not tools_path.is_file():
+        return
+    tools, indent = _load_json(tools_path)
+    by_slug = {t.get("slug"): t for t in tools}
+    for slug, tools_used in promoted_tools:
+        for tool_slug in tools_used:
+            tool = by_slug.get(tool_slug)
+            if tool is None:
+                continue
+            ubs = tool.get("used_by_skills") or []
+            if slug not in ubs:
+                tool["used_by_skills"] = sorted([*ubs, slug])
+    _write_json_if_changed(tools_path, tools, indent)
 
 
 def main(argv=None) -> int:

--- a/scripts/promote_proposals.py
+++ b/scripts/promote_proposals.py
@@ -1,0 +1,262 @@
+"""Promote a staged skill proposal into the published collection.
+
+The maintainer-side, mechanical half of the curation flow: a staged
+``proposals/skills/<slug>/SKILL.md`` (``status: hold``) that has passed review is
+*moved* into ``skills/<slug>/SKILL.md`` with ``status: included``, and the three
+committed indices are updated so the promoted skill is indistinguishable from a
+pipeline-built one:
+
+* ``skills_index.json`` — a new entry derived from the frontmatter
+  (``slug, name, description, edam_operation, edam_topics, techniques, tools,
+  dois, provenance_tier, tools_used, license_tier``);
+* ``kb_bundle.json`` — a new skill record (``dois, tools, kb_slugs, repo_urls,
+  license_tier, provenance_tier, tools_used``);
+* the SKILL.md is re-stamped (``metadata.provenance_tier`` /
+  ``metadata.license_tier``) so it matches its index entry under the
+  provenance / license CI gates.
+
+Reuses the existing machinery rather than re-implementing it:
+``normalize_skill.parse_skill_md`` (frontmatter parse), ``propose_skill``'s
+rendering conventions, ``perspicacite_kb_bind.kb_slug`` (KB-slug derivation),
+``propagate_license_tiers.detect_indent`` (indent-preserving JSON),
+``stamp_provenance.stamp_skill_provenance`` (frontmatter re-stamp).
+
+Invariants:
+
+* **Idempotent.** An already-promoted slug (present in ``skills_index.json``) is a
+  no-op and reported under ``skipped``; JSON files are written only when content
+  changes.
+* **No git/gh side effects.** A maintainer runs git/gh after reviewing the move.
+* **No ``Date.now`` in importable code.** ``promote`` takes ``date`` as an
+  argument; only :func:`main` may default it.
+
+See governance/PROVENANCE_TIERS.md and governance/COMMUNITY_SKILLS.md.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+from scripts.normalize_skill import parse_skill_md
+from scripts.perspicacite_kb_bind import kb_slug
+from scripts.propagate_license_tiers import detect_indent
+from scripts.propose_skill import render_skill_md
+from scripts.stamp_provenance import stamp_skill_provenance
+
+# skills_index entry fields derived from frontmatter (order = output key order).
+_INDEX_KEYS = (
+    "slug",
+    "name",
+    "description",
+    "edam_operation",
+    "edam_topics",
+    "tools",
+    "dois",
+    "techniques",
+    "license_tier",
+    "provenance_tier",
+    "tools_used",
+)
+
+
+def staged_slugs(collection_dir) -> list[str]:
+    """Slugs under ``proposals/skills/`` whose SKILL.md is held (``status: hold``).
+
+    Sorted, deduplicated. A collection with no ``proposals/skills/`` yields []."""
+    d = pathlib.Path(collection_dir)
+    base = d / "proposals" / "skills"
+    if not base.is_dir():
+        return []
+    out: list[str] = []
+    for md in sorted(base.glob("*/SKILL.md")):
+        fm, _ = parse_skill_md(md.read_text(encoding="utf-8"))
+        if isinstance(fm, dict) and fm.get("status") == "hold":
+            out.append(md.parent.name)
+    return out
+
+
+def _index_entry(slug: str, fm: dict) -> dict:
+    """Build the skills_index entry for ``slug`` from its frontmatter.
+
+    Pulls the top-level ``description``/``name`` and the ``metadata`` block
+    (EDAM, tools, techniques, dois, tiers, tools_used). For a community proposal
+    the ``related_skills`` key is carried onto the index so the provenance gate's
+    ``validate_entry(community, related_skills=...)`` is satisfied.
+    """
+    meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+    src = {
+        "slug": slug,
+        "name": fm.get("name") or slug,
+        "description": fm.get("description"),
+        "edam_operation": meta.get("edam_operation"),
+        "edam_topics": list(meta.get("edam_topics") or []),
+        "tools": list(meta.get("tools") or []),
+        "dois": list(meta.get("dois") or fm.get("dois") or []),
+        "techniques": list(meta.get("techniques") or []),
+        "license_tier": meta.get("license_tier"),
+        "provenance_tier": meta.get("provenance_tier"),
+        "tools_used": list(meta.get("tools_used") or []),
+    }
+    entry = {k: src[k] for k in _INDEX_KEYS}
+    # provenance-tier invariants carried onto the index entry.
+    if "related_skills" in fm:
+        entry["related_skills"] = list(fm.get("related_skills") or [])
+    if "synthesized_from" in meta:
+        entry["synthesized_from"] = list(meta.get("synthesized_from") or [])
+    return entry
+
+
+def _kb_record(fm: dict) -> dict:
+    """Build the kb_bundle skill record from frontmatter (KB slugs from dois)."""
+    meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+    dois = list(meta.get("dois") or fm.get("dois") or [])
+    return {
+        "dois": dois,
+        "tools": list(meta.get("tools") or []),
+        "kb_slugs": [kb_slug(d) for d in dois],
+        "repo_urls": list(meta.get("repo_urls") or []),
+        "license_tier": meta.get("license_tier"),
+        "provenance_tier": meta.get("provenance_tier"),
+        "tools_used": list(meta.get("tools_used") or []),
+    }
+
+
+def _load_json(path):
+    raw = path.read_text(encoding="utf-8")
+    return json.loads(raw), detect_indent(raw)
+
+
+def _write_json_if_changed(path, obj, indent) -> bool:
+    """Write ``obj`` only when the serialization differs. Returns True if written."""
+    new = json.dumps(obj, indent=indent, ensure_ascii=False)
+    if path.exists() and path.read_text(encoding="utf-8") == new:
+        return False
+    path.write_text(new, encoding="utf-8")
+    return True
+
+
+def promote(collection_dir, slugs, *, date: str, dry_run: bool = False) -> dict:
+    """Promote staged proposal ``slugs`` into the published collection.
+
+    For each slug: move ``proposals/skills/<slug>/SKILL.md`` →
+    ``skills/<slug>/SKILL.md`` with ``status`` flipped to ``included``; append a
+    ``skills_index.json`` entry + ``kb_bundle.json`` record; re-stamp the SKILL.md
+    so it matches its index entry. Idempotent: a slug already present in
+    ``skills_index.json`` is a no-op and reported under ``skipped`` (so are slugs
+    that are not staged / not held).
+
+    Parameters
+    ----------
+    collection_dir : path-like
+        Collection root (``skills/``, ``proposals/``, the three indices).
+    slugs : iterable[str]
+        Proposal slugs to promote.
+    date : str
+        Curation date (``YYYY-MM-DD``). Required (no ``Date.now`` here). Recorded
+        for symmetry with the proposal ledger; not embedded in the artifacts.
+    dry_run : bool
+        When True, write nothing; ``promoted`` lists the slugs that *would* be
+        promoted (the plan).
+
+    Returns ``{"promoted": [...], "skipped": [...]}``.
+    """
+    if not date:
+        raise ValueError("promote requires an explicit date (YYYY-MM-DD)")
+
+    d = pathlib.Path(collection_dir)
+    si_path = d / "skills_index.json"
+    kb_path = d / "kb_bundle.json"
+
+    si, si_indent = _load_json(si_path)
+    kb, kb_indent = _load_json(kb_path)
+    existing_slugs = {e.get("slug") for e in si}
+
+    promoted: list[str] = []
+    skipped: list[str] = []
+
+    for slug in slugs:
+        proposal_md = d / "proposals" / "skills" / slug / "SKILL.md"
+        # already published, not staged, or not held → skip (idempotent / safe).
+        if slug in existing_slugs or not proposal_md.is_file():
+            skipped.append(slug)
+            continue
+        fm, body = parse_skill_md(proposal_md.read_text(encoding="utf-8"))
+        if not isinstance(fm, dict) or fm.get("status") != "hold":
+            skipped.append(slug)
+            continue
+
+        promoted.append(slug)
+        if dry_run:
+            continue
+
+        # --- move SKILL.md, flip status hold -> included --------------------- #
+        fm = dict(fm)
+        fm["status"] = "included"
+        published_md = d / "skills" / slug / "SKILL.md"
+        published_md.parent.mkdir(parents=True, exist_ok=True)
+        published_md.write_text(render_skill_md(fm, body), encoding="utf-8")
+        proposal_md.unlink()
+        # drop the now-empty proposal directory (best-effort).
+        try:
+            proposal_md.parent.rmdir()
+        except OSError:
+            pass
+
+        # --- append index entry + kb record --------------------------------- #
+        si.append(_index_entry(slug, fm))
+        existing_slugs.add(slug)
+        kb.setdefault("skills", {})[slug] = _kb_record(fm)
+
+        # --- re-stamp the SKILL.md to match the index (idempotent) ----------- #
+        tier = (fm.get("metadata") or {}).get("provenance_tier")
+        if tier:
+            stamp_skill_provenance(published_md, tier)
+
+    if not dry_run and promoted:
+        _write_json_if_changed(si_path, si, si_indent)
+        _write_json_if_changed(kb_path, kb, kb_indent)
+
+    return {"promoted": promoted, "skipped": skipped}
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection",
+        required=True,
+        help="collection root (skills/ + proposals/ + the three indices)",
+    )
+    ap.add_argument(
+        "--slug",
+        action="append",
+        default=None,
+        dest="slugs",
+        help="proposal slug to promote (repeatable; default: all staged/held)",
+    )
+    ap.add_argument(
+        "--date",
+        default=None,
+        help="curation date YYYY-MM-DD (default: today, only in the CLI)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="print the plan; write nothing"
+    )
+    a = ap.parse_args(argv)
+
+    # Date.now lives ONLY here (the importable promote takes date as arg).
+    date = a.date
+    if not date:
+        import datetime
+
+        date = datetime.date.today().isoformat()
+
+    slugs = a.slugs if a.slugs else staged_slugs(a.collection)
+    res = promote(a.collection, slugs, date=date, dry_run=a.dry_run)
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_grounding_bundle.py
+++ b/tests/test_build_grounding_bundle.py
@@ -109,3 +109,61 @@ def test_build_unit_emits_all_artifacts(tmp_path):
     assert ".claude-plugin/plugin.json" not in written2
     desc2 = json.loads((unit / ".claude-plugin" / "plugin.json").read_text())["description"]
     assert desc2 == desc
+
+
+def _make_unit(tmp_path):
+    unit = tmp_path / "unit"
+    (unit / "skills" / "bioactivity-score-aggregation").mkdir(parents=True)
+    (unit / ".claude-plugin").mkdir()
+    (unit / ".claude-plugin" / "plugin.json").write_text(json.dumps({"name": "u", "description": "Subset."}))
+    bind = tmp_path / "src_bind.py"; bind.write_text("# vendored bind\n")
+    return unit, bind
+
+
+def _make_collection_with_commands(tmp_path):
+    col = tmp_path / "col"
+    col.mkdir()
+    shutil_copy_fixture(col)
+    cmds = col / "commands"
+    cmds.mkdir()
+    (cmds / "ground.md").write_text("STALE ground content — should be overwritten\n")
+    (cmds / "propose-skill.md").write_text("# propose-skill\nbody\n")
+    (cmds / "synthesize-meta-skill.md").write_text("# synthesize-meta-skill\nbody\n")
+    return col
+
+
+def shutil_copy_fixture(col):
+    import shutil
+    for name in ("corpus.yaml", "kb_bundle.json", "tools_index.json"):
+        shutil.copyfile(FIX / name, col / name)
+
+
+def test_build_unit_ships_all_collection_commands(tmp_path):
+    from scripts.build_grounding_bundle import build_unit, render_ground_command
+    unit, bind = _make_unit(tmp_path)
+    col = _make_collection_with_commands(tmp_path)
+    written = build_unit(unit, col, bind)
+    cmd_dir = unit / "commands"
+    # all three commands ship
+    assert (cmd_dir / "ground.md").exists()
+    assert (cmd_dir / "propose-skill.md").exists()
+    assert (cmd_dir / "synthesize-meta-skill.md").exists()
+    # ground.md comes from render_ground_command(), not the collection's stale copy
+    assert (cmd_dir / "ground.md").read_text() == render_ground_command()
+    # other commands copied verbatim
+    assert (cmd_dir / "propose-skill.md").read_text() == "# propose-skill\nbody\n"
+    assert (cmd_dir / "synthesize-meta-skill.md").read_text() == "# synthesize-meta-skill\nbody\n"
+    # writes are reported relative to the unit
+    assert "commands/ground.md" in written
+    assert "commands/propose-skill.md" in written
+    assert "commands/synthesize-meta-skill.md" in written
+
+
+def test_build_unit_without_collection_commands_dir(tmp_path):
+    # When the collection has no commands/ dir, only ground.md is shipped.
+    from scripts.build_grounding_bundle import build_unit
+    unit, bind = _make_unit(tmp_path)
+    written = build_unit(unit, FIX, bind)
+    assert (unit / "commands" / "ground.md").exists()
+    assert "commands/ground.md" in written
+    assert not any(w.startswith("commands/") and w != "commands/ground.md" for w in written)

--- a/tests/test_build_related_skills.py
+++ b/tests/test_build_related_skills.py
@@ -1,0 +1,248 @@
+"""Tests for the embedding similarity graph (Task B4).
+
+A FAKE deterministic embedder is used everywhere — NO sentence-transformers
+model, NO network. The fake maps each skill's text to a fixed vector keyed by a
+sentinel token in the text, so cosine neighbours are known up front.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+from scripts import build_related_skills as brs
+from scripts import check_related_skills as crs
+
+
+# --------------------------------------------------------------------------- #
+# Fake embedder: deterministic vectors picked by a token in the text.
+# --------------------------------------------------------------------------- #
+# Four 2-D unit-ish vectors. a/b are close (small angle); c is orthogonal to a;
+# d is anti-parallel to a (cosine < 0).
+_VECTORS = {
+    "AAA": [1.0, 0.0],
+    "BBB": [0.96, 0.28],   # ~16 deg from AAA  -> cosine ~0.96
+    "CCC": [0.0, 1.0],     # orthogonal to AAA -> cosine 0.0
+    "DDD": [-1.0, 0.0],    # opposite AAA      -> cosine -1.0
+}
+
+
+def _fake_embed(texts):
+    out = []
+    for t in texts:
+        for token, vec in _VECTORS.items():
+            if token in t:
+                out.append(list(vec))
+                break
+        else:  # pragma: no cover - guard, tests always tag their text
+            out.append([0.0, 0.0])
+    return out
+
+
+def _index(*pairs):
+    """Build a minimal skills_index list. Each pair = (slug, tag-token)."""
+    return [
+        {"slug": slug, "name": slug, "description": f"desc {tag}", "tools": []}
+        for slug, tag in pairs
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# related_map — pure cosine top-N.
+# --------------------------------------------------------------------------- #
+def test_related_map_orders_by_cosine_and_excludes_self_and_below_threshold():
+    vectors = {
+        "a": _VECTORS["AAA"],
+        "b": _VECTORS["BBB"],
+        "c": _VECTORS["CCC"],
+        "d": _VECTORS["DDD"],
+    }
+    rel = brs.related_map(vectors, top_n=8, threshold=0.3)
+    # a is close to b only (c=0.0 below threshold, d negative)
+    assert rel["a"] == ["b"]
+    assert rel["b"] == ["a"]
+    # c orthogonal to everything -> no neighbours above 0.3
+    assert rel["c"] == []
+    # never include self
+    for slug, neighbours in rel.items():
+        assert slug not in neighbours
+
+
+def test_related_map_respects_top_n():
+    # three mutually-close vectors plus one far one
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.99, 0.10],
+        "c": [0.98, 0.15],
+        "z": [0.0, 1.0],
+    }
+    rel = brs.related_map(vectors, top_n=1, threshold=0.3)
+    assert len(rel["a"]) == 1
+    # the single nearest neighbour of a is b (higher cosine than c)
+    assert rel["a"] == ["b"]
+
+
+def test_related_map_slug_tie_break():
+    # b and c are at the SAME cosine to a -> tie broken by slug ascending.
+    vectors = {
+        "a": [1.0, 0.0],
+        "c": [0.8, 0.6],
+        "b": [0.8, -0.6],
+    }
+    rel = brs.related_map(vectors, top_n=8, threshold=0.3)
+    assert rel["a"] == ["b", "c"]
+
+
+def test_related_map_empty():
+    assert brs.related_map({}, top_n=8, threshold=0.3) == {}
+
+
+# --------------------------------------------------------------------------- #
+# embed_skills — text via skill_match.skill_doc, vectors via injected embedder.
+# --------------------------------------------------------------------------- #
+def test_embed_skills_uses_injected_embedder():
+    idx = _index(("a", "AAA"), ("b", "BBB"))
+    vecs = brs.embed_skills(idx, embedder=_fake_embed)
+    assert set(vecs) == {"a", "b"}
+    assert vecs["a"] == _VECTORS["AAA"]
+    assert vecs["b"] == _VECTORS["BBB"]
+
+
+# --------------------------------------------------------------------------- #
+# build — writes related_skills into both indices, indent-preserving + idempotent.
+# --------------------------------------------------------------------------- #
+def _write_collection(tmp_path, pairs):
+    col = tmp_path / "col"
+    col.mkdir()
+    idx = _index(*pairs)
+    (col / "skills_index.json").write_text(
+        json.dumps(idx, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    kb = {"collection": "x", "version": 2, "skills": {
+        slug: {"dois": [], "tools": []} for slug, _ in pairs
+    }}
+    (col / "kb_bundle.json").write_text(
+        json.dumps(kb, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return col
+
+
+def test_build_writes_related_skills_into_both_indices(tmp_path):
+    col = _write_collection(
+        tmp_path, [("a", "AAA"), ("b", "BBB"), ("c", "CCC")]
+    )
+    res = brs.build(col, embedder=_fake_embed, top_n=8)
+    assert res["count"] == 3
+
+    si = json.loads((col / "skills_index.json").read_text())
+    by_slug = {e["slug"]: e for e in si}
+    assert by_slug["a"]["related_skills"] == ["b"]
+    assert by_slug["b"]["related_skills"] == ["a"]
+    assert by_slug["c"]["related_skills"] == []
+
+    kb = json.loads((col / "kb_bundle.json").read_text())
+    assert kb["skills"]["a"]["related_skills"] == ["b"]
+    assert kb["skills"]["c"]["related_skills"] == []
+
+
+def test_build_is_idempotent(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    first_si = (col / "skills_index.json").read_text()
+    first_kb = (col / "kb_bundle.json").read_text()
+
+    res2 = brs.build(col, embedder=_fake_embed, top_n=8)
+    assert res2["written"] is False
+    assert (col / "skills_index.json").read_text() == first_si
+    assert (col / "kb_bundle.json").read_text() == first_kb
+
+
+def test_build_preserves_four_space_indent(tmp_path):
+    col = tmp_path / "col"
+    col.mkdir()
+    idx = _index(("a", "AAA"), ("b", "BBB"))
+    (col / "skills_index.json").write_text(
+        json.dumps(idx, indent=4, ensure_ascii=False), encoding="utf-8"
+    )
+    kb = {"skills": {"a": {"dois": []}, "b": {"dois": []}}}
+    (col / "kb_bundle.json").write_text(
+        json.dumps(kb, indent=4, ensure_ascii=False), encoding="utf-8"
+    )
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    text = (col / "skills_index.json").read_text()
+    # a 4-space-indented file keeps 4-space indentation after the write.
+    assert '\n        "slug"' in text or '\n    {' in text
+
+
+# --------------------------------------------------------------------------- #
+# default_embedder — lazy import; module must import WITHOUT the extra.
+# --------------------------------------------------------------------------- #
+def test_module_imports_without_sentence_transformers():
+    # Re-importing the module must not require sentence-transformers.
+    mod = importlib.reload(importlib.import_module("scripts.build_related_skills"))
+    assert hasattr(mod, "default_embedder")
+    assert hasattr(mod, "related_map")
+
+
+def test_default_embedder_is_lazy(monkeypatch):
+    # Calling default_embedder() without the extra installed raises a helpful
+    # ImportError — but merely importing the module (done above) does not.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block(name, *args, **kwargs):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise ImportError("no sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block)
+    with pytest.raises(ImportError):
+        brs.default_embedder()
+
+
+# --------------------------------------------------------------------------- #
+# check_related_skills gate.
+# --------------------------------------------------------------------------- #
+def test_gate_passes_on_clean_collection(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB"), ("c", "CCC")])
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    assert crs.check_collection(col) == []
+
+
+def test_gate_passes_when_field_absent(tmp_path):
+    # No related_skills written anywhere -> vacuously clean (real-data state).
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    assert crs.check_collection(col) == []
+
+
+def test_gate_flags_dangling_reference(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    si = json.loads((col / "skills_index.json").read_text())
+    for e in si:
+        if e["slug"] == "a":
+            e["related_skills"] = ["does-not-exist"]
+    (col / "skills_index.json").write_text(
+        json.dumps(si, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    violations = crs.check_collection(col)
+    assert violations
+    assert any("does-not-exist" in v for v in violations)
+
+
+def test_gate_main_exit_codes(tmp_path):
+    clean = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    brs.build(clean, embedder=_fake_embed, top_n=8)
+    assert crs.main([str(clean)]) == 0
+
+    dirty = tmp_path / "dirty"
+    dirty.mkdir()
+    (dirty / "skills_index.json").write_text(
+        json.dumps([{"slug": "a", "related_skills": ["ghost"]}], indent=2),
+        encoding="utf-8",
+    )
+    (dirty / "kb_bundle.json").write_text(
+        json.dumps({"skills": {}}, indent=2), encoding="utf-8"
+    )
+    assert crs.main([str(dirty)]) == 1

--- a/tests/test_build_related_skills.py
+++ b/tests/test_build_related_skills.py
@@ -246,3 +246,32 @@ def test_gate_main_exit_codes(tmp_path):
         json.dumps({"skills": {}}, indent=2), encoding="utf-8"
     )
     assert crs.main([str(dirty)]) == 1
+
+
+# --- backend factory (no model/network) -------------------------------------
+
+def test_embedder_for_dispatches(monkeypatch):
+    monkeypatch.setattr(brs, "default_embedder", lambda: "LOCAL")
+    monkeypatch.setattr(brs, "openai_embedder", lambda **kw: "OPENAI")
+    assert brs.embedder_for("local") == "LOCAL"
+    assert brs.embedder_for("openai") == "OPENAI"
+    with pytest.raises(ValueError):
+        brs.embedder_for("nope")
+
+
+def test_default_backend_follows_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert brs.default_backend() == "openai"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert brs.default_backend() == "local"
+
+
+def test_openai_embedder_requires_key(monkeypatch):
+    # With no key, constructing the openai backend must fail clearly (not silently).
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    import sys, types
+    fake = types.ModuleType("openai")
+    fake.OpenAI = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "openai", fake)
+    with pytest.raises(RuntimeError):
+        brs.openai_embedder()

--- a/tests/test_ground_skill.py
+++ b/tests/test_ground_skill.py
@@ -1,0 +1,139 @@
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from scripts import ground_skill as gs
+
+
+# --- a mock http(method, path, body=None, timeout=...) matching kb._http ------
+
+
+class MockHttp:
+    """Records calls; returns canned bodies keyed by (method, path-substring)."""
+
+    def __init__(self, chat_reply=None, raises=False):
+        self.chat_reply = chat_reply
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, method, path, body=None, timeout=1200):
+        self.calls.append((method, path, body))
+        if self.raises:
+            raise OSError("Connection refused")
+        if path.endswith("/stats"):
+            # KB exists with chunks so prepare_kb short-circuits to "already present".
+            return {"chunk_count": 7}
+        if path == "/api/chat":
+            return self.chat_reply
+        # KB create / ingest endpoints
+        return {}
+
+
+SUPPORTIVE = (
+    'VERDICT: SUPPORTED\n'
+    'CONFIDENCE: high\n'
+    'EVIDENCE: "The authors normalize features by median fold-change before '
+    'differential testing." (Methods, p.4)'
+)
+
+NON_SUPPORTIVE = (
+    "VERDICT: NOT_SUPPORTED\n"
+    "CONFIDENCE: low\n"
+    "EVIDENCE: The paper never discusses the claimed normalization step."
+)
+
+
+def test_supportive_reply_yields_supported_with_evidence():
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    out = gs.verify_doi_support("skill claims median fold-change normalization",
+                                "10.1/xyz", http=http)
+    assert out["supported"] is True
+    assert out["confidence"] == "high"
+    assert out["doi"] == "10.1/xyz"
+    assert "median fold-change" in out["evidence"]
+    # it actually queried /api/chat scoped to the per-DOI KB slug
+    chat = [c for c in http.calls if c[1] == "/api/chat"]
+    assert chat, "expected a POST /api/chat"
+    assert chat[0][2]["kb_names"] == ["asb-paper-10-1-xyz"]
+
+
+def test_non_supportive_reply_yields_false():
+    http = MockHttp(chat_reply={"answer": NON_SUPPORTIVE})
+    out = gs.verify_doi_support("skill claims something unrelated",
+                                "10.1/xyz", http=http)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"
+    assert out["doi"] == "10.1/xyz"
+
+
+def test_http_that_raises_degrades_to_low_conf_false():
+    http = MockHttp(raises=True)
+    out = gs.verify_doi_support("anything", "10.1/down", http=http)
+    assert out == {
+        "supported": False,
+        "confidence": "low",
+        "evidence": "",
+        "doi": "10.1/down",
+    }
+
+
+def test_malformed_chat_reply_never_raises():
+    # chat returns something with no parseable verdict -> graceful False/low.
+    http = MockHttp(chat_reply={"unexpected": "shape"})
+    out = gs.verify_doi_support("x", "10.1/weird", http=http)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"
+    assert out["doi"] == "10.1/weird"
+
+
+def test_prepare_false_skips_kb_creation():
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    out = gs.verify_doi_support("x", "10.1/abc", http=http, prepare=False)
+    assert out["supported"] is True
+    # no KB create/ingest/stats calls when prepare=False — only the chat call.
+    assert all(c[1] == "/api/chat" for c in http.calls)
+
+
+def test_medium_confidence_supported():
+    reply = {"answer": "VERDICT: SUPPORTED\nCONFIDENCE: medium\nEVIDENCE: see Fig 2."}
+    http = MockHttp(chat_reply=reply)
+    out = gs.verify_doi_support("x", "10.1/m", http=http)
+    assert out["supported"] is True
+    assert out["confidence"] == "medium"
+
+
+def test_answer_under_response_or_content_key():
+    for key in ("response", "content"):
+        http = MockHttp(chat_reply={key: SUPPORTIVE})
+        out = gs.verify_doi_support("x", "10.1/k", http=http)
+        assert out["supported"] is True, key
+
+
+def test_main_writes_json_for_skill_md(tmp_path, capsys):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        "---\nname: My Skill\ndescription: Use when normalizing features.\n---\n"
+        "Body: median fold-change normalization.\n",
+        encoding="utf-8",
+    )
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    rc = gs.main(["--doi", "10.1/cli", "--skill-md", str(skill)], http=http)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["supported"] is True
+    assert out["doi"] == "10.1/cli"
+
+
+def test_main_graceful_when_http_down(tmp_path, capsys):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("---\nname: S\ndescription: Use when x.\n---\nbody\n",
+                     encoding="utf-8")
+    http = MockHttp(raises=True)
+    rc = gs.main(["--doi", "10.1/down", "--skill-md", str(skill)], http=http)
+    # never raises; reports unsupported but exits cleanly (0) — grounding is best-effort.
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"

--- a/tests/test_promote_proposals.py
+++ b/tests/test_promote_proposals.py
@@ -252,6 +252,21 @@ def test_promote_moves_into_skills_with_included_status(tmp_path):
     assert kb["skills"][proposal]["provenance_tier"] == "community"
 
 
+def test_promote_updates_used_by_skills_backlink(tmp_path):
+    # the promoted skill must appear in its tools' used_by_skills so the catalog
+    # inverse index stays consistent (without a full DOI re-derive).
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    tools = json.loads((col / "tools_index.json").read_text(encoding="utf-8"))
+    matchms = next(t for t in tools if t["slug"] == "matchms")
+    assert proposal in matchms["used_by_skills"]
+    # idempotent: re-promote does not duplicate the back-link
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    tools2 = json.loads((col / "tools_index.json").read_text(encoding="utf-8"))
+    matchms2 = next(t for t in tools2 if t["slug"] == "matchms")
+    assert matchms2["used_by_skills"].count(proposal) == 1
+
+
 def test_promote_is_gate_clean(tmp_path):
     col, _, proposal = build_fixture(tmp_path)
     promote_proposals.promote(str(col), [proposal], date=DATE)

--- a/tests/test_promote_proposals.py
+++ b/tests/test_promote_proposals.py
@@ -1,0 +1,330 @@
+"""Tests for scripts.promote_proposals — the proposals → published promotion tool.
+
+A tiny fixture collection is built in a tmp dir (skills_index.json, kb_bundle.json,
+tools_index.json, corpus.yaml, one published skill, one *staged* community
+proposal). We then exercise:
+
+* ``staged_slugs`` finds the held proposal;
+* ``promote`` moves it into ``skills/`` with ``status: included``, appends a
+  skills_index entry + kb_bundle record, and the result is gate-clean under the
+  four CI gates;
+* ``check_proposals`` no longer sees the promoted slug;
+* re-running ``promote`` is a no-op (idempotent);
+* ``--dry-run`` writes nothing.
+
+No git/gh, no network. Mirrors the propose_skill / check_proposals discipline.
+"""
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from scripts import (
+    check_license_tiers,
+    check_proposals,
+    check_provenance_tiers,
+    check_tools_index,
+    promote_proposals,
+)
+
+DATE = "2026-06-26"
+
+
+# --------------------------------------------------------------------------- #
+# fixture                                                                      #
+# --------------------------------------------------------------------------- #
+def _write_json(path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _published_skill_md(slug):
+    fm = {
+        "name": slug,
+        "description": (
+            "Use when you need to detect and align LC-MS features across samples "
+            "as the first stage of an untargeted metabolomics workflow."
+        ),
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_3172"],
+            "tools": ["xcms"],
+            "techniques": ["LC-MS"],
+            "license_tier": "open",
+            "provenance_tier": "literature",
+            "tools_used": ["xcms"],
+        },
+    }
+    return (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+        + "---\n"
+        + "Published skill body.\n"
+    )
+
+
+def _staged_proposal_md(slug):
+    """A held *community* proposal: status hold, related_skills present, valid
+    frontmatter discipline, tools_used resolvable in the fixture tool catalog."""
+    fm = {
+        "name": slug,
+        "description": (
+            "Use when you need to annotate molecular network nodes against a "
+            "reference spectral library and propagate the matches to neighbours."
+        ),
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3631",
+            "edam_topics": ["http://edamontology.org/topic_3172"],
+            "tools": ["matchms"],
+            "techniques": ["LC-MS/MS"],
+            "license_tier": "open",
+            "provenance_tier": "community",
+            "tools_used": ["matchms"],
+        },
+        "status": "hold",
+        "related_skills": ["lc-ms-feature-extraction-and-alignment"],
+    }
+    return (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+        + "---\n"
+        + "Staged community proposal body.\n"
+    )
+
+
+def build_fixture(tmp_path):
+    """Materialize a minimal but gate-valid collection with one staged proposal."""
+    col = tmp_path / "collections" / "demo" / "v2"
+    pub = "lc-ms-feature-extraction-and-alignment"
+    proposal = "library-match-annotation"
+
+    # published skill on disk
+    (col / "skills" / pub).mkdir(parents=True, exist_ok=True)
+    (col / "skills" / pub / "SKILL.md").write_text(
+        _published_skill_md(pub), encoding="utf-8"
+    )
+
+    # staged community proposal on disk
+    (col / "proposals" / "skills" / proposal).mkdir(parents=True, exist_ok=True)
+    (col / "proposals" / "skills" / proposal / "SKILL.md").write_text(
+        _staged_proposal_md(proposal), encoding="utf-8"
+    )
+
+    # tools_index.json — two resolvable tools
+    _write_json(
+        col / "tools_index.json",
+        [
+            {
+                "slug": "xcms",
+                "name": "xcms",
+                "dois": [],
+                "license_tier": "open",
+                "license": None,
+                "license_detection": None,
+                "used_by_skills": [pub],
+            },
+            {
+                "slug": "matchms",
+                "name": "matchms",
+                "dois": [],
+                "license_tier": "open",
+                "license": None,
+                "license_detection": None,
+                "used_by_skills": [],
+            },
+        ],
+    )
+
+    # skills_index.json — just the published skill
+    _write_json(
+        col / "skills_index.json",
+        [
+            {
+                "slug": pub,
+                "name": pub,
+                "description": "Use when you need to detect and align LC-MS features.",
+                "edam_operation": "http://edamontology.org/operation_3215",
+                "edam_topics": ["http://edamontology.org/topic_3172"],
+                "tools": ["xcms"],
+                "dois": ["10.1000/demo"],
+                "techniques": ["LC-MS"],
+                "license_tier": "open",
+                "provenance_tier": "literature",
+                "tools_used": ["xcms"],
+            }
+        ],
+    )
+
+    # kb_bundle.json
+    _write_json(
+        col / "kb_bundle.json",
+        {
+            "collection": "demo",
+            "version": "v2",
+            "perspicacite_kb_mode": "paper",
+            "kb_prefix": "asb-paper",
+            "distinct_dois": 1,
+            "skills": {
+                pub: {
+                    "dois": ["10.1000/demo"],
+                    "tools": ["xcms"],
+                    "kb_slugs": ["asb-paper-10-1000-demo"],
+                    "repo_urls": [],
+                    "license_tier": "open",
+                    "provenance_tier": "literature",
+                    "tools_used": ["xcms"],
+                }
+            },
+        },
+    )
+
+    # corpus.yaml — one paper so check_license_tiers' corpus loop is happy
+    (col / "corpus.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "papers": [
+                    {
+                        "name": "demo",
+                        "doi": "10.1000/demo",
+                        "license_tier": "open",
+                        "access": {"license": "CC-BY-4.0"},
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    return col, pub, proposal
+
+
+def _assert_gates_clean(col):
+    assert check_license_tiers.check_collection(str(col)) == []
+    assert check_provenance_tiers.check_collection(str(col)) == []
+    assert check_tools_index.check_collection(str(col)) == []
+    assert check_proposals.check_collection(str(col)) == []
+
+
+# --------------------------------------------------------------------------- #
+# tests                                                                        #
+# --------------------------------------------------------------------------- #
+def test_fixture_starts_gate_clean(tmp_path):
+    col, _, _ = build_fixture(tmp_path)
+    _assert_gates_clean(col)
+
+
+def test_staged_slugs_finds_held_proposal(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    assert promote_proposals.staged_slugs(str(col)) == [proposal]
+
+
+def test_promote_moves_into_skills_with_included_status(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    res = promote_proposals.promote(str(col), [proposal], date=DATE)
+
+    assert res["promoted"] == [proposal]
+    assert res["skipped"] == []
+
+    # SKILL.md now lives under skills/ and is gone from proposals/skills/
+    new_md = col / "skills" / proposal / "SKILL.md"
+    old_md = col / "proposals" / "skills" / proposal / "SKILL.md"
+    assert new_md.is_file()
+    assert not old_md.exists()
+
+    fm = yaml.safe_load(new_md.read_text(encoding="utf-8").split("---\n", 2)[1])
+    assert fm["status"] == "included"
+
+    # appears in skills_index.json with status-independent fields populated
+    si = json.loads((col / "skills_index.json").read_text(encoding="utf-8"))
+    entry = next(e for e in si if e["slug"] == proposal)
+    assert entry["provenance_tier"] == "community"
+    assert entry["license_tier"] == "open"
+    assert entry["tools_used"] == ["matchms"]
+    assert "related_skills" in entry  # community invariant carried onto the index
+
+    # appears in kb_bundle.json
+    kb = json.loads((col / "kb_bundle.json").read_text(encoding="utf-8"))
+    assert proposal in kb["skills"]
+    assert kb["skills"][proposal]["provenance_tier"] == "community"
+
+
+def test_promote_is_gate_clean(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    _assert_gates_clean(col)
+
+
+def test_check_proposals_no_longer_sees_promoted(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    # the proposal is gone from the proposals rail
+    assert promote_proposals.staged_slugs(str(col)) == []
+    assert check_proposals.check_collection(str(col)) == []
+
+
+def test_promote_is_idempotent(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+    kb_before = (col / "kb_bundle.json").read_text(encoding="utf-8")
+    md_before = (col / "skills" / proposal / "SKILL.md").read_text(encoding="utf-8")
+
+    res2 = promote_proposals.promote(str(col), [proposal], date=DATE)
+    assert res2["promoted"] == []
+    assert res2["skipped"] == [proposal]
+
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+    assert (col / "kb_bundle.json").read_text(encoding="utf-8") == kb_before
+    assert (col / "skills" / proposal / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == md_before
+    # still single index entry for the slug (no duplication)
+    si = json.loads(si_before)
+    assert sum(1 for e in si if e["slug"] == proposal) == 1
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+    kb_before = (col / "kb_bundle.json").read_text(encoding="utf-8")
+
+    res = promote_proposals.promote(str(col), [proposal], date=DATE, dry_run=True)
+    assert res["promoted"] == [proposal]  # the *plan*
+
+    # nothing moved, nothing appended
+    assert (col / "proposals" / "skills" / proposal / "SKILL.md").is_file()
+    assert not (col / "skills" / proposal / "SKILL.md").exists()
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+    assert (col / "kb_bundle.json").read_text(encoding="utf-8") == kb_before
+
+
+def test_main_dry_run_writes_nothing(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+
+    rc = promote_proposals.main(
+        [
+            "--collection",
+            str(col),
+            "--slug",
+            proposal,
+            "--date",
+            DATE,
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert not (col / "skills" / proposal / "SKILL.md").exists()
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+
+
+def test_main_promotes_all_staged_when_no_slug(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    rc = promote_proposals.main(["--collection", str(col), "--date", DATE])
+    assert rc == 0
+    assert (col / "skills" / proposal / "SKILL.md").is_file()
+    _assert_gates_clean(col)


### PR DESCRIPTION
Operationalizes the contribution rails (close-the-loop) and adds matcher/grounding depth. Off `dev`; 385 tests; all 5 gates green.

## A2 — ship contribution commands
`build_grounding_bundle.py` now copies **every** `commands/*.md` into plugin units (was only `ground.md`), so `propose-skill` + `synthesize-meta-skill` reach installed plugins. (Regenerating the shipped packs is a separate maintainer `build_all_grounding.sh` run.)

## A1 — promotion tooling (`scripts/promote_proposals.py`)
`promote(collection, slugs, *, date, dry_run)` moves a staged `proposals/skills/<slug>` → `skills/<slug>` (`status: hold → included`), appends the `skills_index` + `kb_bundle` records, re-stamps provenance, and **updates the tools' `used_by_skills` back-links** so the catalog stays consistent. Idempotent; `--dry-run` default-safe; no git/gh. The real `molecular-networking` example stays **staged** (not auto-promoted).

## A3 — executable grounding (`scripts/ground_skill.py`)
`verify_doi_support(skill_text, doi, *, http)` ensures the `asb-paper-<doi>` KB and asks Perspicacité (`/api/chat`, real API) whether the paper supports the skill's claims → `{supported, confidence, evidence}`. **Never raises** (degrades to low-confidence False with no/broken server). Wired into `propose-skill` step 4 (attach `derived_from` + `literature_upgrade_candidate` on support). The agent proposes the candidate DOI (Perspicacité has no topic-search).

## B4 — embedding similarity graph (`scripts/build_related_skills.py`)
Precompute `related_skills` per skill via an **injectable embedder** (mirrors Perspicacité's `EmbeddingProvider.embed` interface), two backends:
- **local** — pinned MiniLM (`[embed]` extra): offline, no key, lightweight.
- **openai** — `text-embedding-3-large` (`[embed-openai]` extra): the *same* model Perspicacité uses; needs `OPENAI_API_KEY`. CLI defaults to this when a key is present, else local.

Lazy imports keep CI light; tests use a fake embedder. New `check_related_skills` gate (referential integrity) wired into CI. The full 5,865-skill precompute is a maintainer op — `related_skills` is empty until then (gate passes vacuously).

## Verification
- `pytest` → **385 passed** (dev baseline 347 + 38).
- All gates exit 0: license / provenance / tool-catalog / proposals / **related-skills**.
- Promotion idempotent + gate-clean on a fixture; `molecular-networking` still staged.
- Grounding never raises with a down/mocked server; `build_related_skills` imports without either embed extra.

Built via subagent-driven TDD; final whole-branch review MERGEABLE. The one Important finding (promotion not syncing `used_by_skills`) is fixed in this branch with a regression test.
