### PR TITLE
Verify pre-print licences instead of assuming CC-BY; make every shipped skill findable

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Run test suite
         run: python -m pytest tests/ -q
 
+      # -- Gate 0b: Index coverage -------------------------------------------
+      # A skill absent from skills_index.json / kb_bundle.json ships on disk but
+      # cannot be found by search, the MCP server, or the docs site. Nothing else
+      # notices: check_license_tiers.py only inspects skills the index already
+      # knows about, so the orphan stays invisible and CI stays green.
+      - name: Every skill is in every index its collection publishes
+        run: python -m scripts.skill_index
+
       # -- Gate 10: Plugin manifest validates --------------------------------
       - name: Validate .claude-plugin/marketplace.json
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ outputs/
 # License clarification wave output (runtime artifact — not committed)
 governance/license_clarification/wave.yaml
 .license-cache-v2.json
+
+# Local resolver caches (preprint licence lookups, embeddings). Never committed.
+.cache/
+**/.cache/

--- a/collections/metabolomics/v2/kb_bundle.json
+++ b/collections/metabolomics/v2/kb_bundle.json
@@ -57256,6 +57256,17 @@
       ],
       "license_tier": "open"
     },
+    "masster": {
+      "dois": [],
+      "kb_slugs": [],
+      "license_tier": "noncommercial",
+      "repo_urls": [
+        "https://github.com/zamboni-lab/masster-dist"
+      ],
+      "tools": [
+        "Masster"
+      ]
+    },
     "match-factor-threshold-filtering": {
       "dois": [
         "10.1371/journal.pone.0306202"

--- a/collections/metabolomics/v2/skills/masster/SKILL.md
+++ b/collections/metabolomics/v2/skills/masster/SKILL.md
@@ -8,6 +8,7 @@ metadata:
   techniques:
   - LC-MS
   repo_url: https://github.com/zamboni-lab/masster-dist
+  license_tier: noncommercial
   tool_license:
     tier: noncommercial
     requires_ack: true

--- a/collections/metabolomics/v2/skills_index.json
+++ b/collections/metabolomics/v2/skills_index.json
@@ -63356,6 +63356,21 @@
   "license_tier": "open"
  },
  {
+  "slug": "masster",
+  "name": "masster",
+  "description": "Use when you need to run the Zamboni-lab Masster (MASSter) workflow for untargeted LC-MS metabolomics data analysis. NONCOMMERCIAL tool — confirm permitted use before applying (see License notice).",
+  "edam_operation": null,
+  "edam_topics": [],
+  "tools": [
+   "Masster"
+  ],
+  "dois": [],
+  "techniques": [
+   "LC-MS"
+  ],
+  "license_tier": "noncommercial"
+ },
+ {
   "slug": "match-factor-threshold-filtering",
   "name": "match-factor-threshold-filtering",
   "description": "Use when you have a GC-MS dataset with Match.Factor scores for each detected compound (output from Agilent Unknowns Analysis or equivalent), and you want to reduce the number of query chemicals passed to computationally intensive cheminformatics functions (categorate, mzExacto, or exactoThese).",

--- a/docs-site/build_search_index.py
+++ b/docs-site/build_search_index.py
@@ -33,6 +33,9 @@ except ImportError:  # pragma: no cover
 
 # Repo root = parent of docs-site/
 REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.skill_index import split_frontmatter  # noqa: E402  (needs REPO_ROOT on the path)
 DOCS_SITE = Path(__file__).resolve().parent
 OUTPUT = DOCS_SITE / "search_index.json"
 
@@ -62,24 +65,16 @@ def _load_yaml(path: Path) -> dict | None:
 
 
 def _parse_skill_md(path: Path) -> tuple[dict | None, str]:
-    """Return (frontmatter_dict, body_text). Body is everything after the
-    closing '---' delimiter; frontmatter is parsed as YAML."""
+    """Return (frontmatter_dict, body_text) via the canonical SKILL.md parser."""
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
         sys.stderr.write(f"warn: failed to read {path}: {exc}\n")
         return None, ""
-    if not raw.startswith("---"):
-        return None, raw
-    parts = raw.split("---", 2)
-    if len(parts) < 3:
-        return None, raw
-    try:
-        fm = yaml.safe_load(parts[1])
-    except yaml.YAMLError as exc:
-        sys.stderr.write(f"warn: bad frontmatter in {path}: {exc}\n")
-        fm = None
-    return fm, parts[2]
+    frontmatter, body = split_frontmatter(raw)
+    if frontmatter is None:
+        sys.stderr.write(f"warn: bad frontmatter in {path}\n")
+    return frontmatter, body
 
 
 def _extract_summary(body: str) -> str:

--- a/docs-site/search_index.json
+++ b/docs-site/search_index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "generated_at": "2026-06-22T09:21:12+00:00",
+  "generated_at": "2026-07-10T10:02:10+00:00",
   "collections": [
     "epigenomics/v1",
     "metabolomics/v1",
@@ -21937,6 +21937,19 @@
       "search_text": "mzml-data-access-abstraction Use when when building or extending a mass spectrometry data parser that must support multiple mzML storage formats (plain .mzML, indexed .mzML.gz, standard-compressed .mzML. Implement a polymorphic file handler interface (FileInterface) that dispatches mzML file reads to specialized handler classes based on file extension and compression format, enabling unified random-access parsing across uncompressed, indexed-gzip, standard-gzip, and SQLite-backed mzML data sources. This abstraction decouples Reader logic from storage format, permitting extensible support for new backends without modifying core parsing code. metabolomics/v1 10.1093/bioinformatics/bty046"
     },
     {
+      "name": "mzml-data-parsing-pymzml-pyopenms",
+      "description": "Use when you have mzML-format mass spectrometry data files and need to load them into memory as structured data (pandas DataFrame) to prepare for visualization with pyOpenMS-Viz or other analysis pipelines.",
+      "when_to_use_negative": "",
+      "edam_topics": [],
+      "collection": "metabolomics/v1",
+      "summary": "Parse and load mass spectrometry data from mzML files into pandas DataFrames using pymzml or pyOpenMS libraries, enabling downstream visualization and analysis of chromatograms, spectra, and peak maps.",
+      "source_dois": [
+        "10.1021/acs.jproteome.4c00873"
+      ],
+      "md_path": "collections/metabolomics/v1/skills/mzml-data-parsing-pymzml-pyopenms/SKILL.md",
+      "search_text": "mzml-data-parsing-pymzml-pyopenms Use when you have mzML-format mass spectrometry data files and need to load them into memory as structured data (pandas DataFrame) to prepare for visualization with pyOpenMS-Viz or other analysis pipelines. Parse and load mass spectrometry data from mzML files into pandas DataFrames using pymzml or pyOpenMS libraries, enabling downstream visualization and analysis of chromatograms, spectra, and peak maps. metabolomics/v1 10.1021/acs.jproteome.4c00873"
+    },
+    {
       "name": "mzml-feature-table-parsing",
       "description": "Use when you have raw LCMS data in mzML format and a feature table (CSV) from a peak detection pipeline (e.g., MZmine) and need to prepare these inputs for NeatMS preprocessing, batch creation, or peak classification. This skill is the mandatory entry point for any NeatMS workflow.",
       "when_to_use_negative": "",
@@ -31221,6 +31234,17 @@
       "search_text": "artifact-size-measurement-and-range-verification Use when you have built multiple Docker image variants (e.g., cli, dev, linux, windows) from a multi-stage Dockerfile and need to verify that their uncompressed and compressed storage footprints fall within documented acceptable ranges (e. Measure uncompressed and compressed sizes of built Docker image artifacts, compare against documented acceptable ranges, and generate a structured pass/fail verification report. This skill ensures Docker image variants meet storage and distribution requirements before deployment. metabolomics/v2 10.1186/s12859-021-04490-0"
     },
     {
+      "name": "asb-metabolomics",
+      "description": "Use when starting any task with the ASB Metabolomics skill collection — read this meta-skill first. It explains good practice (search -> apply -> ground), enforces the license-tier acknowledgment for non-open tools, then hands off to the _router skill for actual skill selection.",
+      "when_to_use_negative": "",
+      "edam_topics": [],
+      "collection": "metabolomics/v2",
+      "summary": "# asb-metabolomics The entry point for the ASB Metabolomics collection. Run this before routing to a specific skill. ## Protocol: search -> apply -> ground 1. **Search** for a skill via `skills_index.json` (EDAM IRI / tool / keyword) or `tools_index.json`. 2. **License-tier gate (governance).** Read the candidate skill's `metadata.tool_license`. - If `requires_ack: true` (tier `noncommercial`): surface `tier` + `ref` + `url` to the user and obtain an **explicit, blocking acknowledgment** that th",
+      "source_dois": [],
+      "md_path": "collections/metabolomics/v2/skills/asb-metabolomics/SKILL.md",
+      "search_text": "asb-metabolomics Use when starting any task with the ASB Metabolomics skill collection — read this meta-skill first. It explains good practice (search -> apply -> ground), enforces the license-tier acknowledgment for non-open tools, then hands off to the _router skill for actual skill selection. # asb-metabolomics The entry point for the ASB Metabolomics collection. Run this before routing to a specific skill. ## Protocol: search -> apply -> ground 1. **Search** for a skill via `skills_index.json` (EDAM IRI / tool / keyword) or `tools_index.json`. 2. **License-tier gate (governance).** Read the candidate skill's `metadata.tool_license`. - If `requires_ack: true` (tier `noncommercial`): surface `tier` + `ref` + `url` to the user and obtain an **explicit, blocking acknowledgment** that th metabolomics/v2"
+    },
+    {
       "name": "assay-matrix-formatting",
       "description": "Use when after generating a feature table via mzrtsim() containing simulated peak abundances across samples with condition and batch effects, and you need to expose the abundance data through Bioconductor's SummarizedExperiment interface for use with standard accessor functions (assay(), colData()).",
       "when_to_use_negative": "",
@@ -31889,7 +31913,7 @@
     },
     {
       "name": "baseline-method-comparison-and-benchmarking",
-      "description": "Use when you have developed or adapted an analytical method (e.g., NPFimg for GC–MS marker identification) and need to demonstrate its reliability or superiority over a widely-used reference method (e.g., XCMS). Apply this skill when you have access to both the same raw input data (e.",
+      "description": "Use when you have developed or adapted an analytical method (e.g., NPFimg for GC–MS marker identification) and need to demonstrate its reliability or improved performance over a widely-used reference method (e.g., XCMS). Apply this skill when you have access to both the same raw input data (e.",
       "when_to_use_negative": "",
       "edam_topics": [],
       "collection": "metabolomics/v2",
@@ -31899,7 +31923,7 @@
         "10.1021/acs.analchem.1c03163"
       ],
       "md_path": "collections/metabolomics/v2/skills/baseline-method-comparison-and-benchmarking/SKILL.md",
-      "search_text": "baseline-method-comparison-and-benchmarking Use when you have developed or adapted an analytical method (e.g., NPFimg for GC–MS marker identification) and need to demonstrate its reliability or superiority over a widely-used reference method (e.g., XCMS). Apply this skill when you have access to both the same raw input data (e. Quantitatively compare a novel analytical method against an established baseline tool by computing error metrics on the same input dataset, enabling objective evaluation of performance improvements in signal detection and feature identification. This skill is essential for validating whether new approaches reduce false positives, false negatives, or other systematic errors relative to conventional pipelines. metabolomics/v2 10.1021/acs.analchem.1c03163?ref= 10.1021/acs.analchem.1c03163"
+      "search_text": "baseline-method-comparison-and-benchmarking Use when you have developed or adapted an analytical method (e.g., NPFimg for GC–MS marker identification) and need to demonstrate its reliability or improved performance over a widely-used reference method (e.g., XCMS). Apply this skill when you have access to both the same raw input data (e. Quantitatively compare a novel analytical method against an established baseline tool by computing error metrics on the same input dataset, enabling objective evaluation of performance improvements in signal detection and feature identification. This skill is essential for validating whether new approaches reduce false positives, false negatives, or other systematic errors relative to conventional pipelines. metabolomics/v2 10.1021/acs.analchem.1c03163?ref= 10.1021/acs.analchem.1c03163"
     },
     {
       "name": "baseline-model-implementation-for-comparison",
@@ -37502,12 +37526,12 @@
       "when_to_use_negative": "",
       "edam_topics": [],
       "collection": "metabolomics/v2",
-      "summary": "# code_artifact_inspection ## When to use Use when the workflow requires code_artifact_inspection.",
+      "summary": "# code_artifact_inspection > **License: restricted** — no clear open-source license detected for the underlying tool; verify licensing before commercial use or redistribution. <!-- asb-license-banner --> ## When to use Use when the workflow requires code_artifact_inspection.",
       "source_dois": [
         "10.3389/fmolb.2022.952149"
       ],
       "md_path": "collections/metabolomics/v2/skills/code-artifact-inspection/SKILL.md",
-      "search_text": "code-artifact-inspection Use when use when the workflow requires code_artifact_inspection. # code_artifact_inspection ## When to use Use when the workflow requires code_artifact_inspection. metabolomics/v2 10.3389/fmolb.2022.952149"
+      "search_text": "code-artifact-inspection Use when use when the workflow requires code_artifact_inspection. # code_artifact_inspection > **License: restricted** — no clear open-source license detected for the underlying tool; verify licensing before commercial use or redistribution. <!-- asb-license-banner --> ## When to use Use when the workflow requires code_artifact_inspection. metabolomics/v2 10.3389/fmolb.2022.952149"
     },
     {
       "name": "code-quality-metrics-interpretation",
@@ -43661,12 +43685,12 @@
       "when_to_use_negative": "",
       "edam_topics": [],
       "collection": "metabolomics/v2",
-      "summary": "# descriptor-fingerprint-feature-engineering ## When to use Use when the workflow requires descriptor-fingerprint-feature-engineering.",
+      "summary": "# descriptor-fingerprint-feature-engineering > **License: restricted** — no clear open-source license detected for the underlying tool; verify licensing before commercial use or redistribution. <!-- asb-license-banner --> ## When to use Use when the workflow requires descriptor-fingerprint-feature-engineering.",
       "source_dois": [
         "10.1186/s13321-022-00613-8"
       ],
       "md_path": "collections/metabolomics/v2/skills/descriptor-fingerprint-feature-engineering/SKILL.md",
-      "search_text": "descriptor-fingerprint-feature-engineering Use when use when the workflow requires descriptor-fingerprint-feature-engineering. # descriptor-fingerprint-feature-engineering ## When to use Use when the workflow requires descriptor-fingerprint-feature-engineering. metabolomics/v2 10.1186/s13321-022-00613-8"
+      "search_text": "descriptor-fingerprint-feature-engineering Use when use when the workflow requires descriptor-fingerprint-feature-engineering. # descriptor-fingerprint-feature-engineering > **License: restricted** — no clear open-source license detected for the underlying tool; verify licensing before commercial use or redistribution. <!-- asb-license-banner --> ## When to use Use when the workflow requires descriptor-fingerprint-feature-engineering. metabolomics/v2 10.1186/s13321-022-00613-8"
     },
     {
       "name": "descriptor-subgroup-partitioning",
@@ -65541,6 +65565,17 @@
       "search_text": "masst-output-visualization Use when you have completed one or more domain-specific MASST searches (microbeMASST, plantMASST, tissueMASST, microbiomeMASST, foodMASST) and have aggregated search outputs (matches.tsv, library.tsv, datasets. metadataMASST consolidates and visualizes aggregated mass spectrometry search results from domain-specific MASST tools (microbeMASST, plantMASST, tissueMASST, microbiomeMASST, foodMASST) into cross-domain interpretable outputs. Use this skill when you have completed batch or single-spectrum searches across multiple domain-specific MASSTs and need to synthesize, rank, and visualize hits and metadata to identify domain overlap and score distributions. metabolomics/v2 10.1038/s41564-023-01575-9"
     },
     {
+      "name": "masster",
+      "description": "Use when you need to run the Zamboni-lab Masster (MASSter) workflow for untargeted LC-MS metabolomics data analysis. NONCOMMERCIAL tool — confirm permitted use before applying (see License notice).",
+      "when_to_use_negative": "",
+      "edam_topics": [],
+      "collection": "metabolomics/v2",
+      "summary": "# masster Run the Zamboni-lab Masster untargeted LC-MS metabolomics workflow. This skill is a description of how to use the tool; it does not embed or redistribute the tool's code. ## License notice Masster is licensed under the **Masster Noncommercial and Commercial Services License 1.0.0** — a noncommercial license. Before applying this skill you must confirm your use is a **permitted (noncommercial) purpose**. Commercial use (by or for a for-profit entity) requires a separate commercial licen",
+      "source_dois": [],
+      "md_path": "collections/metabolomics/v2/skills/masster/SKILL.md",
+      "search_text": "masster Use when you need to run the Zamboni-lab Masster (MASSter) workflow for untargeted LC-MS metabolomics data analysis. NONCOMMERCIAL tool — confirm permitted use before applying (see License notice). # masster Run the Zamboni-lab Masster untargeted LC-MS metabolomics workflow. This skill is a description of how to use the tool; it does not embed or redistribute the tool's code. ## License notice Masster is licensed under the **Masster Noncommercial and Commercial Services License 1.0.0** — a noncommercial license. Before applying this skill you must confirm your use is a **permitted (noncommercial) purpose**. Commercial use (by or for a for-profit entity) requires a separate commercial licen metabolomics/v2"
+    },
+    {
       "name": "match-factor-threshold-filtering",
       "description": "Use when you have a GC-MS dataset with Match.Factor scores for each detected compound (output from Agilent Unknowns Analysis or equivalent), and you want to reduce the number of query chemicals passed to computationally intensive cheminformatics functions (categorate, mzExacto, or exactoThese).",
       "when_to_use_negative": "",
@@ -77283,6 +77318,19 @@
       ],
       "md_path": "collections/metabolomics/v2/skills/mzml-data-access-abstraction/SKILL.md",
       "search_text": "mzml-data-access-abstraction Use when when building or extending a mass spectrometry data parser that must support multiple mzML storage formats (plain .mzML, indexed .mzML.gz, standard-compressed .mzML. Implement a polymorphic file handler interface (FileInterface) that dispatches mzML file reads to specialized handler classes based on file extension and compression format, enabling unified random-access parsing across uncompressed, indexed-gzip, standard-gzip, and SQLite-backed mzML data sources. This abstraction decouples Reader logic from storage format, permitting extensible support for new backends without modifying core parsing code. metabolomics/v2 10.1093/bioinformatics/bty046"
+    },
+    {
+      "name": "mzml-data-parsing-pymzml-pyopenms",
+      "description": "Use when you have mzML-format mass spectrometry data files and need to load them into memory as structured data (pandas DataFrame) to prepare for visualization with pyOpenMS-Viz or other analysis pipelines.",
+      "when_to_use_negative": "",
+      "edam_topics": [],
+      "collection": "metabolomics/v2",
+      "summary": "Parse and load mass spectrometry data from mzML files into pandas DataFrames using pymzml or pyOpenMS libraries, enabling downstream visualization and analysis of chromatograms, spectra, and peak maps.",
+      "source_dois": [
+        "10.1021/acs.jproteome.4c00873"
+      ],
+      "md_path": "collections/metabolomics/v2/skills/mzml-data-parsing-pymzml-pyopenms/SKILL.md",
+      "search_text": "mzml-data-parsing-pymzml-pyopenms Use when you have mzML-format mass spectrometry data files and need to load them into memory as structured data (pandas DataFrame) to prepare for visualization with pyOpenMS-Viz or other analysis pipelines. Parse and load mass spectrometry data from mzML files into pandas DataFrames using pymzml or pyOpenMS libraries, enabling downstream visualization and analysis of chromatograms, spectra, and peak maps. metabolomics/v2 10.1021/acs.jproteome.4c00873"
     },
     {
       "name": "mzml-feature-table-parsing",
@@ -113950,13 +113998,13 @@
     {
       "slug": "10-5281-zenodo-4680579",
       "name": "10.5281/zenodo.4680579",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "while the version used for the analysis in this work can be found at http://doi.org/10.5281/zenodo.4680579",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/10-5281-zenodo-4680579.yaml",
-      "search_text": "10-5281-zenodo-4680579 10.5281/zenodo.4680579 while the version used for the analysis in this work can be found at http://doi.org/10.5281/zenodo.4680579 metabolomics/v2"
+      "search_text": "10-5281-zenodo-4680579 10.5281/zenodo.4680579 while the version used for the analysis in this work can be found at http://doi.org/10.5281/zenodo.4680579 metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "adam-optimizer",
@@ -113983,35 +114031,35 @@
     {
       "slug": "adviselipidomics",
       "name": "ADViSELipidomics",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ShinyFabio/ADViSELipidomics",
       "license_spdx": "",
       "evidence_text": "ADViSELipidomics can normalize the data matrix, providing absolute values of concentration per lipid and sample ADViSELipidomics is a novel Shiny app for the preprocessing, analysis, and visualization of lipidomics data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/adviselipidomics.yaml",
-      "search_text": "adviselipidomics ADViSELipidomics ADViSELipidomics can normalize the data matrix, providing absolute values of concentration per lipid and sample ADViSELipidomics is a novel Shiny app for the preprocessing, analysis, and visualization of lipidomics data. metabolomics/v2"
+      "search_text": "adviselipidomics ADViSELipidomics ADViSELipidomics can normalize the data matrix, providing absolute values of concentration per lipid and sample ADViSELipidomics is a novel Shiny app for the preprocessing, analysis, and visualization of lipidomics data. metabolomics/v2 https://github.com/ShinyFabio/ADViSELipidomics"
     },
     {
       "slug": "aer",
       "name": "AER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FrigerioGianfranco/GetFeatistics",
       "license_spdx": "",
       "evidence_text": "TOBIT linear models, using the _tobit_ function of the AER package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/aer.yaml",
-      "search_text": "aer AER TOBIT linear models, using the _tobit_ function of the AER package metabolomics/v2"
+      "search_text": "aer AER TOBIT linear models, using the _tobit_ function of the AER package metabolomics/v2 https://github.com/FrigerioGianfranco/GetFeatistics"
     },
     {
       "slug": "aerith",
       "name": "Aerith",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/thepanlab/Aerith",
       "license_spdx": "",
       "evidence_text": "Aerith is an R package that provides interfaces to read and write mass spectrum scans, calculate the theoretical isotopic peak envelope Aerith is an R package that provides interfaces to read and write mass spectrum scans",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/aerith.yaml",
-      "search_text": "aerith Aerith Aerith is an R package that provides interfaces to read and write mass spectrum scans, calculate the theoretical isotopic peak envelope Aerith is an R package that provides interfaces to read and write mass spectrum scans metabolomics/v2"
+      "search_text": "aerith Aerith Aerith is an R package that provides interfaces to read and write mass spectrum scans, calculate the theoretical isotopic peak envelope Aerith is an R package that provides interfaces to read and write mass spectrum scans metabolomics/v2 https://github.com/thepanlab/Aerith"
     },
     {
       "slug": "agilent-1290-infinity-uhplc-system",
@@ -114038,24 +114086,24 @@
     {
       "slug": "agilent-masshunter",
       "name": "Agilent MassHunter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor",
       "license_spdx": "",
       "evidence_text": "Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) Agilent MassHunter (.d) and UIMF mass spectrometry data files Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/agilent-masshunter.yaml",
-      "search_text": "agilent-masshunter Agilent MassHunter Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) Agilent MassHunter (.d) and UIMF mass spectrometry data files Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM) metabolomics/v2"
+      "search_text": "agilent-masshunter Agilent MassHunter Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) Agilent MassHunter (.d) and UIMF mass spectrometry data files Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM) metabolomics/v2 https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
     },
     {
       "slug": "agilent-q-tof-uhplc-hrms-ms",
       "name": "Agilent Q-TOF UHPLC-HRMS/MS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/agilent-q-tof-uhplc-hrms-ms.yaml",
-      "search_text": "agilent-q-tof-uhplc-hrms-ms Agilent Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2"
+      "search_text": "agilent-q-tof-uhplc-hrms-ms Agilent Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "agilent-unknowns-analysis",
@@ -114115,57 +114163,57 @@
     {
       "slug": "amanida",
       "name": "amanida",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mariallr/amanida",
       "license_spdx": "",
       "evidence_text": "This vignette illustrates `Amanida` R package, which contains a collection of functions for computing a weighted meta-analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/amanida.yaml",
-      "search_text": "amanida amanida This vignette illustrates `Amanida` R package, which contains a collection of functions for computing a weighted meta-analysis metabolomics/v2"
+      "search_text": "amanida amanida This vignette illustrates `Amanida` R package, which contains a collection of functions for computing a weighted meta-analysis metabolomics/v2 https://github.com/mariallr/amanida"
     },
     {
       "slug": "anaconda",
       "name": "Anaconda",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LabLaskin/MSIGen",
       "license_spdx": "",
       "evidence_text": "Install [Anaconda](https://www.anaconda.com/). Anaconda for python 3.6 [Anaconda](https://www.anaconda.com) for Python 3.12 If you do not have Python installed, we recommend installing the Anaconda distribution of Python [Anaconda](https://www.anaconda.com) for Python 3.9",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/anaconda.yaml",
-      "search_text": "anaconda Anaconda Install [Anaconda](https://www.anaconda.com/). Anaconda for python 3.6 [Anaconda](https://www.anaconda.com) for Python 3.12 If you do not have Python installed, we recommend installing the Anaconda distribution of Python [Anaconda](https://www.anaconda.com) for Python 3.9 metabolomics/v2"
+      "search_text": "anaconda Anaconda Install [Anaconda](https://www.anaconda.com/). Anaconda for python 3.6 [Anaconda](https://www.anaconda.com) for Python 3.12 If you do not have Python installed, we recommend installing the Anaconda distribution of Python [Anaconda](https://www.anaconda.com) for Python 3.9 metabolomics/v2 https://github.com/LabLaskin/MSIGen"
     },
     {
       "slug": "ann-solo",
       "name": "ANN-SoLo",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux-lab/ANN-SoLo",
       "license_spdx": "",
       "evidence_text": "ANN-SoLo (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine **ANN-SoLo** (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ann-solo.yaml",
-      "search_text": "ann-solo ANN-SoLo ANN-SoLo (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine **ANN-SoLo** (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine metabolomics/v2"
+      "search_text": "ann-solo ANN-SoLo ANN-SoLo (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine **ANN-SoLo** (**A**pproximate **N**earest **N**eighbor **S**pectral **L**ibrary) is a spectral library search engine metabolomics/v2 https://github.com/bittremieux-lab/ANN-SoLo"
     },
     {
       "slug": "annome",
       "name": "AnnoMe",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chrboku/AnnoMe",
       "license_spdx": "",
       "evidence_text": "This is a package for the classification of MS/MS spectra of novel compounds",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/annome.yaml",
-      "search_text": "annome AnnoMe This is a package for the classification of MS/MS spectra of novel compounds metabolomics/v2"
+      "search_text": "annome AnnoMe This is a package for the classification of MS/MS spectra of novel compounds metabolomics/v2 https://github.com/chrboku/AnnoMe"
     },
     {
       "slug": "antismash",
       "name": "antiSMASH",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "MetaMiner uses either raw nucleotide sequences or specific genome mining tools' output: raw nucleotide sequences `.fasta` format or *antiSMASH*'s `.final.gbk` or `.gbk` file antismash directory contains a collection of AntiSMASH BGC data after downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection genomes were run through antiSMASH v5.0.0 for BGC detection the genomes were run through antiSMASH v5.0.0 for BGC detection After downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/antismash.yaml",
-      "search_text": "antismash antiSMASH MetaMiner uses either raw nucleotide sequences or specific genome mining tools' output: raw nucleotide sequences `.fasta` format or *antiSMASH*'s `.final.gbk` or `.gbk` file antismash directory contains a collection of AntiSMASH BGC data after downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection genomes were run through antiSMASH v5.0.0 for BGC detection the genomes were run through antiSMASH v5.0.0 for BGC detection After downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection metabolomics/v2"
+      "search_text": "antismash antiSMASH MetaMiner uses either raw nucleotide sequences or specific genome mining tools' output: raw nucleotide sequences `.fasta` format or *antiSMASH*'s `.final.gbk` or `.gbk` file antismash directory contains a collection of AntiSMASH BGC data after downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection genomes were run through antiSMASH v5.0.0 for BGC detection the genomes were run through antiSMASH v5.0.0 for BGC detection After downloading the strain assemblies and metabolomics data, the genomes were run through antiSMASH v5.0.0 for BGC detection metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "apache-maven-3-8",
@@ -114181,13 +114229,13 @@
     {
       "slug": "appveyor",
       "name": "Appveyor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Builds for Windows are run via Appveyor",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/appveyor.yaml",
-      "search_text": "appveyor Appveyor Builds for Windows are run via Appveyor metabolomics/v2"
+      "search_text": "appveyor Appveyor Builds for Windows are run via Appveyor metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "arrow",
@@ -114203,145 +114251,145 @@
     {
       "slug": "asap-ms",
       "name": "ASAP-MS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Katherine00689/RapidMass",
       "license_spdx": "",
       "evidence_text": "supports data from multiple instruments, including DI-MS and ASAP-MS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asap-ms.yaml",
-      "search_text": "asap-ms ASAP-MS supports data from multiple instruments, including DI-MS and ASAP-MS metabolomics/v2"
+      "search_text": "asap-ms ASAP-MS supports data from multiple instruments, including DI-MS and ASAP-MS metabolomics/v2 https://github.com/Katherine00689/RapidMass"
     },
     {
       "slug": "asari-mass-functions-module-nn-cluster-by-mz-seeds",
       "name": "asari mass_functions module (nn_cluster_by_mz_seeds)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "a nearest neighbor (NN) clustering is performed to establish the number of mass tracks. See [mass_functions.nn_cluster_by_mz_seeds](mass_functions.nn_cluster_by_mz_seeds).",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asari-mass-functions-module-nn-cluster-by-mz-seeds.yaml",
-      "search_text": "asari-mass-functions-module-nn-cluster-by-mz-seeds asari mass_functions module (nn_cluster_by_mz_seeds) a nearest neighbor (NN) clustering is performed to establish the number of mass tracks. See [mass_functions.nn_cluster_by_mz_seeds](mass_functions.nn_cluster_by_mz_seeds). metabolomics/v2"
+      "search_text": "asari-mass-functions-module-nn-cluster-by-mz-seeds asari mass_functions module (nn_cluster_by_mz_seeds) a nearest neighbor (NN) clustering is performed to establish the number of mass tracks. See [mass_functions.nn_cluster_by_mz_seeds](mass_functions.nn_cluster_by_mz_seeds). metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs",
       "name": "asari MassGrid class (build_grid_sample_wise, add_sample, build_grid_by_centroiding, bin_track_mzs)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "See [MassGrid.build_grid_sample_wise](MassGrid.build_grid_sample_wise), [MassGrid.add_sample](MassGrid.add_sample). See [MassGrid.build_grid_by_centroiding](MassGrid.build_grid_by_centroiding),",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs.yaml",
-      "search_text": "asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs asari MassGrid class (build_grid_sample_wise, add_sample, build_grid_by_centroiding, bin_track_mzs) See [MassGrid.build_grid_sample_wise](MassGrid.build_grid_sample_wise), [MassGrid.add_sample](MassGrid.add_sample). See [MassGrid.build_grid_by_centroiding](MassGrid.build_grid_by_centroiding), metabolomics/v2"
+      "search_text": "asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs asari MassGrid class (build_grid_sample_wise, add_sample, build_grid_by_centroiding, bin_track_mzs) See [MassGrid.build_grid_sample_wise](MassGrid.build_grid_sample_wise), [MassGrid.add_sample](MassGrid.add_sample). See [MassGrid.build_grid_by_centroiding](MassGrid.build_grid_by_centroiding), metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "asari-peaks-module",
       "name": "asari peaks module",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "See [peaks.evaluate_gaussian_peak_on_intensity_list](peaks.evaluate_gaussian_peak_on_intensity_list), [peaks.__peaks_cSelectivity_stats_](peaks.__peaks_cSelectivity_stats_),",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asari-peaks-module.yaml",
-      "search_text": "asari-peaks-module asari peaks module See [peaks.evaluate_gaussian_peak_on_intensity_list](peaks.evaluate_gaussian_peak_on_intensity_list), [peaks.__peaks_cSelectivity_stats_](peaks.__peaks_cSelectivity_stats_), metabolomics/v2"
+      "search_text": "asari-peaks-module asari peaks module See [peaks.evaluate_gaussian_peak_on_intensity_list](peaks.evaluate_gaussian_peak_on_intensity_list), [peaks.__peaks_cSelectivity_stats_](peaks.__peaks_cSelectivity_stats_), metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "asari",
       "name": "asari",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing process mzML data to feature tables (Asari) pcpfm asari -i ./my_experiment",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asari.yaml",
-      "search_text": "asari asari Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing process mzML data to feature tables (Asari) pcpfm asari -i ./my_experiment metabolomics/v2"
+      "search_text": "asari asari Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing process mzML data to feature tables (Asari) pcpfm asari -i ./my_experiment metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "ase-ani",
       "name": "ASE-ANI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DasSusanta/snakemake_ccs",
       "license_spdx": "",
       "evidence_text": "ASE-ANI: For conformation filtering",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ase-ani.yaml",
-      "search_text": "ase-ani ASE-ANI ASE-ANI: For conformation filtering metabolomics/v2"
+      "search_text": "ase-ani ASE-ANI ASE-ANI: For conformation filtering metabolomics/v2 https://github.com/DasSusanta/snakemake_ccs"
     },
     {
       "slug": "asics",
       "name": "ASICS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GaelleLefort/ASICS",
       "license_spdx": "",
       "evidence_text": "The **R** package `ASICS` is a fully automated procedure to identify and quantify metabolites in $^1$H 1D-NMR spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/asics.yaml",
-      "search_text": "asics ASICS The **R** package `ASICS` is a fully automated procedure to identify and quantify metabolites in $^1$H 1D-NMR spectra metabolomics/v2"
+      "search_text": "asics ASICS The **R** package `ASICS` is a fully automated procedure to identify and quantify metabolites in $^1$H 1D-NMR spectra metabolomics/v2 https://github.com/GaelleLefort/ASICS"
     },
     {
       "slug": "assign-hierarchy",
       "name": "assign_hierarchy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/connor-reid-tiffany/Omu",
       "license_spdx": "",
       "evidence_text": "To assign hierarchical class data, use the ```assign_hierarchy``` function and pick the correct identifier, either \"KEGG\", \"KO_Number\", \"Prokaryote\", or \"Eukaryote\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/assign-hierarchy.yaml",
-      "search_text": "assign-hierarchy assign_hierarchy To assign hierarchical class data, use the ```assign_hierarchy``` function and pick the correct identifier, either \"KEGG\", \"KO_Number\", \"Prokaryote\", or \"Eukaryote\" metabolomics/v2"
+      "search_text": "assign-hierarchy assign_hierarchy To assign hierarchical class data, use the ```assign_hierarchy``` function and pick the correct identifier, either \"KEGG\", \"KO_Number\", \"Prokaryote\", or \"Eukaryote\" metabolomics/v2 https://github.com/connor-reid-tiffany/Omu"
     },
     {
       "slug": "autoccs",
       "name": "AutoCCS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-Comp-Mass-Spec/AutoCCS",
       "license_spdx": "",
       "evidence_text": "github.com__PNNL-Comp-Mass-Spec__AutoCCS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/autoccs.yaml",
-      "search_text": "autoccs AutoCCS github.com__PNNL-Comp-Mass-Spec__AutoCCS metabolomics/v2"
+      "search_text": "autoccs AutoCCS github.com__PNNL-Comp-Mass-Spec__AutoCCS metabolomics/v2 https://github.com/PNNL-Comp-Mass-Spec/AutoCCS"
     },
     {
       "slug": "autotuner",
       "name": "Autotuner",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/KujawinskiLaboratory/Autotuner",
       "license_spdx": "",
       "evidence_text": "library(Autotuner)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/autotuner.yaml",
-      "search_text": "autotuner Autotuner library(Autotuner) metabolomics/v2"
+      "search_text": "autotuner Autotuner library(Autotuner) metabolomics/v2 https://github.com/KujawinskiLaboratory/Autotuner"
     },
     {
       "slug": "avir-r",
       "name": "AVIR.R",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/AVIR",
       "license_spdx": "",
       "evidence_text": "AVIR.R is a program developed to recognize computational variation among metabolic features in samples",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/avir-r.yaml",
-      "search_text": "avir-r AVIR.R AVIR.R is a program developed to recognize computational variation among metabolic features in samples metabolomics/v2"
+      "search_text": "avir-r AVIR.R AVIR.R is a program developed to recognize computational variation among metabolic features in samples metabolomics/v2 https://github.com/HuanLab/AVIR"
     },
     {
       "slug": "aws-cli",
       "name": "AWS CLI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/meowcat/MSNovelist",
       "license_spdx": "",
       "evidence_text": "aws s3 cp --recursive s3://sirius-novelist/dataset-s6-202311 data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/aws-cli.yaml",
-      "search_text": "aws-cli AWS CLI aws s3 cp --recursive s3://sirius-novelist/dataset-s6-202311 data metabolomics/v2"
+      "search_text": "aws-cli AWS CLI aws s3 cp --recursive s3://sirius-novelist/dataset-s6-202311 data metabolomics/v2 https://github.com/meowcat/MSNovelist"
     },
     {
       "slug": "bago",
       "name": "BAGO",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/huaxuyu/bago",
       "license_spdx": "",
       "evidence_text": "BAGO is a Bayesian optimization strategy for LC gradient optimization for MS-based small molecule analysis A :class:`ms1Spectrum` object (supported by :mod:`bago`) Function to calculate the next gradient to run using an acquisition function.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bago.yaml",
-      "search_text": "bago BAGO BAGO is a Bayesian optimization strategy for LC gradient optimization for MS-based small molecule analysis A :class:`ms1Spectrum` object (supported by :mod:`bago`) Function to calculate the next gradient to run using an acquisition function. metabolomics/v2"
+      "search_text": "bago BAGO BAGO is a Bayesian optimization strategy for LC gradient optimization for MS-based small molecule analysis A :class:`ms1Spectrum` object (supported by :mod:`bago`) Function to calculate the next gradient to run using an acquisition function. metabolomics/v2 https://github.com/huaxuyu/bago"
     },
     {
       "slug": "bam",
@@ -114357,35 +114405,35 @@
     {
       "slug": "bart",
       "name": "BART",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenDFM/MS-BART",
       "license_spdx": "",
       "evidence_text": "MS-BART is the first to leverage language model for mass spectra structure elucidation by introducing a unified vocabulary",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bart.yaml",
-      "search_text": "bart BART MS-BART is the first to leverage language model for mass spectra structure elucidation by introducing a unified vocabulary metabolomics/v2"
+      "search_text": "bart BART MS-BART is the first to leverage language model for mass spectra structure elucidation by introducing a unified vocabulary metabolomics/v2 https://github.com/OpenDFM/MS-BART"
     },
     {
       "slug": "base64enc",
       "name": "base64enc",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/yufree/mzrtsim",
       "license_spdx": "",
       "evidence_text": "The underlying engine handles binary data encoding via the `base64enc` package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/base64enc.yaml",
-      "search_text": "base64enc base64enc The underlying engine handles binary data encoding via the `base64enc` package metabolomics/v2"
+      "search_text": "base64enc base64enc The underlying engine handles binary data encoding via the `base64enc` package metabolomics/v2 https://github.com/yufree/mzrtsim"
     },
     {
       "slug": "basicevaluationengine",
       "name": "BasicEvaluationEngine",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base",
       "license_spdx": "",
       "evidence_text": "eval_engine = BasicEvaluationEngine(default_method=\"is_max\") eval_engine = BasicEvaluationEngine(default_method=\"average_distance\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/basicevaluationengine.yaml",
-      "search_text": "basicevaluationengine BasicEvaluationEngine eval_engine = BasicEvaluationEngine(default_method=\"is_max\") eval_engine = BasicEvaluationEngine(default_method=\"average_distance\") metabolomics/v2"
+      "search_text": "basicevaluationengine BasicEvaluationEngine eval_engine = BasicEvaluationEngine(default_method=\"is_max\") eval_engine = BasicEvaluationEngine(default_method=\"average_distance\") metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base"
     },
     {
       "slug": "benjamini-hochberg-fdr-correction",
@@ -114401,57 +114449,57 @@
     {
       "slug": "big-scape",
       "name": "BiG-SCAPE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "and BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE clusters the BGCs separately by product type",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/big-scape.yaml",
-      "search_text": "big-scape BiG-SCAPE and BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE clusters the BGCs separately by product type metabolomics/v2"
+      "search_text": "big-scape BiG-SCAPE and BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE v1.0.0 to cluster the BGCs into GCFs BiG-SCAPE clusters the BGCs separately by product type metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "big-slice",
       "name": "BiG-SLiCE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/medema-group/bigslice",
       "license_spdx": "",
       "evidence_text": "**BiG-SLiCE** using pip Ability to __export pre-calculated BGCs and GCFs table into TSVs__ (use __--export-csv__ parameter)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/big-slice.yaml",
-      "search_text": "big-slice BiG-SLiCE **BiG-SLiCE** using pip Ability to __export pre-calculated BGCs and GCFs table into TSVs__ (use __--export-csv__ parameter) metabolomics/v2"
+      "search_text": "big-slice BiG-SLiCE **BiG-SLiCE** using pip Ability to __export pre-calculated BGCs and GCFs table into TSVs__ (use __--export-csv__ parameter) metabolomics/v2 https://github.com/medema-group/bigslice"
     },
     {
       "slug": "bigscape",
       "name": "BigScape",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "NPLinker can run BigScape automatically if the `bigscape` directory does not exist in the working directory. NPLinker can run BigScape automatically if the `bigscape` directory does not exist",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bigscape.yaml",
-      "search_text": "bigscape BigScape NPLinker can run BigScape automatically if the `bigscape` directory does not exist in the working directory. NPLinker can run BigScape automatically if the `bigscape` directory does not exist metabolomics/v2"
+      "search_text": "bigscape BigScape NPLinker can run BigScape automatically if the `bigscape` directory does not exist in the working directory. NPLinker can run BigScape automatically if the `bigscape` directory does not exist metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "biobase",
       "name": "Biobase",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/antonvsdata/notame",
       "license_spdx": "",
       "evidence_text": "BiocManager::install(\"Biobase\") ```MetaboSet``` is built upon the ```ExpressionSet``` class from the Biobase package by Bioconductor",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biobase.yaml",
-      "search_text": "biobase Biobase BiocManager::install(\"Biobase\") ```MetaboSet``` is built upon the ```ExpressionSet``` class from the Biobase package by Bioconductor metabolomics/v2"
+      "search_text": "biobase Biobase BiocManager::install(\"Biobase\") ```MetaboSet``` is built upon the ```ExpressionSet``` class from the Biobase package by Bioconductor metabolomics/v2 https://github.com/antonvsdata/notame"
     },
     {
       "slug": "biocmanager",
       "name": "BiocManager",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kilgain/MassSpec",
       "license_spdx": "",
       "evidence_text": "if (!require(BiocManager)) if (!requireNamespace(\"BiocManager\", quietly = TRUE)) install.packages(\"BiocManager\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biocmanager.yaml",
-      "search_text": "biocmanager BiocManager if (!require(BiocManager)) if (!requireNamespace(\"BiocManager\", quietly = TRUE)) install.packages(\"BiocManager\") metabolomics/v2"
+      "search_text": "biocmanager BiocManager if (!require(BiocManager)) if (!requireNamespace(\"BiocManager\", quietly = TRUE)) install.packages(\"BiocManager\") metabolomics/v2 https://github.com/kilgain/MassSpec"
     },
     {
       "slug": "bioconda",
@@ -114467,79 +114515,79 @@
     {
       "slug": "bioconductor",
       "name": "Bioconductor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AndreaRMICL/MWASTools",
       "license_spdx": "",
       "evidence_text": "marr: An R/Bioconductor package for Maximum Rank Reproducibility `marr`: An R/Bioconductor package for Maximum Rank Reproducibility Assuming that R (>=3.3) and Bioconductor have been correctly installed or from Bioconductor by the ```ExpressionSet``` class from the Biobase package by Bioconductor This is primarily due to the Bioconductor project that currently provides >1900 open-source software packages",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bioconductor.yaml",
-      "search_text": "bioconductor Bioconductor marr: An R/Bioconductor package for Maximum Rank Reproducibility `marr`: An R/Bioconductor package for Maximum Rank Reproducibility Assuming that R (>=3.3) and Bioconductor have been correctly installed or from Bioconductor by the ```ExpressionSet``` class from the Biobase package by Bioconductor This is primarily due to the Bioconductor project that currently provides >1900 open-source software packages metabolomics/v2"
+      "search_text": "bioconductor Bioconductor marr: An R/Bioconductor package for Maximum Rank Reproducibility `marr`: An R/Bioconductor package for Maximum Rank Reproducibility Assuming that R (>=3.3) and Bioconductor have been correctly installed or from Bioconductor by the ```ExpressionSet``` class from the Biobase package by Bioconductor This is primarily due to the Bioconductor project that currently provides >1900 open-source software packages metabolomics/v2 https://github.com/AndreaRMICL/MWASTools"
     },
     {
       "slug": "biocparallel",
       "name": "BiocParallel",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kuwisdelu/Cardinal",
       "license_spdx": "",
       "evidence_text": "Parallel processing support via the *BiocParallel* package for all pre-processing methods Parallel processing support via the *BiocParallel* package for all pre-processing methods and any statistical analysis methods with a `BPPARAM` option",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biocparallel.yaml",
-      "search_text": "biocparallel BiocParallel Parallel processing support via the *BiocParallel* package for all pre-processing methods Parallel processing support via the *BiocParallel* package for all pre-processing methods and any statistical analysis methods with a `BPPARAM` option metabolomics/v2"
+      "search_text": "biocparallel BiocParallel Parallel processing support via the *BiocParallel* package for all pre-processing methods Parallel processing support via the *BiocParallel* package for all pre-processing methods and any statistical analysis methods with a `BPPARAM` option metabolomics/v2 https://github.com/kuwisdelu/Cardinal"
     },
     {
       "slug": "bioinformatic-toolbox",
       "name": "Bioinformatic Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bioinformatic-toolbox.yaml",
-      "search_text": "bioinformatic-toolbox Bioinformatic Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "bioinformatic-toolbox Bioinformatic Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "biosynfoni",
       "name": "biosynfoni",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lucinamay/biosynfoni",
       "license_spdx": "",
       "evidence_text": "biosynfoni a biosynformatic molecular fingerprint tailored to natural product chem- and bioinformatic research",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biosynfoni.yaml",
-      "search_text": "biosynfoni biosynfoni biosynfoni a biosynformatic molecular fingerprint tailored to natural product chem- and bioinformatic research metabolomics/v2"
+      "search_text": "biosynfoni biosynfoni biosynfoni a biosynformatic molecular fingerprint tailored to natural product chem- and bioinformatic research metabolomics/v2 https://github.com/lucinamay/biosynfoni"
     },
     {
       "slug": "biotransformer",
       "name": "BioTransformer",
-      "canonical_url": "",
+      "canonical_url": "https://bitbucket.org/wishartlab/biotransformer.git",
       "license_spdx": "",
       "evidence_text": "This is version 3.0.0 of BioTransformer. BioTransformer is a software tool that predicts small molecule metabolism BioTransformer's environmental microbial degradation module uses data from the EAWAG's Biodegradation and Biocatalysis Database `generateTPs(algorithm = \"biotransformer\", ...)` | Parents | TPs structural information",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biotransformer.yaml",
-      "search_text": "biotransformer BioTransformer This is version 3.0.0 of BioTransformer. BioTransformer is a software tool that predicts small molecule metabolism BioTransformer's environmental microbial degradation module uses data from the EAWAG's Biodegradation and Biocatalysis Database `generateTPs(algorithm = \"biotransformer\", ...)` | Parents | TPs structural information metabolomics/v2"
+      "search_text": "biotransformer BioTransformer This is version 3.0.0 of BioTransformer. BioTransformer is a software tool that predicts small molecule metabolism BioTransformer's environmental microbial degradation module uses data from the EAWAG's Biodegradation and Biocatalysis Database `generateTPs(algorithm = \"biotransformer\", ...)` | Parents | TPs structural information metabolomics/v2 https://bitbucket.org/wishartlab/biotransformer.git"
     },
     {
       "slug": "biotransformerapi",
       "name": "BioTransformerAPI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Le0nT1/CyProduct",
       "license_spdx": "",
       "evidence_text": "there is a class called BioTransformerAPI in the jar file",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biotransformerapi.yaml",
-      "search_text": "biotransformerapi BioTransformerAPI there is a class called BioTransformerAPI in the jar file metabolomics/v2"
+      "search_text": "biotransformerapi BioTransformerAPI there is a class called BioTransformerAPI in the jar file metabolomics/v2 https://github.com/Le0nT1/CyProduct"
     },
     {
       "slug": "biotranslator",
       "name": "biotranslator",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Pathway enrichment analysis | Clusterprofiler, Biotranslator",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/biotranslator.yaml",
-      "search_text": "biotranslator biotranslator Pathway enrichment analysis | Clusterprofiler, Biotranslator metabolomics/v2"
+      "search_text": "biotranslator biotranslator Pathway enrichment analysis | Clusterprofiler, Biotranslator metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "bitterpredict-m",
@@ -114566,68 +114614,68 @@
     {
       "slug": "black",
       "name": "black",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SysMedOs/LipidLynxX",
       "license_spdx": "",
       "evidence_text": "We use black for auto formatting LipidLynxX source code use [code style Black](https://github.com/psf/black) for all python codes",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/black.yaml",
-      "search_text": "black black We use black for auto formatting LipidLynxX source code use [code style Black](https://github.com/psf/black) for all python codes metabolomics/v2"
+      "search_text": "black black We use black for auto formatting LipidLynxX source code use [code style Black](https://github.com/psf/black) for all python codes metabolomics/v2 https://github.com/SysMedOs/LipidLynxX"
     },
     {
       "slug": "blast",
       "name": "BLAST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mibig-secmet/mibig-json",
       "license_spdx": "",
       "evidence_text": "GenBank/RefSeq databases",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/blast.yaml",
-      "search_text": "blast BLAST GenBank/RefSeq databases metabolomics/v2"
+      "search_text": "blast BLAST GenBank/RefSeq databases metabolomics/v2 https://github.com/mibig-secmet/mibig-json"
     },
     {
       "slug": "bmxp",
       "name": "bmxp",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/broadinstitute/bmxp",
       "license_spdx": "",
       "evidence_text": "pip install bmxp",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bmxp.yaml",
-      "search_text": "bmxp bmxp pip install bmxp metabolomics/v2"
+      "search_text": "bmxp bmxp pip install bmxp metabolomics/v2 https://github.com/broadinstitute/bmxp"
     },
     {
       "slug": "bokeh",
       "name": "Bokeh",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "The main area will be populated with interactive Bokeh figures integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: BOKEH These examples are generated if `backend='ms_bokheh' Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically faster than the PLOTLY backend",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bokeh.yaml",
-      "search_text": "bokeh Bokeh The main area will be populated with interactive Bokeh figures integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: BOKEH These examples are generated if `backend='ms_bokheh' Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically faster than the PLOTLY backend metabolomics/v2"
+      "search_text": "bokeh Bokeh The main area will be populated with interactive Bokeh figures integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: BOKEH These examples are generated if `backend='ms_bokheh' Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically faster than the PLOTLY backend metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "bridgedb",
       "name": "BridgeDb",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [BridgeDb](https://bridgedb.github.io/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService']",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bridgedb.yaml",
-      "search_text": "bridgedb BridgeDb fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [BridgeDb](https://bridgedb.github.io/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2"
+      "search_text": "bridgedb BridgeDb fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [BridgeDb](https://bridgedb.github.io/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "bruker-q-tof-uhplc-hrms-ms",
       "name": "Bruker Q-TOF UHPLC-HRMS/MS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/bruker-q-tof-uhplc-hrms-ms.yaml",
-      "search_text": "bruker-q-tof-uhplc-hrms-ms Bruker Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2"
+      "search_text": "bruker-q-tof-uhplc-hrms-ms Bruker Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "bruker-solarix",
@@ -114654,24 +114702,24 @@
     {
       "slug": "calculator",
       "name": "Calculator",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/djdt/pewpew",
       "license_spdx": "",
       "evidence_text": "The built in `Calculator` can perform simple calculations on image data by entering the desired formula into the `Formula` text box",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/calculator.yaml",
-      "search_text": "calculator Calculator The built in `Calculator` can perform simple calculations on image data by entering the desired formula into the `Formula` text box metabolomics/v2"
+      "search_text": "calculator Calculator The built in `Calculator` can perform simple calculations on image data by entering the desired formula into the `Formula` text box metabolomics/v2 https://github.com/djdt/pewpew"
     },
     {
       "slug": "camera",
       "name": "CAMERA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LinShuhaiLAB/LipidIN",
       "license_spdx": "",
       "evidence_text": "CAMERA: an The default table of adducts and fragments is built using information from CAMERA R package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/camera.yaml",
-      "search_text": "camera CAMERA CAMERA: an The default table of adducts and fragments is built using information from CAMERA R package metabolomics/v2"
+      "search_text": "camera CAMERA CAMERA: an The default table of adducts and fragments is built using information from CAMERA R package metabolomics/v2 https://github.com/LinShuhaiLAB/LipidIN"
     },
     {
       "slug": "canonical-correlation-analysis-cca",
@@ -114687,57 +114735,57 @@
     {
       "slug": "canopus",
       "name": "CANOPUS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) Class Component (CC): a score considering the presence of predicted known chemical classes new to the species",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/canopus.yaml",
-      "search_text": "canopus CANOPUS The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) Class Component (CC): a score considering the presence of predicted known chemical classes new to the species metabolomics/v2"
+      "search_text": "canopus CANOPUS The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) Class Component (CC): a score considering the presence of predicted known chemical classes new to the species metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "cardinal",
       "name": "Cardinal",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GenomicsMachineLearning/SpaMTP",
       "license_spdx": "",
       "evidence_text": "library(Cardinal) *Cardinal 3.6* is a major update with breaking changes. It bring support many of the new low-level signal processing functions LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. If you are using Cardinal to process your MSI data, data objects in the `MSProcessedImagingExperiment` or `MSContinuousImagingExperiment` formats can be converted to mass2adduct's `msimat` format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cardinal.yaml",
-      "search_text": "cardinal Cardinal library(Cardinal) *Cardinal 3.6* is a major update with breaking changes. It bring support many of the new low-level signal processing functions LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. If you are using Cardinal to process your MSI data, data objects in the `MSProcessedImagingExperiment` or `MSContinuousImagingExperiment` formats can be converted to mass2adduct's `msimat` format metabolomics/v2"
+      "search_text": "cardinal Cardinal library(Cardinal) *Cardinal 3.6* is a major update with breaking changes. It bring support many of the new low-level signal processing functions LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. If you are using Cardinal to process your MSI data, data objects in the `MSProcessedImagingExperiment` or `MSContinuousImagingExperiment` formats can be converted to mass2adduct's `msimat` format metabolomics/v2 https://github.com/GenomicsMachineLearning/SpaMTP"
     },
     {
       "slug": "cardinalio",
       "name": "CardinalIO",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kuwisdelu/Cardinal",
       "license_spdx": "",
       "evidence_text": "We can read an example of a \"continuous\" imzML file from the `CardinalIO` package:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cardinalio.yaml",
-      "search_text": "cardinalio CardinalIO We can read an example of a \"continuous\" imzML file from the `CardinalIO` package: metabolomics/v2"
+      "search_text": "cardinalio CardinalIO We can read an example of a \"continuous\" imzML file from the `CardinalIO` package: metabolomics/v2 https://github.com/kuwisdelu/Cardinal"
     },
     {
       "slug": "caret",
       "name": "caret",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/KelseyChetnik/MetaClean",
       "license_spdx": "",
       "evidence_text": "MetaClean provides 8 classification algorithms (implemented with the R package caret) packageVersion(\"caret\") [1] ‘6.0.86’",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/caret.yaml",
-      "search_text": "caret caret MetaClean provides 8 classification algorithms (implemented with the R package caret) packageVersion(\"caret\") [1] ‘6.0.86’ metabolomics/v2"
+      "search_text": "caret caret MetaClean provides 8 classification algorithms (implemented with the R package caret) packageVersion(\"caret\") [1] ‘6.0.86’ metabolomics/v2 https://github.com/KelseyChetnik/MetaClean"
     },
     {
       "slug": "casanovo",
       "name": "Casanovo",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Noble-Lab/casanovo",
       "license_spdx": "",
       "evidence_text": "Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing. Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/casanovo.yaml",
-      "search_text": "casanovo Casanovo Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing. Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing metabolomics/v2"
+      "search_text": "casanovo Casanovo Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing. Casanovo is a state-of-the-art deep learning tool designed for _de novo_ peptide sequencing metabolomics/v2 https://github.com/Noble-Lab/casanovo"
     },
     {
       "slug": "cca-canonical-correlation-analysis",
@@ -114764,68 +114812,68 @@
     {
       "slug": "cfm-id",
       "name": "CFM-ID",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/aaronma2020/MSGO",
       "license_spdx": "",
       "evidence_text": "CFM-ID the CFM-ID spectra, the Chemdraw files, the mol files and the SDF files of the DNA adducts compatible with the customized database prepared using CFM-id, the fragment prediction tool The current version of MS2Compound is compatible with the customized database prepared using CFM-id, the fragment prediction tool. we use 30k+ pseudo smiles-specturm pairs generated by cfmid",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cfm-id.yaml",
-      "search_text": "cfm-id CFM-ID CFM-ID the CFM-ID spectra, the Chemdraw files, the mol files and the SDF files of the DNA adducts compatible with the customized database prepared using CFM-id, the fragment prediction tool The current version of MS2Compound is compatible with the customized database prepared using CFM-id, the fragment prediction tool. we use 30k+ pseudo smiles-specturm pairs generated by cfmid metabolomics/v2"
+      "search_text": "cfm-id CFM-ID CFM-ID the CFM-ID spectra, the Chemdraw files, the mol files and the SDF files of the DNA adducts compatible with the customized database prepared using CFM-id, the fragment prediction tool The current version of MS2Compound is compatible with the customized database prepared using CFM-id, the fragment prediction tool. we use 30k+ pseudo smiles-specturm pairs generated by cfmid metabolomics/v2 https://github.com/aaronma2020/MSGO"
     },
     {
       "slug": "cfmid",
       "name": "cfmid",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/aaronma2020/MSGO",
       "license_spdx": "",
       "evidence_text": "30k+ pseudo smiles-specturm pairs generated by cfmid",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cfmid.yaml",
-      "search_text": "cfmid cfmid 30k+ pseudo smiles-specturm pairs generated by cfmid metabolomics/v2"
+      "search_text": "cfmid cfmid 30k+ pseudo smiles-specturm pairs generated by cfmid metabolomics/v2 https://github.com/aaronma2020/MSGO"
     },
     {
       "slug": "chambm-pwiz-skyline-i-agree-to-the-vendor-licenses",
       "name": "chambm/pwiz-skyline-i-agree-to-the-vendor-licenses",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/VIU-Metabolomics/imzML_Writer",
       "license_spdx": "",
       "evidence_text": "docker pull chambm/pwiz-skyline-i-agree-to-the-vendor-licenses",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chambm-pwiz-skyline-i-agree-to-the-vendor-licenses.yaml",
-      "search_text": "chambm-pwiz-skyline-i-agree-to-the-vendor-licenses chambm/pwiz-skyline-i-agree-to-the-vendor-licenses docker pull chambm/pwiz-skyline-i-agree-to-the-vendor-licenses metabolomics/v2"
+      "search_text": "chambm-pwiz-skyline-i-agree-to-the-vendor-licenses chambm/pwiz-skyline-i-agree-to-the-vendor-licenses docker pull chambm/pwiz-skyline-i-agree-to-the-vendor-licenses metabolomics/v2 https://github.com/VIU-Metabolomics/imzML_Writer"
     },
     {
       "slug": "chebi",
       "name": "ChEBI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "find structures on other chemical projects like ChEBI",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chebi.yaml",
-      "search_text": "chebi ChEBI find structures on other chemical projects like ChEBI metabolomics/v2"
+      "search_text": "chebi ChEBI find structures on other chemical projects like ChEBI metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "chem-spectra-app",
       "name": "chem-spectra-app",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "git clone https://github.com/ComPlat/chem-spectra-app.git",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chem-spectra-app.yaml",
-      "search_text": "chem-spectra-app chem-spectra-app git clone https://github.com/ComPlat/chem-spectra-app.git metabolomics/v2"
+      "search_text": "chem-spectra-app chem-spectra-app git clone https://github.com/ComPlat/chem-spectra-app.git metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "chemecho",
       "name": "ChemEcho",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biorack/chemecho",
       "license_spdx": "",
       "evidence_text": "github.com__biorack__chemecho",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chemecho.yaml",
-      "search_text": "chemecho ChemEcho github.com__biorack__chemecho metabolomics/v2"
+      "search_text": "chemecho ChemEcho github.com__biorack__chemecho metabolomics/v2 https://github.com/biorack/chemecho"
     },
     {
       "slug": "chemicalmixturefrommzml",
@@ -114841,13 +114889,13 @@
     {
       "slug": "chemistry-development-kit-cdk",
       "name": "Chemistry Development Kit (CDK)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29] Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29]. The fingerprint vector is composed of three concatenated sets of fingerprints: CDK Substructure,",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chemistry-development-kit-cdk.yaml",
-      "search_text": "chemistry-development-kit-cdk Chemistry Development Kit (CDK) Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29] Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29]. The fingerprint vector is composed of three concatenated sets of fingerprints: CDK Substructure, metabolomics/v2"
+      "search_text": "chemistry-development-kit-cdk Chemistry Development Kit (CDK) Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29] Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit [29]. The fingerprint vector is composed of three concatenated sets of fingerprints: CDK Substructure, metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "chemminer",
@@ -114863,13 +114911,13 @@
     {
       "slug": "chemparse",
       "name": "chemparse",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FanzhouKong/spectral_denoising",
       "license_spdx": "",
       "evidence_text": "chemparse==0.3.1 - ``chemparse==0.3.1``",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chemparse.yaml",
-      "search_text": "chemparse chemparse chemparse==0.3.1 - ``chemparse==0.3.1`` metabolomics/v2"
+      "search_text": "chemparse chemparse chemparse==0.3.1 - ``chemparse==0.3.1`` metabolomics/v2 https://github.com/FanzhouKong/spectral_denoising"
     },
     {
       "slug": "chemprop-ir",
@@ -114896,79 +114944,79 @@
     {
       "slug": "chemspider",
       "name": "ChemSpider",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "find structures on other chemical projects like ChemSpider",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/chemspider.yaml",
-      "search_text": "chemspider ChemSpider find structures on other chemical projects like ChemSpider metabolomics/v2"
+      "search_text": "chemspider ChemSpider find structures on other chemical projects like ChemSpider metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "cir",
       "name": "CIR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService']",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cir.yaml",
-      "search_text": "cir CIR fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2"
+      "search_text": "cir CIR fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb fetched from the following services: [CIR](https://cactus.nci.nih.gov/chemical/structure_documentation) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "classyfire",
       "name": "ClassyFire",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/michaelwitting/RepoRT",
       "license_spdx": "",
       "evidence_text": "use NPClassifier instead of ClassyFire by checking the box in the GUI You can copy the InChiKey's from the GNPS DBResult file into the Fiehn Labs' classyfire Batch identifier Classification of molecules is performed using ClassyFire",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/classyfire.yaml",
-      "search_text": "classyfire ClassyFire use NPClassifier instead of ClassyFire by checking the box in the GUI You can copy the InChiKey's from the GNPS DBResult file into the Fiehn Labs' classyfire Batch identifier Classification of molecules is performed using ClassyFire metabolomics/v2"
+      "search_text": "classyfire ClassyFire use NPClassifier instead of ClassyFire by checking the box in the GUI You can copy the InChiKey's from the GNPS DBResult file into the Fiehn Labs' classyfire Batch identifier Classification of molecules is performed using ClassyFire metabolomics/v2 https://github.com/michaelwitting/RepoRT"
     },
     {
       "slug": "cliquems",
       "name": "cliqueMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/b2slab/mWISE",
       "license_spdx": "",
       "evidence_text": "The default table of adducts and fragments is built using information from CAMERA R package, H. Tong et al., and cliqueMS. information from CAMERA R package, H. Tong et al., and cliqueMS.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cliquems.yaml",
-      "search_text": "cliquems cliqueMS The default table of adducts and fragments is built using information from CAMERA R package, H. Tong et al., and cliqueMS. information from CAMERA R package, H. Tong et al., and cliqueMS. metabolomics/v2"
+      "search_text": "cliquems cliqueMS The default table of adducts and fragments is built using information from CAMERA R package, H. Tong et al., and cliqueMS. information from CAMERA R package, H. Tong et al., and cliqueMS. metabolomics/v2 https://github.com/b2slab/mWISE"
     },
     {
       "slug": "clumsid",
       "name": "CluMSID",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "CluMSID",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/clumsid.yaml",
-      "search_text": "clumsid CluMSID CluMSID metabolomics/v2"
+      "search_text": "clumsid CluMSID CluMSID metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "clumsiddata",
       "name": "CluMSIDdata",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "CluMSIDdata",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/clumsiddata.yaml",
-      "search_text": "clumsiddata CluMSIDdata CluMSIDdata metabolomics/v2"
+      "search_text": "clumsiddata CluMSIDdata CluMSIDdata metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "clusterprofiler",
       "name": "clusterProfiler",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "margheRita implements both Over Representation Analysis (ORA) and Metabolite Set Enrichment Analysis (MSEA), based on clusterProfiler Pathway enrichment analysis | Clusterprofiler, Biotranslator",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/clusterprofiler.yaml",
-      "search_text": "clusterprofiler clusterProfiler margheRita implements both Over Representation Analysis (ORA) and Metabolite Set Enrichment Analysis (MSEA), based on clusterProfiler Pathway enrichment analysis | Clusterprofiler, Biotranslator metabolomics/v2"
+      "search_text": "clusterprofiler clusterProfiler margheRita implements both Over Representation Analysis (ORA) and Metabolite Set Enrichment Analysis (MSEA), based on clusterProfiler Pathway enrichment analysis | Clusterprofiler, Biotranslator metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "cobrapy-for-optgpsampler-uniform-sampling",
@@ -115006,13 +115054,13 @@
     {
       "slug": "coconut",
       "name": "COCONUT",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "find structures on other chemical projects like COCONUT",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/coconut.yaml",
-      "search_text": "coconut COCONUT find structures on other chemical projects like COCONUT metabolomics/v2"
+      "search_text": "coconut COCONUT find structures on other chemical projects like COCONUT metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "cohen-s-kappa-metric",
@@ -115039,13 +115087,13 @@
     {
       "slug": "combat",
       "name": "ComBat",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ShinyFabio/ADViSELipidomics",
       "license_spdx": "",
       "evidence_text": "dealing with batch effect correction.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/combat.yaml",
-      "search_text": "combat ComBat dealing with batch effect correction. metabolomics/v2"
+      "search_text": "combat ComBat dealing with batch effect correction. metabolomics/v2 https://github.com/ShinyFabio/ADViSELipidomics"
     },
     {
       "slug": "commit",
@@ -115061,68 +115109,68 @@
     {
       "slug": "commons-math3",
       "name": "commons-math3",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rformassspectrometry/Spectra",
       "license_spdx": "",
       "evidence_text": "commons-math3-3.4.1",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/commons-math3.yaml",
-      "search_text": "commons-math3 commons-math3 commons-math3-3.4.1 metabolomics/v2"
+      "search_text": "commons-math3 commons-math3 commons-math3-3.4.1 metabolomics/v2 https://github.com/rformassspectrometry/Spectra"
     },
     {
       "slug": "comparador",
       "name": "Comparador",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "Comparador: Tool to compare lists of features (CSV files) from different acquisition methods or processing software",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/comparador.yaml",
-      "search_text": "comparador Comparador Comparador: Tool to compare lists of features (CSV files) from different acquisition methods or processing software metabolomics/v2"
+      "search_text": "comparador Comparador Comparador: Tool to compare lists of features (CSV files) from different acquisition methods or processing software metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "comparems2",
       "name": "compareMS2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/524D/compareMS2",
       "license_spdx": "",
       "evidence_text": "compareMS2 calculates the global similarity between tandem mass spectrometry datasets",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/comparems2.yaml",
-      "search_text": "comparems2 compareMS2 compareMS2 calculates the global similarity between tandem mass spectrometry datasets metabolomics/v2"
+      "search_text": "comparems2 compareMS2 compareMS2 calculates the global similarity between tandem mass spectrometry datasets metabolomics/v2 https://github.com/524D/compareMS2"
     },
     {
       "slug": "complexheatmap",
       "name": "ComplexHeatmap",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "The function `h_map()` provides heatmaps based on package ComplexHeatmap Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap R packages: DESeq2, edger, RankProd, ggplot2 ComplexHeatmap Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/complexheatmap.yaml",
-      "search_text": "complexheatmap ComplexHeatmap The function `h_map()` provides heatmaps based on package ComplexHeatmap Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap R packages: DESeq2, edger, RankProd, ggplot2 ComplexHeatmap Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap metabolomics/v2"
+      "search_text": "complexheatmap ComplexHeatmap The function `h_map()` provides heatmaps based on package ComplexHeatmap Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap R packages: DESeq2, edger, RankProd, ggplot2 ComplexHeatmap Data preprocessing | R packages: edger, limma, sva, ggplot2, ComplexHeatmap metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "compound-discoverer",
       "name": "Compound Discoverer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/compound-discoverer.yaml",
-      "search_text": "compound-discoverer Compound Discoverer LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) metabolomics/v2"
+      "search_text": "compound-discoverer Compound Discoverer LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "conda",
       "name": "conda",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/JESTR1",
       "license_spdx": "",
       "evidence_text": "We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html) Use conda to create a virtual environment with required dependencies. Use `conda <https://www.anaconda.com/download/>`_ to create a virtual environment with required dependencies. We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html). Create a Conda environment and install the necessary compiler tools and GPU runtime Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/conda.yaml",
-      "search_text": "conda conda We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html) Use conda to create a virtual environment with required dependencies. Use `conda <https://www.anaconda.com/download/>`_ to create a virtual environment with required dependencies. We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html). Create a Conda environment and install the necessary compiler tools and GPU runtime Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip] metabolomics/v2"
+      "search_text": "conda conda We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html) Use conda to create a virtual environment with required dependencies. Use `conda <https://www.anaconda.com/download/>`_ to create a virtual environment with required dependencies. We recommend to use [conda](https://conda.io/docs/user-guide/install/download.html). Create a Conda environment and install the necessary compiler tools and GPU runtime Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip] metabolomics/v2 https://github.com/HassounLab/JESTR1"
     },
     {
       "slug": "consensus-clustering",
@@ -115149,24 +115197,24 @@
     {
       "slug": "converterbuilder",
       "name": "ConverterBuilder",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "Converter Builder: Automatically discovers and instantiates available converters",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/converterbuilder.yaml",
-      "search_text": "converterbuilder ConverterBuilder Converter Builder: Automatically discovers and instantiates available converters metabolomics/v2"
+      "search_text": "converterbuilder ConverterBuilder Converter Builder: Automatically discovers and instantiates available converters metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "convolutional-neural-network-cnn",
       "name": "Convolutional Neural Network (CNN)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/massspecdl/ChemEmbed",
       "license_spdx": "",
       "evidence_text": "perform predictions using a trained Convolutional Neural Network (CNN) model Integrating this capability with a convolutional neural network, we build an end-to-end model",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/convolutional-neural-network-cnn.yaml",
-      "search_text": "convolutional-neural-network-cnn Convolutional Neural Network (CNN) perform predictions using a trained Convolutional Neural Network (CNN) model Integrating this capability with a convolutional neural network, we build an end-to-end model metabolomics/v2"
+      "search_text": "convolutional-neural-network-cnn Convolutional Neural Network (CNN) perform predictions using a trained Convolutional Neural Network (CNN) model Integrating this capability with a convolutional neural network, we build an end-to-end model metabolomics/v2 https://github.com/massspecdl/ChemEmbed"
     },
     {
       "slug": "convolutional-neural-network",
@@ -115182,13 +115230,13 @@
     {
       "slug": "cordbat",
       "name": "CordBat",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BorchLab/CordBat",
       "license_spdx": "",
       "evidence_text": "fit <- CordBat( X = X_mat, batch = batch_vec, group = group_vec, ref.batch = \"Ref\", grouping = FALSE, print.detail = FALSE )",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cordbat.yaml",
-      "search_text": "cordbat CordBat fit <- CordBat( X = X_mat, batch = batch_vec, group = group_vec, ref.batch = \"Ref\", grouping = FALSE, print.detail = FALSE ) metabolomics/v2"
+      "search_text": "cordbat CordBat fit <- CordBat( X = X_mat, batch = batch_vec, group = group_vec, ref.batch = \"Ref\", grouping = FALSE, print.detail = FALSE ) metabolomics/v2 https://github.com/BorchLab/CordBat"
     },
     {
       "slug": "corems",
@@ -115204,266 +115252,266 @@
     {
       "slug": "cosine-neutral-loss-repository",
       "name": "cosine_neutral_loss repository",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux/cosine_neutral_loss",
       "license_spdx": "",
       "evidence_text": "Code repository implements cosine similarity, modified cosine similarity, and neutral loss similarity measures",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cosine-neutral-loss-repository.yaml",
-      "search_text": "cosine-neutral-loss-repository cosine_neutral_loss repository Code repository implements cosine similarity, modified cosine similarity, and neutral loss similarity measures metabolomics/v2"
+      "search_text": "cosine-neutral-loss-repository cosine_neutral_loss repository Code repository implements cosine similarity, modified cosine similarity, and neutral loss similarity measures metabolomics/v2 https://github.com/bittremieux/cosine_neutral_loss"
     },
     {
       "slug": "cosine-neutral-loss",
       "name": "cosine_neutral_loss",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux/cosine_neutral_loss",
       "license_spdx": "",
       "evidence_text": "github.com/bittremieux/cosine_neutral_loss",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cosine-neutral-loss.yaml",
-      "search_text": "cosine-neutral-loss cosine_neutral_loss github.com/bittremieux/cosine_neutral_loss metabolomics/v2"
+      "search_text": "cosine-neutral-loss cosine_neutral_loss github.com/bittremieux/cosine_neutral_loss metabolomics/v2 https://github.com/bittremieux/cosine_neutral_loss"
     },
     {
       "slug": "cox-nnet",
       "name": "Cox-nnet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lanagarmire/lilikoi2",
       "license_spdx": "",
       "evidence_text": "the deep-learning based Cox-nnet model",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cox-nnet.yaml",
-      "search_text": "cox-nnet Cox-nnet the deep-learning based Cox-nnet model metabolomics/v2"
+      "search_text": "cox-nnet Cox-nnet the deep-learning based Cox-nnet model metabolomics/v2 https://github.com/lanagarmire/lilikoi2"
     },
     {
       "slug": "cox-ph",
       "name": "Cox-PH",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lanagarmire/lilikoi2",
       "license_spdx": "",
       "evidence_text": "prognosis prediction, implemented by Cox-PH model",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cox-ph.yaml",
-      "search_text": "cox-ph Cox-PH prognosis prediction, implemented by Cox-PH model metabolomics/v2"
+      "search_text": "cox-ph Cox-PH prognosis prediction, implemented by Cox-PH model metabolomics/v2 https://github.com/lanagarmire/lilikoi2"
     },
     {
       "slug": "cpat",
       "name": "CPAT",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Functional annotation | CPAT, signalP, pfam",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cpat.yaml",
-      "search_text": "cpat CPAT Functional annotation | CPAT, signalP, pfam metabolomics/v2"
+      "search_text": "cpat CPAT Functional annotation | CPAT, signalP, pfam metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "crest",
       "name": "CREST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "**CREST** (version >= 3.0.2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/crest.yaml",
-      "search_text": "crest CREST **CREST** (version >= 3.0.2) metabolomics/v2"
+      "search_text": "crest CREST **CREST** (version >= 3.0.2) metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "csi-fingerid",
       "name": "CSI:FingerID",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sirius-ms/sirius",
       "license_spdx": "",
       "evidence_text": "The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/csi-fingerid.yaml",
-      "search_text": "csi-fingerid CSI:FingerID The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) metabolomics/v2"
+      "search_text": "csi-fingerid CSI:FingerID The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) metabolomics/v2 https://github.com/sirius-ms/sirius"
     },
     {
       "slug": "cts",
       "name": "CTS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [CTS](https://cts.fiehnlab.ucdavis.edu/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] `generateTPs(algorithm = \"cts\", ...)` | Parents | TPs with structural information",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cts.yaml",
-      "search_text": "cts CTS fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [CTS](https://cts.fiehnlab.ucdavis.edu/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] `generateTPs(algorithm = \"cts\", ...)` | Parents | TPs with structural information metabolomics/v2"
+      "search_text": "cts CTS fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [CTS](https://cts.fiehnlab.ucdavis.edu/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] `generateTPs(algorithm = \"cts\", ...)` | Parents | TPs with structural information metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "cuda-toolkit",
       "name": "CUDA Toolkit",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Noble-Lab/casanovo",
       "license_spdx": "",
       "evidence_text": "Install the latest version of the NVIDIA drivers using the official CUDA Toolkit",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cuda-toolkit.yaml",
-      "search_text": "cuda-toolkit CUDA Toolkit Install the latest version of the NVIDIA drivers using the official CUDA Toolkit metabolomics/v2"
+      "search_text": "cuda-toolkit CUDA Toolkit Install the latest version of the NVIDIA drivers using the official CUDA Toolkit metabolomics/v2 https://github.com/Noble-Lab/casanovo"
     },
     {
       "slug": "cuda",
       "name": "CUDA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/JESTR1",
       "license_spdx": "",
       "evidence_text": "HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. The model was trained and tested on GPU nVidia A100 with CUDA 11.8 cuda >= 9.0 PyTorch：2.6.0 + CUDA 12.4",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cuda.yaml",
-      "search_text": "cuda CUDA HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. The model was trained and tested on GPU nVidia A100 with CUDA 11.8 cuda >= 9.0 PyTorch：2.6.0 + CUDA 12.4 metabolomics/v2"
+      "search_text": "cuda CUDA HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. The model was trained and tested on GPU nVidia A100 with CUDA 11.8 cuda >= 9.0 PyTorch：2.6.0 + CUDA 12.4 metabolomics/v2 https://github.com/HassounLab/JESTR1"
     },
     {
       "slug": "cudnn",
       "name": "cuDNN",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chensaian/TransG-Net",
       "license_spdx": "",
       "evidence_text": "cudnn >= 7.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cudnn.yaml",
-      "search_text": "cudnn cuDNN cudnn >= 7.0 metabolomics/v2"
+      "search_text": "cudnn cuDNN cudnn >= 7.0 metabolomics/v2 https://github.com/chensaian/TransG-Net"
     },
     {
       "slug": "curl",
       "name": "curl",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "curl xxx.xxx.xxx.xxx:3007/ping",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/curl.yaml",
-      "search_text": "curl curl curl xxx.xxx.xxx.xxx:3007/ping metabolomics/v2"
+      "search_text": "curl curl curl xxx.xxx.xxx.xxx:3007/ping metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "cyclobranch",
       "name": "CycloBranch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "export format for open source program CycloBranch from Jiří Novák",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cyclobranch.yaml",
-      "search_text": "cyclobranch CycloBranch export format for open source program CycloBranch from Jiří Novák metabolomics/v2"
+      "search_text": "cyclobranch CycloBranch export format for open source program CycloBranch from Jiří Novák metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "cypreact",
       "name": "CypReact",
-      "canonical_url": "",
+      "canonical_url": "https://bitbucket.org/Leon_Ti/cypreact.git",
       "license_spdx": "",
       "evidence_text": "To run the CypReact tool, the user should use command in the terminal as: ->java -jar \"PathOfCypReactBundle\" java -jar \"PathOfCypReactBundle\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cypreact.yaml",
-      "search_text": "cypreact CypReact To run the CypReact tool, the user should use command in the terminal as: ->java -jar \"PathOfCypReactBundle\" java -jar \"PathOfCypReactBundle\" metabolomics/v2"
+      "search_text": "cypreact CypReact To run the CypReact tool, the user should use command in the terminal as: ->java -jar \"PathOfCypReactBundle\" java -jar \"PathOfCypReactBundle\" metabolomics/v2 https://bitbucket.org/Leon_Ti/cypreact.git"
     },
     {
       "slug": "cyproduct",
       "name": "CyProduct",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Le0nT1/CyProduct",
       "license_spdx": "",
       "evidence_text": "Please download the CyProduct.jar to run the tool",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cyproduct.yaml",
-      "search_text": "cyproduct CyProduct Please download the CyProduct.jar to run the tool metabolomics/v2"
+      "search_text": "cyproduct CyProduct Please download the CyProduct.jar to run the tool metabolomics/v2 https://github.com/Le0nT1/CyProduct"
     },
     {
       "slug": "cytoscape-js",
       "name": "cytoscape.js",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/dgrapov/MetaMapR",
       "license_spdx": "",
       "evidence_text": "add cytoscape.js networks",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cytoscape-js.yaml",
-      "search_text": "cytoscape-js cytoscape.js add cytoscape.js networks metabolomics/v2"
+      "search_text": "cytoscape-js cytoscape.js add cytoscape.js networks metabolomics/v2 https://github.com/dgrapov/MetaMapR"
     },
     {
       "slug": "cytoscape",
       "name": "Cytoscape",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Karnovsky-Lab/DNEA",
       "license_spdx": "",
       "evidence_text": "[Cytoscape](https://cytoscape.org/) users need to download Cytoscape from http://www.cytoscape.org/download.php You can also save the network as an NX object and review in [Cytoscape](https://cytoscape.org) Networks are then constructed using Cytoscape [79] and colored based on their molecular class. Networks are then constructed using Cytoscape and colored based on their molecular class using Cytoscape",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/cytoscape.yaml",
-      "search_text": "cytoscape Cytoscape [Cytoscape](https://cytoscape.org/) users need to download Cytoscape from http://www.cytoscape.org/download.php You can also save the network as an NX object and review in [Cytoscape](https://cytoscape.org) Networks are then constructed using Cytoscape [79] and colored based on their molecular class. Networks are then constructed using Cytoscape and colored based on their molecular class using Cytoscape metabolomics/v2"
+      "search_text": "cytoscape Cytoscape [Cytoscape](https://cytoscape.org/) users need to download Cytoscape from http://www.cytoscape.org/download.php You can also save the network as an NX object and review in [Cytoscape](https://cytoscape.org) Networks are then constructed using Cytoscape [79] and colored based on their molecular class. Networks are then constructed using Cytoscape and colored based on their molecular class using Cytoscape metabolomics/v2 https://github.com/Karnovsky-Lab/DNEA"
     },
     {
       "slug": "d3-js",
       "name": "D3.js",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website",
       "license_spdx": "",
       "evidence_text": "interactive visualization and analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/d3-js.yaml",
-      "search_text": "d3-js D3.js interactive visualization and analysis metabolomics/v2"
+      "search_text": "d3-js D3.js interactive visualization and analysis metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website"
     },
     {
       "slug": "data-table",
       "name": "data.table",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BalunasLab/mpact",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" library(data.table)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/data-table.yaml",
-      "search_text": "data-table data.table invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" library(data.table) metabolomics/v2"
+      "search_text": "data-table data.table invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" library(data.table) metabolomics/v2 https://github.com/BalunasLab/mpact"
     },
     {
       "slug": "dbdipy",
       "name": "DBDIpy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/leopold-weidner/DBDIpy",
       "license_spdx": "",
       "evidence_text": "DBDIpy is an open-source Python library for the curation and interpretation of dielectric barrier discharge ionisation mass spectrometric datasets",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dbdipy.yaml",
-      "search_text": "dbdipy DBDIpy DBDIpy is an open-source Python library for the curation and interpretation of dielectric barrier discharge ionisation mass spectrometric datasets metabolomics/v2"
+      "search_text": "dbdipy DBDIpy DBDIpy is an open-source Python library for the curation and interpretation of dielectric barrier discharge ionisation mass spectrometric datasets metabolomics/v2 https://github.com/leopold-weidner/DBDIpy"
     },
     {
       "slug": "dbnorm",
       "name": "dbnorm",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NBDZ/dbnorm",
       "license_spdx": "",
       "evidence_text": "dbnorm (V-0.2.2) A package for drift across batches normalization and visualization",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dbnorm.yaml",
-      "search_text": "dbnorm dbnorm dbnorm (V-0.2.2) A package for drift across batches normalization and visualization metabolomics/v2"
+      "search_text": "dbnorm dbnorm dbnorm (V-0.2.2) A package for drift across batches normalization and visualization metabolomics/v2 https://github.com/NBDZ/dbnorm"
     },
     {
       "slug": "decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework",
       "name": "Decision tree classifier (scikit-learn or equivalent tree-based ML framework)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biorack/chemecho",
       "license_spdx": "",
       "evidence_text": "Using ChemEcho vectors, we can train decision trees which are able to be directly converted to MassQL",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework.yaml",
-      "search_text": "decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework Decision tree classifier (scikit-learn or equivalent tree-based ML framework) Using ChemEcho vectors, we can train decision trees which are able to be directly converted to MassQL metabolomics/v2"
+      "search_text": "decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework Decision tree classifier (scikit-learn or equivalent tree-based ML framework) Using ChemEcho vectors, we can train decision trees which are able to be directly converted to MassQL metabolomics/v2 https://github.com/biorack/chemecho"
     },
     {
       "slug": "decometdia",
       "name": "DecoMetDIA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ZhuMSLab/DecoMetDIA",
       "license_spdx": "",
       "evidence_text": "DecoMetDIA was developed to process SWATH-MS based data for metabolomics.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/decometdia.yaml",
-      "search_text": "decometdia DecoMetDIA DecoMetDIA was developed to process SWATH-MS based data for metabolomics. metabolomics/v2"
+      "search_text": "decometdia DecoMetDIA DecoMetDIA was developed to process SWATH-MS based data for metabolomics. metabolomics/v2 https://github.com/ZhuMSLab/DecoMetDIA"
     },
     {
       "slug": "deepmass2",
       "name": "DeepMASS2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/hcji/DeepMASS2_Data_Processing",
       "license_spdx": "",
       "evidence_text": "DeepMASS2 is a cross-platform GUI software tool, which enables deep-learning based metabolite annotation",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/deepmass2.yaml",
-      "search_text": "deepmass2 DeepMASS2 DeepMASS2 is a cross-platform GUI software tool, which enables deep-learning based metabolite annotation metabolomics/v2"
+      "search_text": "deepmass2 DeepMASS2 DeepMASS2 is a cross-platform GUI software tool, which enables deep-learning based metabolite annotation metabolomics/v2 https://github.com/hcji/DeepMASS2_Data_Processing"
     },
     {
       "slug": "deimos",
@@ -115479,134 +115527,134 @@
     {
       "slug": "deoptim",
       "name": "DEoptim",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/deoptim.yaml",
-      "search_text": "deoptim DEoptim invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2"
+      "search_text": "deoptim DEoptim invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "depthcharge",
       "name": "DepthCharge",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Noble-Lab/casanovo",
       "license_spdx": "",
       "evidence_text": "Upgraded minimum DepthCharge version to 0.4.10.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/depthcharge.yaml",
-      "search_text": "depthcharge DepthCharge Upgraded minimum DepthCharge version to 0.4.10. metabolomics/v2"
+      "search_text": "depthcharge DepthCharge Upgraded minimum DepthCharge version to 0.4.10. metabolomics/v2 https://github.com/Noble-Lab/casanovo"
     },
     {
       "slug": "dereplicator",
       "name": "Dereplicator",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "matches tandem mass spectra against the constructed post-translationally modified RiPPs structure database using Dereplicator",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dereplicator.yaml",
-      "search_text": "dereplicator Dereplicator matches tandem mass spectra against the constructed post-translationally modified RiPPs structure database using Dereplicator metabolomics/v2"
+      "search_text": "dereplicator Dereplicator matches tandem mass spectra against the constructed post-translationally modified RiPPs structure database using Dereplicator metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "deseq2",
       "name": "DESeq2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Differential expression analyss | R packages: DESeq2, edger, RankProd ### DESeq2 [deseq](../modules/local/deseq2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/deseq2.yaml",
-      "search_text": "deseq2 DESeq2 Differential expression analyss | R packages: DESeq2, edger, RankProd ### DESeq2 [deseq](../modules/local/deseq2) metabolomics/v2"
+      "search_text": "deseq2 DESeq2 Differential expression analyss | R packages: DESeq2, edger, RankProd ### DESeq2 [deseq](../modules/local/deseq2) metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "devtools",
       "name": "devtools",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Ghoshlab/marr",
       "license_spdx": "",
       "evidence_text": "if (!require(devtools)) The R-package **marr** can be installed from GitHub using the R package [devtools] devtools::install_github(\"KelseyChetnik/MetaCleanData\") library(devtools) ![installed with devtools](https://img.shields.io/badge/installed%20with-devtools-blueviolet.svg) install.packages(\"devtools\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/devtools.yaml",
-      "search_text": "devtools devtools if (!require(devtools)) The R-package **marr** can be installed from GitHub using the R package [devtools] devtools::install_github(\"KelseyChetnik/MetaCleanData\") library(devtools) ![installed with devtools](https://img.shields.io/badge/installed%20with-devtools-blueviolet.svg) install.packages(\"devtools\") metabolomics/v2"
+      "search_text": "devtools devtools if (!require(devtools)) The R-package **marr** can be installed from GitHub using the R package [devtools] devtools::install_github(\"KelseyChetnik/MetaCleanData\") library(devtools) ![installed with devtools](https://img.shields.io/badge/installed%20with-devtools-blueviolet.svg) install.packages(\"devtools\") metabolomics/v2 https://github.com/Ghoshlab/marr"
     },
     {
       "slug": "dgl",
       "name": "DGL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HopkinsLaboratory/Graphormer-RT",
       "license_spdx": "",
       "evidence_text": "import dgl",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dgl.yaml",
-      "search_text": "dgl DGL import dgl metabolomics/v2"
+      "search_text": "dgl DGL import dgl metabolomics/v2 https://github.com/HopkinsLaboratory/Graphormer-RT"
     },
     {
       "slug": "di-ms",
       "name": "DI-MS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Katherine00689/RapidMass",
       "license_spdx": "",
       "evidence_text": "supports data from multiple instruments, including DI-MS and ASAP-MS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/di-ms.yaml",
-      "search_text": "di-ms DI-MS supports data from multiple instruments, including DI-MS and ASAP-MS metabolomics/v2"
+      "search_text": "di-ms DI-MS supports data from multiple instruments, including DI-MS and ASAP-MS metabolomics/v2 https://github.com/Katherine00689/RapidMass"
     },
     {
       "slug": "dia-nn",
       "name": "DIA-NN",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "search results information obtained from DIA-NN for the selected precursor",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dia-nn.yaml",
-      "search_text": "dia-nn DIA-NN search results information obtained from DIA-NN for the selected precursor metabolomics/v2"
+      "search_text": "dia-nn DIA-NN search results information obtained from DIA-NN for the selected precursor metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "diffspectra",
       "name": "DiffSpectra",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AzureLeon1/DiffSpectra",
       "license_spdx": "",
       "evidence_text": "github.com/AzureLeon1/DiffSpectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/diffspectra.yaml",
-      "search_text": "diffspectra DiffSpectra github.com/AzureLeon1/DiffSpectra metabolomics/v2"
+      "search_text": "diffspectra DiffSpectra github.com/AzureLeon1/DiffSpectra metabolomics/v2 https://github.com/AzureLeon1/DiffSpectra"
     },
     {
       "slug": "dimorphite-dl",
       "name": "Dimorphite-DL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DasSusanta/snakemake_ccs",
       "license_spdx": "",
       "evidence_text": "Dimorphite-DL: For ionization state determination",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dimorphite-dl.yaml",
-      "search_text": "dimorphite-dl Dimorphite-DL Dimorphite-DL: For ionization state determination metabolomics/v2"
+      "search_text": "dimorphite-dl Dimorphite-DL Dimorphite-DL: For ionization state determination metabolomics/v2 https://github.com/DasSusanta/snakemake_ccs"
     },
     {
       "slug": "django",
       "name": "Django",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "The platform is built with Python, Django, JavaScript, and HTML",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/django.yaml",
-      "search_text": "django Django The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2"
+      "search_text": "django Django The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "docker-compose",
       "name": "docker-compose",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/NP-Classifier",
       "license_spdx": "",
       "evidence_text": "you need docker and docker-compose",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/docker-compose.yaml",
-      "search_text": "docker-compose docker-compose you need docker and docker-compose metabolomics/v2"
+      "search_text": "docker-compose docker-compose you need docker and docker-compose metabolomics/v2 https://github.com/mwang87/NP-Classifier"
     },
     {
       "slug": "docker-desktop-for-mac",
@@ -115644,13 +115692,13 @@
     {
       "slug": "docker",
       "name": "Docker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses Follow these steps to install Docker and run CloMet for the first time you need docker and docker-compose To bring everything up, you need docker and docker-compose. you need docker and docker-compose. Deploying to your own web server with docker. `docker pull databio2022/graphbio:v2.2.7-manual`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/docker.yaml",
-      "search_text": "docker Docker docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses Follow these steps to install Docker and run CloMet for the first time you need docker and docker-compose To bring everything up, you need docker and docker-compose. you need docker and docker-compose. Deploying to your own web server with docker. `docker pull databio2022/graphbio:v2.2.7-manual` metabolomics/v2"
+      "search_text": "docker Docker docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses Follow these steps to install Docker and run CloMet for the first time you need docker and docker-compose To bring everything up, you need docker and docker-compose. you need docker and docker-compose. Deploying to your own web server with docker. `docker pull databio2022/graphbio:v2.2.7-manual` metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "dockerfile-multi-stage-build-with-target-flag",
@@ -115666,24 +115714,24 @@
     {
       "slug": "doparallel",
       "name": "doParallel",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/antonvsdata/notame",
       "license_spdx": "",
       "evidence_text": "Load the libraries (doParallel is used for parallel processing)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/doparallel.yaml",
-      "search_text": "doparallel doParallel Load the libraries (doParallel is used for parallel processing) metabolomics/v2"
+      "search_text": "doparallel doParallel Load the libraries (doParallel is used for parallel processing) metabolomics/v2 https://github.com/antonvsdata/notame"
     },
     {
       "slug": "dplyr",
       "name": "dplyr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" we will load the hRUV package and other packages required for the demonstration... library(dplyr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(dplyr)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dplyr.yaml",
-      "search_text": "dplyr dplyr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" we will load the hRUV package and other packages required for the demonstration... library(dplyr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(dplyr) metabolomics/v2"
+      "search_text": "dplyr dplyr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" we will load the hRUV package and other packages required for the demonstration... library(dplyr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(dplyr) metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "dropms",
@@ -115699,79 +115747,79 @@
     {
       "slug": "drugbank-extraction-py",
       "name": "drugbank_extraction.py",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/corinnabrungs/msn_tree_library",
       "license_spdx": "",
       "evidence_text": "run `drugbank_extraction.py` on that file",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/drugbank-extraction-py.yaml",
-      "search_text": "drugbank-extraction-py drugbank_extraction.py run `drugbank_extraction.py` on that file metabolomics/v2"
+      "search_text": "drugbank-extraction-py drugbank_extraction.py run `drugbank_extraction.py` on that file metabolomics/v2 https://github.com/corinnabrungs/msn_tree_library"
     },
     {
       "slug": "drugbank",
       "name": "DrugBANK",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/daniellyz/meRgeION2",
       "license_spdx": "",
       "evidence_text": "search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/drugbank.yaml",
-      "search_text": "drugbank DrugBANK search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK) metabolomics/v2"
+      "search_text": "drugbank DrugBANK search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK) metabolomics/v2 https://github.com/daniellyz/meRgeION2"
     },
     {
       "slug": "dures",
       "name": "dures",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "devtools::install_github(\"BiosystemEngineeringLab-IITB/dures\", auth_token = NULL)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dures.yaml",
-      "search_text": "dures dures devtools::install_github(\"BiosystemEngineeringLab-IITB/dures\", auth_token = NULL) metabolomics/v2"
+      "search_text": "dures dures devtools::install_github(\"BiosystemEngineeringLab-IITB/dures\", auth_token = NULL) metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "dynaconf",
       "name": "Dynaconf",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "Pass Dynaconf config validation",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dynaconf.yaml",
-      "search_text": "dynaconf Dynaconf Pass Dynaconf config validation metabolomics/v2"
+      "search_text": "dynaconf Dynaconf Pass Dynaconf config validation metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "dynamic-time-warping-dtw",
       "name": "dynamic time warping (DTW)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ChiungTingWu/ncGTW",
       "license_spdx": "",
       "evidence_text": "graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW) based alignment method",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dynamic-time-warping-dtw.yaml",
-      "search_text": "dynamic-time-warping-dtw dynamic time warping (DTW) graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW) based alignment method metabolomics/v2"
+      "search_text": "dynamic-time-warping-dtw dynamic time warping (DTW) graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW) based alignment method metabolomics/v2 https://github.com/ChiungTingWu/ncGTW"
     },
     {
       "slug": "dynamictreecut",
       "name": "dynamicTreeCut",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/cbroeckl/RAMClustR",
       "license_spdx": "",
       "evidence_text": "submitting this score matrix for heirarchical clustering, and then cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/dynamictreecut.yaml",
-      "search_text": "dynamictreecut dynamicTreeCut submitting this score matrix for heirarchical clustering, and then cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package metabolomics/v2"
+      "search_text": "dynamictreecut dynamicTreeCut submitting this score matrix for heirarchical clustering, and then cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package cutting the resulting dendrogram into neat chunks using the dynamicTreeCut package metabolomics/v2 https://github.com/cbroeckl/RAMClustR"
     },
     {
       "slug": "edger",
       "name": "edgeR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "allows the identification of differentially abundant lipids in simple and complex experimental designs Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva Differential expression analyss | R packages: DESeq2, edger, RankProd ### edger [edger](../modules/local/edger)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/edger.yaml",
-      "search_text": "edger edgeR allows the identification of differentially abundant lipids in simple and complex experimental designs Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva Differential expression analyss | R packages: DESeq2, edger, RankProd ### edger [edger](../modules/local/edger) metabolomics/v2"
+      "search_text": "edger edgeR allows the identification of differentially abundant lipids in simple and complex experimental designs Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva Differential expression analyss | R packages: DESeq2, edger, RankProd ### edger [edger](../modules/local/edger) metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "eflux",
@@ -115809,13 +115857,13 @@
     {
       "slug": "elemcor",
       "name": "ElemCor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/4dsoftware/elemcor",
       "license_spdx": "",
       "evidence_text": "ElemCor is a software tool to correct LC-MS data in isotope labeling experiments. ElemCor is a software tool to correct LC-MS data in isotope labeling experiments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/elemcor.yaml",
-      "search_text": "elemcor ElemCor ElemCor is a software tool to correct LC-MS data in isotope labeling experiments. ElemCor is a software tool to correct LC-MS data in isotope labeling experiments metabolomics/v2"
+      "search_text": "elemcor ElemCor ElemCor is a software tool to correct LC-MS data in isotope labeling experiments. ElemCor is a software tool to correct LC-MS data in isotope labeling experiments metabolomics/v2 https://github.com/4dsoftware/elemcor"
     },
     {
       "slug": "elementtree",
@@ -115831,24 +115879,24 @@
     {
       "slug": "email-service",
       "name": "Email service",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/czbiohub-sf/Rapid-QC-MS",
       "license_spdx": "",
       "evidence_text": "**Realtime updates on QC fails** in the form of Slack or email notifications",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/email-service.yaml",
-      "search_text": "email-service Email service **Realtime updates on QC fails** in the form of Slack or email notifications metabolomics/v2"
+      "search_text": "email-service Email service **Realtime updates on QC fails** in the form of Slack or email notifications metabolomics/v2 https://github.com/czbiohub-sf/Rapid-QC-MS"
     },
     {
       "slug": "emperor",
       "name": "Emperor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/ReDU-MS2-Documentation",
       "license_spdx": "",
       "evidence_text": "How do I find out more about the plotting options in Emperor?",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/emperor.yaml",
-      "search_text": "emperor Emperor How do I find out more about the plotting options in Emperor? metabolomics/v2"
+      "search_text": "emperor Emperor How do I find out more about the plotting options in Emperor? metabolomics/v2 https://github.com/mwang87/ReDU-MS2-Documentation"
     },
     {
       "slug": "enpkg",
@@ -115864,13 +115912,13 @@
     {
       "slug": "entropy-search",
       "name": "Entropy Search",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuanyueLi/FlashEntropySearch",
       "license_spdx": "",
       "evidence_text": "a standalone software with a Graphical User Interface (GUI) named Entropy Search",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/entropy-search.yaml",
-      "search_text": "entropy-search Entropy Search a standalone software with a Graphical User Interface (GUI) named Entropy Search metabolomics/v2"
+      "search_text": "entropy-search Entropy Search a standalone software with a Graphical User Interface (GUI) named Entropy Search metabolomics/v2 https://github.com/YuanyueLi/FlashEntropySearch"
     },
     {
       "slug": "enveda-ccs-prediction-repository-model-code-and-pre-trained-weights",
@@ -115886,13 +115934,13 @@
     {
       "slug": "envipat",
       "name": "enviPat",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YasinEl/mzRAPP",
       "license_spdx": "",
       "evidence_text": "isoSCAN makes use of __enviPat__ package mzRAPP extracts and validates chromatographic peaks for which boundaries are provided for all (enviPat predicted) isotopologues",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/envipat.yaml",
-      "search_text": "envipat enviPat isoSCAN makes use of __enviPat__ package mzRAPP extracts and validates chromatographic peaks for which boundaries are provided for all (enviPat predicted) isotopologues metabolomics/v2"
+      "search_text": "envipat enviPat isoSCAN makes use of __enviPat__ package mzRAPP extracts and validates chromatographic peaks for which boundaries are provided for all (enviPat predicted) isotopologues metabolomics/v2 https://github.com/YasinEl/mzRAPP"
     },
     {
       "slug": "environment",
@@ -115908,35 +115956,35 @@
     {
       "slug": "excalibur",
       "name": "Excalibur",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/98104781/LSG",
       "license_spdx": "",
       "evidence_text": "Excalibur compatible precursor list (for DDA analysis via orbitrap)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/excalibur.yaml",
-      "search_text": "excalibur Excalibur Excalibur compatible precursor list (for DDA analysis via orbitrap) metabolomics/v2"
+      "search_text": "excalibur Excalibur Excalibur compatible precursor list (for DDA analysis via orbitrap) metabolomics/v2 https://github.com/98104781/LSG"
     },
     {
       "slug": "expressionset",
       "name": "ExpressionSet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/antonvsdata/notame",
       "license_spdx": "",
       "evidence_text": "```MetaboSet``` objects are the primary data structure of this package. ```MetaboSet``` is built upon the ```ExpressionSet``` class",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/expressionset.yaml",
-      "search_text": "expressionset ExpressionSet ```MetaboSet``` objects are the primary data structure of this package. ```MetaboSet``` is built upon the ```ExpressionSet``` class metabolomics/v2"
+      "search_text": "expressionset ExpressionSet ```MetaboSet``` objects are the primary data structure of this package. ```MetaboSet``` is built upon the ```ExpressionSet``` class metabolomics/v2 https://github.com/antonvsdata/notame"
     },
     {
       "slug": "factoextra",
       "name": "factoextra",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LargeMetabo/LargeMetabo",
       "license_spdx": "",
       "evidence_text": "several R packages are utilized in the background processes, including factoextra, FSelector, genefilter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/factoextra.yaml",
-      "search_text": "factoextra factoextra several R packages are utilized in the background processes, including factoextra, FSelector, genefilter metabolomics/v2"
+      "search_text": "factoextra factoextra several R packages are utilized in the background processes, including factoextra, FSelector, genefilter metabolomics/v2 https://github.com/LargeMetabo/LargeMetabo"
     },
     {
       "slug": "falcon",
@@ -115952,13 +116000,13 @@
     {
       "slug": "fastqc",
       "name": "FastQC",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Genes, miRNA, isoforms | Quality control | FastQC, trimgalore It then performs quality control with [FASTQC](../modules/nf-core/fastqc)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fastqc.yaml",
-      "search_text": "fastqc FastQC Genes, miRNA, isoforms | Quality control | FastQC, trimgalore It then performs quality control with [FASTQC](../modules/nf-core/fastqc) metabolomics/v2"
+      "search_text": "fastqc FastQC Genes, miRNA, isoforms | Quality control | FastQC, trimgalore It then performs quality control with [FASTQC](../modules/nf-core/fastqc) metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "featurefindermetabo",
@@ -115974,24 +116022,24 @@
     {
       "slug": "fella",
       "name": "FELLA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/b2slab/mWISE",
       "license_spdx": "",
       "evidence_text": "we will now use the sample graph provided by FELLA R package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fella.yaml",
-      "search_text": "fella FELLA we will now use the sample graph provided by FELLA R package metabolomics/v2"
+      "search_text": "fella FELLA we will now use the sample graph provided by FELLA R package metabolomics/v2 https://github.com/b2slab/mWISE"
     },
     {
       "slug": "fgsea",
       "name": "fgsea",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biodatalab/enrichmet",
       "license_spdx": "",
       "evidence_text": "enrichmet integrates fgsea for fast MetSEA",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fgsea.yaml",
-      "search_text": "fgsea fgsea enrichmet integrates fgsea for fast MetSEA metabolomics/v2"
+      "search_text": "fgsea fgsea enrichmet integrates fgsea for fast MetSEA metabolomics/v2 https://github.com/biodatalab/enrichmet"
     },
     {
       "slug": "fiddle",
@@ -116007,13 +116055,13 @@
     {
       "slug": "figshare",
       "name": "figshare",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sword-nan/SpecEmbedding",
       "license_spdx": "",
       "evidence_text": "All cleaned data, along with the preprocessing scripts and 10-fold query/reference splits used for evaluation, are available on [figshare]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/figshare.yaml",
-      "search_text": "figshare figshare All cleaned data, along with the preprocessing scripts and 10-fold query/reference splits used for evaluation, are available on [figshare] metabolomics/v2"
+      "search_text": "figshare figshare All cleaned data, along with the preprocessing scripts and 10-fold query/reference splits used for evaluation, are available on [figshare] metabolomics/v2 https://github.com/sword-nan/SpecEmbedding"
     },
     {
       "slug": "filtering-augmentation",
@@ -116029,46 +116077,46 @@
     {
       "slug": "fimo",
       "name": "fimo",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Find motif | fimo",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fimo.yaml",
-      "search_text": "fimo fimo Find motif | fimo metabolomics/v2"
+      "search_text": "fimo fimo Find motif | fimo metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "fisher-s-exact-test",
       "name": "Fisher's exact test",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biodatalab/enrichmet",
       "license_spdx": "",
       "evidence_text": "enrichmet performs pathway enrichment analysis using Fisher's exact test",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fisher-s-exact-test.yaml",
-      "search_text": "fisher-s-exact-test Fisher's exact test enrichmet performs pathway enrichment analysis using Fisher's exact test metabolomics/v2"
+      "search_text": "fisher-s-exact-test Fisher's exact test enrichmet performs pathway enrichment analysis using Fisher's exact test metabolomics/v2 https://github.com/biodatalab/enrichmet"
     },
     {
       "slug": "flake8",
       "name": "flake8",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/medema-group/BiG-SCAPE",
       "license_spdx": "",
       "evidence_text": "uses flake8 for linting",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/flake8.yaml",
-      "search_text": "flake8 flake8 uses flake8 for linting metabolomics/v2"
+      "search_text": "flake8 flake8 uses flake8 for linting metabolomics/v2 https://github.com/medema-group/BiG-SCAPE"
     },
     {
       "slug": "flask",
       "name": "Flask",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run --host=0.0.0.0 --port=3007",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/flask.yaml",
-      "search_text": "flask Flask export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run --host=0.0.0.0 --port=3007 metabolomics/v2"
+      "search_text": "flask Flask export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run export FLASK_APP=chem_spectra && export FLASK_DEBUG=true && flask run --host=0.0.0.0 --port=3007 metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "flux-variability-analysis-fva",
@@ -116106,24 +116154,24 @@
     {
       "slug": "fnicm",
       "name": "FNICM",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LiQi94/FNICM",
       "license_spdx": "",
       "evidence_text": "FNICM is a tool to identify core nodes from significantly perturbed subnetwork.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/fnicm.yaml",
-      "search_text": "fnicm FNICM FNICM is a tool to identify core nodes from significantly perturbed subnetwork. metabolomics/v2"
+      "search_text": "fnicm FNICM FNICM is a tool to identify core nodes from significantly perturbed subnetwork. metabolomics/v2 https://github.com/LiQi94/FNICM"
     },
     {
       "slug": "foodmasst",
       "name": "foodMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/foodmasst.yaml",
-      "search_text": "foodmasst foodMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2"
+      "search_text": "foodmasst foodMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "formularity",
@@ -116172,68 +116220,68 @@
     {
       "slug": "galaxy-genomics-framework",
       "name": "Galaxy Genomics Framework",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/secimTools/SECIMTools",
       "license_spdx": "",
       "evidence_text": "can be run in a standalone mode or via Galaxy Genomics Framework",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/galaxy-genomics-framework.yaml",
-      "search_text": "galaxy-genomics-framework Galaxy Genomics Framework can be run in a standalone mode or via Galaxy Genomics Framework metabolomics/v2"
+      "search_text": "galaxy-genomics-framework Galaxy Genomics Framework can be run in a standalone mode or via Galaxy Genomics Framework metabolomics/v2 https://github.com/secimTools/SECIMTools"
     },
     {
       "slug": "galaxy",
       "name": "Galaxy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Viant-Metabolomics/Galaxy-M",
       "license_spdx": "",
       "evidence_text": "Metabolomics Tools for [Galaxy](http://galaxyproject.org/) Galaxy tool for processing and analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/galaxy.yaml",
-      "search_text": "galaxy Galaxy Metabolomics Tools for [Galaxy](http://galaxyproject.org/) Galaxy tool for processing and analysis metabolomics/v2"
+      "search_text": "galaxy Galaxy Metabolomics Tools for [Galaxy](http://galaxyproject.org/) Galaxy tool for processing and analysis metabolomics/v2 https://github.com/Viant-Metabolomics/Galaxy-M"
     },
     {
       "slug": "gcims",
       "name": "GCIMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sipss/GCIMS",
       "license_spdx": "",
       "evidence_text": "library(GCIMS)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gcims.yaml",
-      "search_text": "gcims GCIMS library(GCIMS) metabolomics/v2"
+      "search_text": "gcims GCIMS library(GCIMS) metabolomics/v2 https://github.com/sipss/GCIMS"
     },
     {
       "slug": "gensim",
       "name": "gensim",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Qiong-Yang/FastEI",
       "license_spdx": "",
       "evidence_text": "A Word2Vec [22] model is trained on all documents of a chosen dataset using gensim [37] conda install -c conda-forge gensim Run gensim lda",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gensim.yaml",
-      "search_text": "gensim gensim A Word2Vec [22] model is trained on all documents of a chosen dataset using gensim [37] conda install -c conda-forge gensim Run gensim lda metabolomics/v2"
+      "search_text": "gensim gensim A Word2Vec [22] model is trained on all documents of a chosen dataset using gensim [37] conda install -c conda-forge gensim Run gensim lda metabolomics/v2 https://github.com/Qiong-Yang/FastEI"
     },
     {
       "slug": "geodesic-interpolate",
       "name": "geodesic_interpolate",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "**geodesic_interpolate** (version",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/geodesic-interpolate.yaml",
-      "search_text": "geodesic-interpolate geodesic_interpolate **geodesic_interpolate** (version metabolomics/v2"
+      "search_text": "geodesic-interpolate geodesic_interpolate **geodesic_interpolate** (version metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "george",
       "name": "geoRge",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/jcapelladesto/geoRge",
       "license_spdx": "",
       "evidence_text": "library(geoRge) hits <- database_query(geoRgeR = s2, adducts = negative, db = db)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/george.yaml",
-      "search_text": "george geoRge library(geoRge) hits <- database_query(geoRgeR = s2, adducts = negative, db = db) metabolomics/v2"
+      "search_text": "george geoRge library(geoRge) hits <- database_query(geoRgeR = s2, adducts = negative, db = db) metabolomics/v2 https://github.com/jcapelladesto/geoRge"
     },
     {
       "slug": "get-models-sh",
@@ -116249,134 +116297,134 @@
     {
       "slug": "get-precmz-prodmz",
       "name": "get_PrecMZ_ProdMZ",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kslynn128171/MRMQuant",
       "license_spdx": "",
       "evidence_text": "Users can install get_PrecMZ_ProdMZ in the \"program/associated programs\" folder to acquire precursor and product m/z values in an MRM sample file.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/get-precmz-prodmz.yaml",
-      "search_text": "get-precmz-prodmz get_PrecMZ_ProdMZ Users can install get_PrecMZ_ProdMZ in the \"program/associated programs\" folder to acquire precursor and product m/z values in an MRM sample file. metabolomics/v2"
+      "search_text": "get-precmz-prodmz get_PrecMZ_ProdMZ Users can install get_PrecMZ_ProdMZ in the \"program/associated programs\" folder to acquire precursor and product m/z values in an MRM sample file. metabolomics/v2 https://github.com/kslynn128171/MRMQuant"
     },
     {
       "slug": "getfeatistics",
       "name": "GetFeatistics",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FrigerioGianfranco/GetFeatistics",
       "license_spdx": "",
       "evidence_text": "devtools::install_github(\"FrigerioGianfranco/GetFeatistics\", dependencies = TRUE) The **GetFeatistics** (GF) package provides several functions useful for the elaboration of metabolomics data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/getfeatistics.yaml",
-      "search_text": "getfeatistics GetFeatistics devtools::install_github(\"FrigerioGianfranco/GetFeatistics\", dependencies = TRUE) The **GetFeatistics** (GF) package provides several functions useful for the elaboration of metabolomics data metabolomics/v2"
+      "search_text": "getfeatistics GetFeatistics devtools::install_github(\"FrigerioGianfranco/GetFeatistics\", dependencies = TRUE) The **GetFeatistics** (GF) package provides several functions useful for the elaboration of metabolomics data metabolomics/v2 https://github.com/FrigerioGianfranco/GetFeatistics"
     },
     {
       "slug": "ggplot",
       "name": "ggplot",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BalunasLab/mpact",
       "license_spdx": "",
       "evidence_text": "creating an interactive plot of input features and the filters they failed, if any, using `ggplot` and `plotly`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ggplot.yaml",
-      "search_text": "ggplot ggplot creating an interactive plot of input features and the filters they failed, if any, using `ggplot` and `plotly` metabolomics/v2"
+      "search_text": "ggplot ggplot creating an interactive plot of input features and the filters they failed, if any, using `ggplot` and `plotly` metabolomics/v2 https://github.com/BalunasLab/mpact"
     },
     {
       "slug": "ggplot2",
       "name": "ggplot2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "library(ggplot2) invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" All the figures of this package are created as ggplot object, so they can be furhter modified following the ggplot2 sintax. required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", several R packages are utilized in the background processes, including ggfortify, ggplot2, igraph you can visualize filtering results with a tree map using the filtering summary obtained from `qc_summary()` and the packages `ggplot2` and `treemapify`.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ggplot2.yaml",
-      "search_text": "ggplot2 ggplot2 library(ggplot2) invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" All the figures of this package are created as ggplot object, so they can be furhter modified following the ggplot2 sintax. required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", several R packages are utilized in the background processes, including ggfortify, ggplot2, igraph you can visualize filtering results with a tree map using the filtering summary obtained from `qc_summary()` and the packages `ggplot2` and `treemapify`. metabolomics/v2"
+      "search_text": "ggplot2 ggplot2 library(ggplot2) invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" All the figures of this package are created as ggplot object, so they can be furhter modified following the ggplot2 sintax. required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", several R packages are utilized in the background processes, including ggfortify, ggplot2, igraph you can visualize filtering results with a tree map using the filtering summary obtained from `qc_summary()` and the packages `ggplot2` and `treemapify`. metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "git",
       "name": "git",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Chen-micslab/QCCAssisted4DSterol",
       "license_spdx": "",
       "evidence_text": "Step 0: Install git (if you have not done so before) git clone --recursive git@github.com:eugenemel/maven.git maven git clone https://github.com/ipb-halle/MetFragRelaunched.git Clone the Met-ID repository github.com/mibig-secmet/mibig-json push your feature branch to (your fork of) the ms2query repository on GitHub",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/git.yaml",
-      "search_text": "git git Step 0: Install git (if you have not done so before) git clone --recursive git@github.com:eugenemel/maven.git maven git clone https://github.com/ipb-halle/MetFragRelaunched.git Clone the Met-ID repository github.com/mibig-secmet/mibig-json push your feature branch to (your fork of) the ms2query repository on GitHub metabolomics/v2"
+      "search_text": "git git Step 0: Install git (if you have not done so before) git clone --recursive git@github.com:eugenemel/maven.git maven git clone https://github.com/ipb-halle/MetFragRelaunched.git Clone the Met-ID repository github.com/mibig-secmet/mibig-json push your feature branch to (your fork of) the ms2query repository on GitHub metabolomics/v2 https://github.com/Chen-micslab/QCCAssisted4DSterol"
     },
     {
       "slug": "github-actions-workflow-ci-build-yml",
       "name": "GitHub actions workflow CI_build.yml",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fermo-metabolomics/FERMO",
       "license_spdx": "",
       "evidence_text": "Build testing with GitHub actions workflow `.github/workflows/CI_build.yml`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-actions-workflow-ci-build-yml.yaml",
-      "search_text": "github-actions-workflow-ci-build-yml GitHub actions workflow CI_build.yml Build testing with GitHub actions workflow `.github/workflows/CI_build.yml` metabolomics/v2"
+      "search_text": "github-actions-workflow-ci-build-yml GitHub actions workflow CI_build.yml Build testing with GitHub actions workflow `.github/workflows/CI_build.yml` metabolomics/v2 https://github.com/fermo-metabolomics/FERMO"
     },
     {
       "slug": "github-actions",
       "name": "GitHub Actions",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MassBank/MassBank-data",
       "license_spdx": "",
       "evidence_text": "To conduct tests, please refer to section `test:` of GitHub Actions GitHub Actions 'Build and Publish' workflow (distribute.yaml) uses GitHub Actions to validate the content of all records uses GitHub Actions to validate the content of all records with the [Validator] GitHub Actions CI workflow (main.yml) A GitHub action will run which will publish the new version to [pypi](https://pypi.org/project/ms2query/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-actions.yaml",
-      "search_text": "github-actions GitHub Actions To conduct tests, please refer to section `test:` of GitHub Actions GitHub Actions 'Build and Publish' workflow (distribute.yaml) uses GitHub Actions to validate the content of all records uses GitHub Actions to validate the content of all records with the [Validator] GitHub Actions CI workflow (main.yml) A GitHub action will run which will publish the new version to [pypi](https://pypi.org/project/ms2query/) metabolomics/v2"
+      "search_text": "github-actions GitHub Actions To conduct tests, please refer to section `test:` of GitHub Actions GitHub Actions 'Build and Publish' workflow (distribute.yaml) uses GitHub Actions to validate the content of all records uses GitHub Actions to validate the content of all records with the [Validator] GitHub Actions CI workflow (main.yml) A GitHub action will run which will publish the new version to [pypi](https://pypi.org/project/ms2query/) metabolomics/v2 https://github.com/MassBank/MassBank-data"
     },
     {
       "slug": "github-com-bittremieux-cosine-neutral-loss",
       "name": "github.com/bittremieux/cosine_neutral_loss",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux/cosine_neutral_loss",
       "license_spdx": "",
       "evidence_text": "github.com__bittremieux__cosine_neutral_loss",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-com-bittremieux-cosine-neutral-loss.yaml",
-      "search_text": "github-com-bittremieux-cosine-neutral-loss github.com/bittremieux/cosine_neutral_loss github.com__bittremieux__cosine_neutral_loss metabolomics/v2"
+      "search_text": "github-com-bittremieux-cosine-neutral-loss github.com/bittremieux/cosine_neutral_loss github.com__bittremieux__cosine_neutral_loss metabolomics/v2 https://github.com/bittremieux/cosine_neutral_loss"
     },
     {
       "slug": "github-com-hassounlab-esp",
       "name": "github.com/HassounLab/ESP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/ESP",
       "license_spdx": "",
       "evidence_text": "github.com/HassounLab/ESP",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-com-hassounlab-esp.yaml",
-      "search_text": "github-com-hassounlab-esp github.com/HassounLab/ESP github.com/HassounLab/ESP metabolomics/v2"
+      "search_text": "github-com-hassounlab-esp github.com/HassounLab/ESP github.com/HassounLab/ESP metabolomics/v2 https://github.com/HassounLab/ESP"
     },
     {
       "slug": "github-com-jlichtarge-pcaglasso",
       "name": "github.com/jlichtarge/pcaGLASSO",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/jlichtarge/pcaGLASSO",
       "license_spdx": "",
       "evidence_text": "github.com__jlichtarge__pcaGLASSO",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-com-jlichtarge-pcaglasso.yaml",
-      "search_text": "github-com-jlichtarge-pcaglasso github.com/jlichtarge/pcaGLASSO github.com__jlichtarge__pcaGLASSO metabolomics/v2"
+      "search_text": "github-com-jlichtarge-pcaglasso github.com/jlichtarge/pcaGLASSO github.com__jlichtarge__pcaGLASSO metabolomics/v2 https://github.com/jlichtarge/pcaGLASSO"
     },
     {
       "slug": "github-com-wanluliulab-spatialmeta",
       "name": "github.com/WanluLiuLab/SpatialMETA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/WanluLiuLab/SpatialMETA",
       "license_spdx": "",
       "evidence_text": "github.com__WanluLiuLab__SpatialMETA",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-com-wanluliulab-spatialmeta.yaml",
-      "search_text": "github-com-wanluliulab-spatialmeta github.com/WanluLiuLab/SpatialMETA github.com__WanluLiuLab__SpatialMETA metabolomics/v2"
+      "search_text": "github-com-wanluliulab-spatialmeta github.com/WanluLiuLab/SpatialMETA github.com__WanluLiuLab__SpatialMETA metabolomics/v2 https://github.com/WanluLiuLab/SpatialMETA"
     },
     {
       "slug": "github-com-zsspython-lagf",
       "name": "github.com/zsspython/LAGF",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zsspython/LAGF",
       "license_spdx": "",
       "evidence_text": "Source: github:github.com__zsspython__LAGF github.com__zsspython__LAGF",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github-com-zsspython-lagf.yaml",
-      "search_text": "github-com-zsspython-lagf github.com/zsspython/LAGF Source: github:github.com__zsspython__LAGF github.com__zsspython__LAGF metabolomics/v2"
+      "search_text": "github-com-zsspython-lagf github.com/zsspython/LAGF Source: github:github.com__zsspython__LAGF github.com__zsspython__LAGF metabolomics/v2 https://github.com/zsspython/LAGF"
     },
     {
       "slug": "github-kbseah-mass2adduct",
@@ -116392,167 +116440,167 @@
     {
       "slug": "github",
       "name": "GitHub",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/13479776/statTarget",
       "license_spdx": "",
       "evidence_text": "Source: github:gitlab.gwdg.de__joerg.buescher__automrm Source: github:arina-iva__DI-MS2_scripts Source: github:jesilee__CIDMD_setup github.com__zhangxiang1205__CorrDIA Source: github:github.com__iconSS__FCC github.com__iconSS__FCC",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/github.yaml",
-      "search_text": "github GitHub Source: github:gitlab.gwdg.de__joerg.buescher__automrm Source: github:arina-iva__DI-MS2_scripts Source: github:jesilee__CIDMD_setup github.com__zhangxiang1205__CorrDIA Source: github:github.com__iconSS__FCC github.com__iconSS__FCC metabolomics/v2"
+      "search_text": "github GitHub Source: github:gitlab.gwdg.de__joerg.buescher__automrm Source: github:arina-iva__DI-MS2_scripts Source: github:jesilee__CIDMD_setup github.com__zhangxiang1205__CorrDIA Source: github:github.com__iconSS__FCC github.com__iconSS__FCC metabolomics/v2 https://github.com/13479776/statTarget"
     },
     {
       "slug": "gitlab",
       "name": "GitLab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/hcji/TarMet",
       "license_spdx": "",
       "evidence_text": "",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gitlab.yaml",
-      "search_text": "gitlab GitLab metabolomics/v2"
+      "search_text": "gitlab GitLab metabolomics/v2 https://github.com/hcji/TarMet"
     },
     {
       "slug": "gleams",
       "name": "GLEAMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux-lab/GLEAMS",
       "license_spdx": "",
       "evidence_text": "GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network GLEAMS is a Learned Embedding for Annotating Mass Spectra. GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gleams.yaml",
-      "search_text": "gleams GLEAMS GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network GLEAMS is a Learned Embedding for Annotating Mass Spectra. GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network metabolomics/v2"
+      "search_text": "gleams GLEAMS GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network GLEAMS is a Learned Embedding for Annotating Mass Spectra. GLEAMS encodes mass spectra as vectors of features and feeds them to a neural network metabolomics/v2 https://github.com/bittremieux-lab/GLEAMS"
     },
     {
       "slug": "gnps-gc",
       "name": "GNPS_GC",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux/GNPS_GC",
       "license_spdx": "",
       "evidence_text": "bittremieux/GNPS_GC",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-gc.yaml",
-      "search_text": "gnps-gc GNPS_GC bittremieux/GNPS_GC metabolomics/v2"
+      "search_text": "gnps-gc GNPS_GC bittremieux/GNPS_GC metabolomics/v2 https://github.com/bittremieux/GNPS_GC"
     },
     {
       "slug": "gnps-lcms-visualization-dashboard",
       "name": "GNPS LCMS Visualization Dashboard",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/GNPS_LCMSDashboard",
       "license_spdx": "",
       "evidence_text": "GNPS LCMS Visualization Dashboard GNPS Analysis Tasks - [mzspec:GNPS:TASK-d93bdbb5cdda40e48975e6e18a45c3ce",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-lcms-visualization-dashboard.yaml",
-      "search_text": "gnps-lcms-visualization-dashboard GNPS LCMS Visualization Dashboard GNPS LCMS Visualization Dashboard GNPS Analysis Tasks - [mzspec:GNPS:TASK-d93bdbb5cdda40e48975e6e18a45c3ce metabolomics/v2"
+      "search_text": "gnps-lcms-visualization-dashboard GNPS LCMS Visualization Dashboard GNPS LCMS Visualization Dashboard GNPS Analysis Tasks - [mzspec:GNPS:TASK-d93bdbb5cdda40e48975e6e18a45c3ce metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/GNPS_LCMSDashboard"
     },
     {
       "slug": "gnps-masst",
       "name": "GNPS_MASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "The code for the different standalone web applications, which allow users to search one spectrum at a time, can be found in GNPS_MASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-masst.yaml",
-      "search_text": "gnps-masst GNPS_MASST The code for the different standalone web applications, which allow users to search one spectrum at a time, can be found in GNPS_MASST metabolomics/v2"
+      "search_text": "gnps-masst GNPS_MASST The code for the different standalone web applications, which allow users to search one spectrum at a time, can be found in GNPS_MASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "gnps-molecular-networking",
       "name": "GNPS Molecular Networking",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "GNPS Molecular Networking Clustered Spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-molecular-networking.yaml",
-      "search_text": "gnps-molecular-networking GNPS Molecular Networking GNPS Molecular Networking Clustered Spectra metabolomics/v2"
+      "search_text": "gnps-molecular-networking GNPS Molecular Networking GNPS Molecular Networking Clustered Spectra metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "gnps-spectral-libraries",
       "name": "GNPS Spectral Libraries",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "GNPS Spectral Libraries",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-spectral-libraries.yaml",
-      "search_text": "gnps-spectral-libraries GNPS Spectral Libraries GNPS Spectral Libraries metabolomics/v2"
+      "search_text": "gnps-spectral-libraries GNPS Spectral Libraries GNPS Spectral Libraries metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "gnps-spectral-networking-molecular-networking",
       "name": "GNPS Spectral Networking / Molecular Networking",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "Spectral network can be easily run through GNPS. Detailed instructions can be found in the [GNPS documentation]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps-spectral-networking-molecular-networking.yaml",
-      "search_text": "gnps-spectral-networking-molecular-networking GNPS Spectral Networking / Molecular Networking Spectral network can be easily run through GNPS. Detailed instructions can be found in the [GNPS documentation] metabolomics/v2"
+      "search_text": "gnps-spectral-networking-molecular-networking GNPS Spectral Networking / Molecular Networking Spectral network can be easily run through GNPS. Detailed instructions can be found in the [GNPS documentation] metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "gnps",
       "name": "GNPS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks",
       "license_spdx": "",
       "evidence_text": "the GNPS web-platform (http://gnps.ucsd.edu) Currently GNPS has stopped supplying classyfire ontology information for spectral library matches Currently GNPS has stopped supplying classyfire ontology information for spectral library matches. Link for Feature-Based Molecular Network](https://gnps.ucsd.edu/ProteoSAFe/status.jsp?task=b661d12ba88745639664988329c1363e) job_id= \"yourjobidgoeshere\" ##### For cleaning-up annotations from GNPS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps.yaml",
-      "search_text": "gnps GNPS the GNPS web-platform (http://gnps.ucsd.edu) Currently GNPS has stopped supplying classyfire ontology information for spectral library matches Currently GNPS has stopped supplying classyfire ontology information for spectral library matches. Link for Feature-Based Molecular Network](https://gnps.ucsd.edu/ProteoSAFe/status.jsp?task=b661d12ba88745639664988329c1363e) job_id= \"yourjobidgoeshere\" ##### For cleaning-up annotations from GNPS metabolomics/v2"
+      "search_text": "gnps GNPS the GNPS web-platform (http://gnps.ucsd.edu) Currently GNPS has stopped supplying classyfire ontology information for spectral library matches Currently GNPS has stopped supplying classyfire ontology information for spectral library matches. Link for Feature-Based Molecular Network](https://gnps.ucsd.edu/ProteoSAFe/status.jsp?task=b661d12ba88745639664988329c1363e) job_id= \"yourjobidgoeshere\" ##### For cleaning-up annotations from GNPS metabolomics/v2 https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks"
     },
     {
       "slug": "gnps2",
       "name": "GNPS2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "These workflows are also available for you to run on federated GNPS2 instances and locally on any computing environment or in the cloud. It currently accepts data from both GNPS1 (https://gnps.ucsd.edu) and GNPS2 (https://gnps2.org) workflows. ReDU is the bridge between the [(GNPS2)](https://gnps2.org/) and [MassIVE]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnps2.yaml",
-      "search_text": "gnps2 GNPS2 These workflows are also available for you to run on federated GNPS2 instances and locally on any computing environment or in the cloud. It currently accepts data from both GNPS1 (https://gnps.ucsd.edu) and GNPS2 (https://gnps2.org) workflows. ReDU is the bridge between the [(GNPS2)](https://gnps2.org/) and [MassIVE] metabolomics/v2"
+      "search_text": "gnps2 GNPS2 These workflows are also available for you to run on federated GNPS2 instances and locally on any computing environment or in the cloud. It currently accepts data from both GNPS1 (https://gnps.ucsd.edu) and GNPS2 (https://gnps2.org) workflows. ReDU is the bridge between the [(GNPS2)](https://gnps2.org/) and [MassIVE] metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "gnuplot",
       "name": "Gnuplot",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/matteogiulietti/LipidOne",
       "license_spdx": "",
       "evidence_text": "https://sourceforge.net/projects/gnuplot/files/gnuplot/5.4.2/",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gnuplot.yaml",
-      "search_text": "gnuplot Gnuplot https://sourceforge.net/projects/gnuplot/files/gnuplot/5.4.2/ metabolomics/v2"
+      "search_text": "gnuplot Gnuplot https://sourceforge.net/projects/gnuplot/files/gnuplot/5.4.2/ metabolomics/v2 https://github.com/matteogiulietti/LipidOne"
     },
     {
       "slug": "google-chrome",
       "name": "Google Chrome",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lidawei1975/colmarvista",
       "license_spdx": "",
       "evidence_text": "For Google Chrome: 1. Right-click the Google Chrome icon and select \"Properties.\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/google-chrome.yaml",
-      "search_text": "google-chrome Google Chrome For Google Chrome: 1. Right-click the Google Chrome icon and select \"Properties.\" metabolomics/v2"
+      "search_text": "google-chrome Google Chrome For Google Chrome: 1. Right-click the Google Chrome icon and select \"Properties.\" metabolomics/v2 https://github.com/lidawei1975/colmarvista"
     },
     {
       "slug": "google-colab",
       "name": "Google Colab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/alexandrovteam/SpaceM",
       "license_spdx": "",
       "evidence_text": "we [present interactively using Google Collab](https://colab.research.google.com/drive/1CKdHDUkGIpAcBzrSfuCodMF_l2xbVAKT?usp=sharing)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/google-colab.yaml",
-      "search_text": "google-colab Google Colab we [present interactively using Google Collab](https://colab.research.google.com/drive/1CKdHDUkGIpAcBzrSfuCodMF_l2xbVAKT?usp=sharing) metabolomics/v2"
+      "search_text": "google-colab Google Colab we [present interactively using Google Collab](https://colab.research.google.com/drive/1CKdHDUkGIpAcBzrSfuCodMF_l2xbVAKT?usp=sharing) metabolomics/v2 https://github.com/alexandrovteam/SpaceM"
     },
     {
       "slug": "google-colaboratory",
       "name": "Google Colaboratory",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/facundof2016/CCSP2.0",
       "license_spdx": "",
       "evidence_text": "a Google Colaboratory Jupyter notebook that is well suited for beginners",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/google-colaboratory.yaml",
-      "search_text": "google-colaboratory Google Colaboratory a Google Colaboratory Jupyter notebook that is well suited for beginners metabolomics/v2"
+      "search_text": "google-colaboratory Google Colaboratory a Google Colaboratory Jupyter notebook that is well suited for beginners metabolomics/v2 https://github.com/facundof2016/CCSP2.0"
     },
     {
       "slug": "graph-neural-network-gnn-framework-pytorch-geometric-or-equivalent",
@@ -116568,46 +116616,46 @@
     {
       "slug": "graphical-time-warping-gtw",
       "name": "graphical time warping (GTW)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ChiungTingWu/ncGTW",
       "license_spdx": "",
       "evidence_text": "This algorithm is improved from graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/graphical-time-warping-gtw.yaml",
-      "search_text": "graphical-time-warping-gtw graphical time warping (GTW) This algorithm is improved from graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW) metabolomics/v2"
+      "search_text": "graphical-time-warping-gtw graphical time warping (GTW) This algorithm is improved from graphical time warping (GTW) [@gtw16], a popular dynamic time warping (DTW) metabolomics/v2 https://github.com/ChiungTingWu/ncGTW"
     },
     {
       "slug": "graphormer",
       "name": "Graphormer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HopkinsLaboratory/Graphormer-RT",
       "license_spdx": "",
       "evidence_text": "Graphormer-RT is an extension to the Graphormer package, with documentation, and the original code on Github",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/graphormer.yaml",
-      "search_text": "graphormer Graphormer Graphormer-RT is an extension to the Graphormer package, with documentation, and the original code on Github metabolomics/v2"
+      "search_text": "graphormer Graphormer Graphormer-RT is an extension to the Graphormer package, with documentation, and the original code on Github metabolomics/v2 https://github.com/HopkinsLaboratory/Graphormer-RT"
     },
     {
       "slug": "grid",
       "name": "grid",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "grid",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/grid.yaml",
-      "search_text": "grid grid grid metabolomics/v2"
+      "search_text": "grid grid grid metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "gunicorn",
       "name": "gunicorn",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "gunicorn -w 4 -b 0.0.0.0:3007 server:app --daemon",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/gunicorn.yaml",
-      "search_text": "gunicorn gunicorn gunicorn -w 4 -b 0.0.0.0:3007 server:app --daemon metabolomics/v2"
+      "search_text": "gunicorn gunicorn gunicorn -w 4 -b 0.0.0.0:3007 server:app --daemon metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "gx-fba",
@@ -116623,46 +116671,46 @@
     {
       "slug": "h2o",
       "name": "h2o",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lanagarmire/lilikoi2",
       "license_spdx": "",
       "evidence_text": "DL via h2o",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/h2o.yaml",
-      "search_text": "h2o h2o DL via h2o metabolomics/v2"
+      "search_text": "h2o h2o DL via h2o metabolomics/v2 https://github.com/lanagarmire/lilikoi2"
     },
     {
       "slug": "h5py-2-7-1",
       "name": "h5py 2.7.1",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "h5py(2.7.1)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/h5py-2-7-1.yaml",
-      "search_text": "h5py-2-7-1 h5py 2.7.1 h5py(2.7.1) metabolomics/v2"
+      "search_text": "h5py-2-7-1 h5py 2.7.1 h5py(2.7.1) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "h5py",
       "name": "h5py",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mza",
       "license_spdx": "",
       "evidence_text": "h5py(2.7.1) using generic HDF5 libraries available (e.g., h5py and rhdf5) * ``h5py`` h5py <https://www.h5py.org/> and optionally hdf5plugin h5py",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/h5py.yaml",
-      "search_text": "h5py h5py h5py(2.7.1) using generic HDF5 libraries available (e.g., h5py and rhdf5) * ``h5py`` h5py <https://www.h5py.org/> and optionally hdf5plugin h5py metabolomics/v2"
+      "search_text": "h5py h5py h5py(2.7.1) using generic HDF5 libraries available (e.g., h5py and rhdf5) * ``h5py`` h5py <https://www.h5py.org/> and optionally hdf5plugin h5py metabolomics/v2 https://github.com/PNNL-m-q/mza"
     },
     {
       "slug": "hacca",
       "name": "haCCA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LittleLittleCloud/haCCA",
       "license_spdx": "",
       "evidence_text": "haCCA, a workflow utilizing high Correlated feature pairs combined with a modified spatial morphological alignment",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hacca.yaml",
-      "search_text": "hacca haCCA haCCA, a workflow utilizing high Correlated feature pairs combined with a modified spatial morphological alignment metabolomics/v2"
+      "search_text": "hacca haCCA haCCA, a workflow utilizing high Correlated feature pairs combined with a modified spatial morphological alignment metabolomics/v2 https://github.com/LittleLittleCloud/haCCA"
     },
     {
       "slug": "hassounlab-bam",
@@ -116678,35 +116726,35 @@
     {
       "slug": "hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent",
       "name": "HDF5 reader/writer library (h5py, h5netcdf, or equivalent)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/swinnenteam/LipidQMap",
       "license_spdx": "",
       "evidence_text": "LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent.yaml",
-      "search_text": "hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent HDF5 reader/writer library (h5py, h5netcdf, or equivalent) LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. metabolomics/v2"
+      "search_text": "hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent HDF5 reader/writer library (h5py, h5netcdf, or equivalent) LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. metabolomics/v2 https://github.com/swinnenteam/LipidQMap"
     },
     {
       "slug": "hdf5",
       "name": "HDF5",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mza",
       "license_spdx": "",
       "evidence_text": "the MZA simple data structure based on the HDF5 format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hdf5.yaml",
-      "search_text": "hdf5 HDF5 the MZA simple data structure based on the HDF5 format metabolomics/v2"
+      "search_text": "hdf5 HDF5 the MZA simple data structure based on the HDF5 format metabolomics/v2 https://github.com/PNNL-m-q/mza"
     },
     {
       "slug": "hdf5plugin",
       "name": "hdf5plugin",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mzapy",
       "license_spdx": "",
       "evidence_text": "* ``hdf5plugin`` h5py and optionally hdf5plugin <https://hdf5plugin.readthedocs.io/en/latest/>",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hdf5plugin.yaml",
-      "search_text": "hdf5plugin hdf5plugin * ``hdf5plugin`` h5py and optionally hdf5plugin <https://hdf5plugin.readthedocs.io/en/latest/> metabolomics/v2"
+      "search_text": "hdf5plugin hdf5plugin * ``hdf5plugin`` h5py and optionally hdf5plugin <https://hdf5plugin.readthedocs.io/en/latest/> metabolomics/v2 https://github.com/PNNL-m-q/mzapy"
     },
     {
       "slug": "hierarchical-clustering-euclidean-distance-complete-linkage",
@@ -116733,68 +116781,68 @@
     {
       "slug": "hmdb-4",
       "name": "HMDB 4",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "known compound database (default HMDB 4)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hmdb-4.yaml",
-      "search_text": "hmdb-4 HMDB 4 known compound database (default HMDB 4) metabolomics/v2"
+      "search_text": "hmdb-4 HMDB 4 known compound database (default HMDB 4) metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "hmdb",
       "name": "HMDB",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/griquelme/tidyms",
       "license_spdx": "",
       "evidence_text": "we recommend that you download the JMS-compliant versions of the HMDB and LMSD using the `download extras` command",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hmdb.yaml",
-      "search_text": "hmdb HMDB we recommend that you download the JMS-compliant versions of the HMDB and LMSD using the `download extras` command metabolomics/v2"
+      "search_text": "hmdb HMDB we recommend that you download the JMS-compliant versions of the HMDB and LMSD using the `download extras` command metabolomics/v2 https://github.com/griquelme/tidyms"
     },
     {
       "slug": "hnswlib",
       "name": "hnswlib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Qiong-Yang/FastEI",
       "license_spdx": "",
       "evidence_text": "conda install -c conda-forge hnswlib",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hnswlib.yaml",
-      "search_text": "hnswlib hnswlib conda install -c conda-forge hnswlib metabolomics/v2"
+      "search_text": "hnswlib hnswlib conda install -c conda-forge hnswlib metabolomics/v2 https://github.com/Qiong-Yang/FastEI"
     },
     {
       "slug": "homebrew",
       "name": "Homebrew",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Install the Homebrew package management system",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/homebrew.yaml",
-      "search_text": "homebrew Homebrew Install the Homebrew package management system metabolomics/v2"
+      "search_text": "homebrew Homebrew Install the Homebrew package management system metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "hruv",
       "name": "hRUV",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SydneyBioX/hRUV",
       "license_spdx": "",
       "evidence_text": "`hRUV` is a package for normalisation of multiple batches of metabolomics data `hRUV` is a package for normalisation of multiple batches of metabolomics data in a hierarchical strategy",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hruv.yaml",
-      "search_text": "hruv hRUV `hRUV` is a package for normalisation of multiple batches of metabolomics data `hRUV` is a package for normalisation of multiple batches of metabolomics data in a hierarchical strategy metabolomics/v2"
+      "search_text": "hruv hRUV `hRUV` is a package for normalisation of multiple batches of metabolomics data `hRUV` is a package for normalisation of multiple batches of metabolomics data in a hierarchical strategy metabolomics/v2 https://github.com/SydneyBioX/hRUV"
     },
     {
       "slug": "html",
       "name": "HTML",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "The platform is built with Python, Django, JavaScript, and HTML",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/html.yaml",
-      "search_text": "html HTML The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2"
+      "search_text": "html HTML The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "htseq-v-0-6-1",
@@ -116810,79 +116858,79 @@
     {
       "slug": "https-doi-org-10-5281-zenodo-11243781",
       "name": "https://doi.org/10.5281/zenodo.11243781",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/emosca-cnr/margheRita",
       "license_spdx": "",
       "evidence_text": "The full version of the \"Urine\" dataset, which was used for margheRita assessment and to generate this documentation, is available at https://doi.org/10.5281/zenodo.11243781",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/https-doi-org-10-5281-zenodo-11243781.yaml",
-      "search_text": "https-doi-org-10-5281-zenodo-11243781 https://doi.org/10.5281/zenodo.11243781 The full version of the \"Urine\" dataset, which was used for margheRita assessment and to generate this documentation, is available at https://doi.org/10.5281/zenodo.11243781 metabolomics/v2"
+      "search_text": "https-doi-org-10-5281-zenodo-11243781 https://doi.org/10.5281/zenodo.11243781 The full version of the \"Urine\" dataset, which was used for margheRita assessment and to generate this documentation, is available at https://doi.org/10.5281/zenodo.11243781 metabolomics/v2 https://github.com/emosca-cnr/margheRita"
     },
     {
       "slug": "https-github-com-emosca-cnr-margherita",
       "name": "https://github.com/emosca-cnr/margheRita",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/emosca-cnr/margheRita",
       "license_spdx": "",
       "evidence_text": "Source code: https://github.com/emosca-cnr/margheRita devtools::install_github(\"antonvsdata/notame\") github.com__emosca-cnr__margheRita",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/https-github-com-emosca-cnr-margherita.yaml",
-      "search_text": "https-github-com-emosca-cnr-margherita https://github.com/emosca-cnr/margheRita Source code: https://github.com/emosca-cnr/margheRita devtools::install_github(\"antonvsdata/notame\") github.com__emosca-cnr__margheRita metabolomics/v2"
+      "search_text": "https-github-com-emosca-cnr-margherita https://github.com/emosca-cnr/margheRita Source code: https://github.com/emosca-cnr/margheRita devtools::install_github(\"antonvsdata/notame\") github.com__emosca-cnr__margheRita metabolomics/v2 https://github.com/emosca-cnr/margheRita"
     },
     {
       "slug": "https-github-com-sdrogers-nplinker",
       "name": "https://github.com/sdrogers/nplinker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "The NPLinker source code and documentation can be found at https://github.com/sdrogers/nplinker",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/https-github-com-sdrogers-nplinker.yaml",
-      "search_text": "https-github-com-sdrogers-nplinker https://github.com/sdrogers/nplinker The NPLinker source code and documentation can be found at https://github.com/sdrogers/nplinker metabolomics/v2"
+      "search_text": "https-github-com-sdrogers-nplinker https://github.com/sdrogers/nplinker The NPLinker source code and documentation can be found at https://github.com/sdrogers/nplinker metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "https-github-com-shuzhao-li-asari",
       "name": "https://github.com/shuzhao-li/asari",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "Source code: [https://github.com/shuzhao-li/asari](https://github.com/shuzhao-li/asari) The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/https-github-com-shuzhao-li-asari.yaml",
-      "search_text": "https-github-com-shuzhao-li-asari https://github.com/shuzhao-li/asari Source code: [https://github.com/shuzhao-li/asari](https://github.com/shuzhao-li/asari) The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS) metabolomics/v2"
+      "search_text": "https-github-com-shuzhao-li-asari https://github.com/shuzhao-li/asari Source code: [https://github.com/shuzhao-li/asari](https://github.com/shuzhao-li/asari) The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS) metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "hugging-face-transformers",
       "name": "Hugging Face Transformers",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenDFM/MS-BART",
       "license_spdx": "",
       "evidence_text": "github.com/OpenDFM/MS-BART",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hugging-face-transformers.yaml",
-      "search_text": "hugging-face-transformers Hugging Face Transformers github.com/OpenDFM/MS-BART metabolomics/v2"
+      "search_text": "hugging-face-transformers Hugging Face Transformers github.com/OpenDFM/MS-BART metabolomics/v2 https://github.com/OpenDFM/MS-BART"
     },
     {
       "slug": "human-metabolome-database-hmdb",
       "name": "Human Metabolome Database (HMDB)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Leo-Cheng-Lab/ROIAL-NMR",
       "license_spdx": "",
       "evidence_text": "using the Human Metabolome Database (HMDB) as a reference platform",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/human-metabolome-database-hmdb.yaml",
-      "search_text": "human-metabolome-database-hmdb Human Metabolome Database (HMDB) using the Human Metabolome Database (HMDB) as a reference platform metabolomics/v2"
+      "search_text": "human-metabolome-database-hmdb Human Metabolome Database (HMDB) using the Human Metabolome Database (HMDB) as a reference platform metabolomics/v2 https://github.com/Leo-Cheng-Lab/ROIAL-NMR"
     },
     {
       "slug": "hyperspec",
       "name": "HyperSpec",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wh-xu/Hyper-Spec",
       "license_spdx": "",
       "evidence_text": "github.com__wh-xu__Hyper-Spec github.com/wh-xu/Hyper-Spec",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/hyperspec.yaml",
-      "search_text": "hyperspec HyperSpec github.com__wh-xu__Hyper-Spec github.com/wh-xu/Hyper-Spec metabolomics/v2"
+      "search_text": "hyperspec HyperSpec github.com__wh-xu__Hyper-Spec github.com/wh-xu/Hyper-Spec metabolomics/v2 https://github.com/wh-xu/Hyper-Spec"
     },
     {
       "slug": "i-van-krevelen",
@@ -116898,101 +116946,101 @@
     {
       "slug": "iceberg-model",
       "name": "ICEBERG (model)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "ICEBERG predicts spectra at the level of molecular fragments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/iceberg-model.yaml",
-      "search_text": "iceberg-model ICEBERG (model) ICEBERG predicts spectra at the level of molecular fragments metabolomics/v2"
+      "search_text": "iceberg-model ICEBERG (model) ICEBERG predicts spectra at the level of molecular fragments metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "iceberg-webui",
       "name": "ICEBERG WebUI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/iceberg-webui.yaml",
-      "search_text": "iceberg-webui ICEBERG WebUI You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/ metabolomics/v2"
+      "search_text": "iceberg-webui ICEBERG WebUI You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/ metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "iceberg",
       "name": "ICEBERG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/iceberg.yaml",
-      "search_text": "iceberg ICEBERG You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/ metabolomics/v2"
+      "search_text": "iceberg ICEBERG You can run ICEBERG structural elucidation easily at http://iceberg-ms.mit.edu/ metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "idsl-csa",
       "name": "IDSL.CSA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/idslme/IDSL.CSA",
       "license_spdx": "",
       "evidence_text": "The **Composite Spectra Analysis (IDSL.CSA)** R package for the analysis of mass spectrometry data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/idsl-csa.yaml",
-      "search_text": "idsl-csa IDSL.CSA The **Composite Spectra Analysis (IDSL.CSA)** R package for the analysis of mass spectrometry data metabolomics/v2"
+      "search_text": "idsl-csa IDSL.CSA The **Composite Spectra Analysis (IDSL.CSA)** R package for the analysis of mass spectrometry data metabolomics/v2 https://github.com/idslme/IDSL.CSA"
     },
     {
       "slug": "idsl-ipa",
       "name": "IDSL.IPA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/idslme/IDSL.IPA",
       "license_spdx": "",
       "evidence_text": "**Intrinsic Peak Analysis (IPA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me) is a light-weight R package annotate peaklists from the IDSL.IPA package with molecular formula",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/idsl-ipa.yaml",
-      "search_text": "idsl-ipa IDSL.IPA **Intrinsic Peak Analysis (IPA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me) is a light-weight R package annotate peaklists from the IDSL.IPA package with molecular formula metabolomics/v2"
+      "search_text": "idsl-ipa IDSL.IPA **Intrinsic Peak Analysis (IPA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me) is a light-weight R package annotate peaklists from the IDSL.IPA package with molecular formula metabolomics/v2 https://github.com/idslme/IDSL.IPA"
     },
     {
       "slug": "idsl-ufa",
       "name": "IDSL.UFA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/idslme/IDSL.UFA",
       "license_spdx": "",
       "evidence_text": "**United Formula Annotation (UFA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me/) is a light-weight R package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/idsl-ufa.yaml",
-      "search_text": "idsl-ufa IDSL.UFA **United Formula Annotation (UFA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me/) is a light-weight R package metabolomics/v2"
+      "search_text": "idsl-ufa IDSL.UFA **United Formula Annotation (UFA)** by the [**Integrated Data Science Laboratory for Metabolomics and Exposomics (IDSL.ME)**](https://www.idsl.me/) is a light-weight R package metabolomics/v2 https://github.com/idslme/IDSL.UFA"
     },
     {
       "slug": "idsm",
       "name": "IDSM",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [IDSM](https://idsm.elixir-czech.cz/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService']",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/idsm.yaml",
-      "search_text": "idsm IDSM fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [IDSM](https://idsm.elixir-czech.cz/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2"
+      "search_text": "idsm IDSM fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb [IDSM](https://idsm.elixir-czech.cz/) __all__ = ['IDSM', 'CTS', 'CIR', 'PubChem', 'BridgeDb', 'MyService'] metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "igraph",
       "name": "igraph",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LargeMetabo/LargeMetabo",
       "license_spdx": "",
       "evidence_text": "integrates fgsea for fast MetSEA, igraph for topology-based metrics several R packages are utilized in the background processes, including ggplot2, igraph, MASS %\\VignetteDepends{igraph} g.metab <- igraph::as.undirected(sample.graph)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/igraph.yaml",
-      "search_text": "igraph igraph integrates fgsea for fast MetSEA, igraph for topology-based metrics several R packages are utilized in the background processes, including ggplot2, igraph, MASS %\\VignetteDepends{igraph} g.metab <- igraph::as.undirected(sample.graph) metabolomics/v2"
+      "search_text": "igraph igraph integrates fgsea for fast MetSEA, igraph for topology-based metrics several R packages are utilized in the background processes, including ggplot2, igraph, MASS %\\VignetteDepends{igraph} g.metab <- igraph::as.undirected(sample.graph) metabolomics/v2 https://github.com/LargeMetabo/LargeMetabo"
     },
     {
       "slug": "image-processing-toolbox",
       "name": "Image Processing Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/image-processing-toolbox.yaml",
-      "search_text": "image-processing-toolbox Image Processing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "image-processing-toolbox Image Processing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "impute",
@@ -117008,13 +117056,13 @@
     {
       "slug": "imzml-writer",
       "name": "imzML Writer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/VIU-Metabolomics/imzML_Writer",
       "license_spdx": "",
       "evidence_text": "iw_utils.RAW_to_mzML(raw_data_path) imzML Writer is available as: (1) A distributable package on pypi (for CLI, stable GUI, `pip install imzML-Writer`)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/imzml-writer.yaml",
-      "search_text": "imzml-writer imzML Writer iw_utils.RAW_to_mzML(raw_data_path) imzML Writer is available as: (1) A distributable package on pypi (for CLI, stable GUI, `pip install imzML-Writer`) metabolomics/v2"
+      "search_text": "imzml-writer imzML Writer iw_utils.RAW_to_mzML(raw_data_path) imzML Writer is available as: (1) A distributable package on pypi (for CLI, stable GUI, `pip install imzML-Writer`) metabolomics/v2 https://github.com/VIU-Metabolomics/imzML_Writer"
     },
     {
       "slug": "independentmassspectrometer",
@@ -117030,13 +117078,13 @@
     {
       "slug": "injectiondesign",
       "name": "InjectionDesign",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/CSi-Studio/InjectionDesign",
       "license_spdx": "",
       "evidence_text": "LC/GC-MS-based Multi-Omics Injection-Plate Design Web Service",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/injectiondesign.yaml",
-      "search_text": "injectiondesign InjectionDesign LC/GC-MS-based Multi-Omics Injection-Plate Design Web Service metabolomics/v2"
+      "search_text": "injectiondesign InjectionDesign LC/GC-MS-based Multi-Omics Injection-Plate Design Web Service metabolomics/v2 https://github.com/CSi-Studio/InjectionDesign"
     },
     {
       "slug": "intensity-dependent-missing-value-augmentation",
@@ -117052,90 +117100,90 @@
     {
       "slug": "interactiveplotter",
       "name": "InteractivePlotter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "InteractivePlotter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/interactiveplotter.yaml",
-      "search_text": "interactiveplotter InteractivePlotter InteractivePlotter metabolomics/v2"
+      "search_text": "interactiveplotter InteractivePlotter InteractivePlotter metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "interactivetwodimensionplotter",
       "name": "InteractiveTwoDimensionPlotter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "InteractiveTwoDimensionPlotter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/interactivetwodimensionplotter.yaml",
-      "search_text": "interactivetwodimensionplotter InteractiveTwoDimensionPlotter InteractiveTwoDimensionPlotter metabolomics/v2"
+      "search_text": "interactivetwodimensionplotter InteractiveTwoDimensionPlotter InteractiveTwoDimensionPlotter metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "interpretmsspectrum",
       "name": "InterpretMSSpectrum",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/cbroeckl/RAMClustR",
       "license_spdx": "",
       "evidence_text": "We have adapted the 'findMain' function from the 'InterpretMSSpectrum' CRAN package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/interpretmsspectrum.yaml",
-      "search_text": "interpretmsspectrum InterpretMSSpectrum We have adapted the 'findMain' function from the 'InterpretMSSpectrum' CRAN package metabolomics/v2"
+      "search_text": "interpretmsspectrum InterpretMSSpectrum We have adapted the 'findMain' function from the 'InterpretMSSpectrum' CRAN package metabolomics/v2 https://github.com/cbroeckl/RAMClustR"
     },
     {
       "slug": "iokr",
       "name": "IOKR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "In principle, IOKR works by first learning a mapping from the space of spectra to the space of molecular fingerprints",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/iokr.yaml",
-      "search_text": "iokr IOKR In principle, IOKR works by first learning a mapping from the space of spectra to the space of molecular fingerprints metabolomics/v2"
+      "search_text": "iokr IOKR In principle, IOKR works by first learning a mapping from the space of spectra to the space of molecular fingerprints metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "ion-identity",
       "name": "Ion Identity",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "Inventa is capable to performe the calcultions based on the results from Ion Identity, reducing the total number of features.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ion-identity.yaml",
-      "search_text": "ion-identity Ion Identity Inventa is capable to performe the calcultions based on the results from Ion Identity, reducing the total number of features. metabolomics/v2"
+      "search_text": "ion-identity Ion Identity Inventa is capable to performe the calcultions based on the results from Ion Identity, reducing the total number of features. metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "ionflow",
       "name": "ionflow",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wanchanglin/ionflow",
       "license_spdx": "",
       "evidence_text": "github.com__wanchanglin__ionflow",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ionflow.yaml",
-      "search_text": "ionflow ionflow github.com__wanchanglin__ionflow metabolomics/v2"
+      "search_text": "ionflow ionflow github.com__wanchanglin__ionflow metabolomics/v2 https://github.com/wanchanglin/ionflow"
     },
     {
       "slug": "iontoolpack",
       "name": "IonToolPack",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "IonToolPack is a software suite housing tools for mass spectrometry data IonToolPack is a software suite housing tools for mass spectrometry data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/iontoolpack.yaml",
-      "search_text": "iontoolpack IonToolPack IonToolPack is a software suite housing tools for mass spectrometry data IonToolPack is a software suite housing tools for mass spectrometry data. metabolomics/v2"
+      "search_text": "iontoolpack IonToolPack IonToolPack is a software suite housing tools for mass spectrometry data IonToolPack is a software suite housing tools for mass spectrometry data. metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "ipapy2",
       "name": "ipaPy2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/francescodc87/ipaPy2",
       "license_spdx": "",
       "evidence_text": "github.com__francescodc87__ipaPy2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ipapy2.yaml",
-      "search_text": "ipapy2 ipaPy2 github.com__francescodc87__ipaPy2 metabolomics/v2"
+      "search_text": "ipapy2 ipaPy2 github.com__francescodc87__ipaPy2 metabolomics/v2 https://github.com/francescodc87/ipaPy2"
     },
     {
       "slug": "ipbhalle-metfragweb",
@@ -117151,68 +117199,68 @@
     {
       "slug": "ipresto",
       "name": "iPRESTO",
-      "canonical_url": "",
+      "canonical_url": "https://git.wur.nl/bioinformatics/iPRESTO.git",
       "license_spdx": "",
       "evidence_text": "iPRESTO (integrated Prediction and Rigorous Exploration of biosynthetic Sub-clusters Tool) is a command line tool for the detection of gene sub-clusters",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ipresto.yaml",
-      "search_text": "ipresto iPRESTO iPRESTO (integrated Prediction and Rigorous Exploration of biosynthetic Sub-clusters Tool) is a command line tool for the detection of gene sub-clusters metabolomics/v2"
+      "search_text": "ipresto iPRESTO iPRESTO (integrated Prediction and Rigorous Exploration of biosynthetic Sub-clusters Tool) is a command line tool for the detection of gene sub-clusters metabolomics/v2 https://git.wur.nl/bioinformatics/iPRESTO.git"
     },
     {
       "slug": "isfrag",
       "name": "ISFrag",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/ISFrag",
       "license_spdx": "",
       "evidence_text": "ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table. ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/isfrag.yaml",
-      "search_text": "isfrag ISFrag ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table. ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table metabolomics/v2"
+      "search_text": "isfrag ISFrag ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table. ISFrag is an R package for identifying and annotating in-source fragments in LCMS metabolite feature table metabolomics/v2 https://github.com/HuanLab/ISFrag"
     },
     {
       "slug": "isoformswitchanalyzer",
       "name": "IsoformSwitchAnalyzer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Isoforms | Genome wide isoform analysis | IsoformSwitchAnalyzer",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/isoformswitchanalyzer.yaml",
-      "search_text": "isoformswitchanalyzer IsoformSwitchAnalyzer Isoforms | Genome wide isoform analysis | IsoformSwitchAnalyzer metabolomics/v2"
+      "search_text": "isoformswitchanalyzer IsoformSwitchAnalyzer Isoforms | Genome wide isoform analysis | IsoformSwitchAnalyzer metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "isofusion",
       "name": "IsoFusion",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/xfcui/IsoFusion",
       "license_spdx": "",
       "evidence_text": "github.com__xfcui__IsoFusion",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/isofusion.yaml",
-      "search_text": "isofusion IsoFusion github.com__xfcui__IsoFusion metabolomics/v2"
+      "search_text": "isofusion IsoFusion github.com__xfcui__IsoFusion metabolomics/v2 https://github.com/xfcui/IsoFusion"
     },
     {
       "slug": "isopairfinder",
       "name": "IsoPairFinder",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kilgain/MassSpec",
       "license_spdx": "",
       "evidence_text": "devtools::install_github(\"DoddLab/IsoPairFinder\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/isopairfinder.yaml",
-      "search_text": "isopairfinder IsoPairFinder devtools::install_github(\"DoddLab/IsoPairFinder\") metabolomics/v2"
+      "search_text": "isopairfinder IsoPairFinder devtools::install_github(\"DoddLab/IsoPairFinder\") metabolomics/v2 https://github.com/kilgain/MassSpec"
     },
     {
       "slug": "isoscan",
       "name": "isoSCAN",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/jcapelladesto/isoSCAN",
       "license_spdx": "",
       "evidence_text": "install_github(\"jcapelladesto/isoSCAN\") library(isoSCAN) install_github(\"jcapelladesto/isoSCAN\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/isoscan.yaml",
-      "search_text": "isoscan isoSCAN install_github(\"jcapelladesto/isoSCAN\") library(isoSCAN) install_github(\"jcapelladesto/isoSCAN\") metabolomics/v2"
+      "search_text": "isoscan isoSCAN install_github(\"jcapelladesto/isoSCAN\") library(isoSCAN) install_github(\"jcapelladesto/isoSCAN\") metabolomics/v2 https://github.com/jcapelladesto/isoSCAN"
     },
     {
       "slug": "java-21",
@@ -117228,13 +117276,13 @@
     {
       "slug": "java",
       "name": "Java",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Le0nT1/CyProduct",
       "license_spdx": "",
       "evidence_text": "Java -jar CyProduct.jar QueryMolecule enzymeList OutputFolderPath MetNet is a Java tool",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/java.yaml",
-      "search_text": "java Java Java -jar CyProduct.jar QueryMolecule enzymeList OutputFolderPath MetNet is a Java tool metabolomics/v2"
+      "search_text": "java Java Java -jar CyProduct.jar QueryMolecule enzymeList OutputFolderPath MetNet is a Java tool metabolomics/v2 https://github.com/Le0nT1/CyProduct"
     },
     {
       "slug": "javafx-24",
@@ -117250,24 +117298,24 @@
     {
       "slug": "javascript",
       "name": "JavaScript",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "The platform is built with Python, Django, JavaScript, and HTML",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/javascript.yaml",
-      "search_text": "javascript JavaScript The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2"
+      "search_text": "javascript JavaScript The platform is built with Python, Django, JavaScript, and HTML metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "javax-faces-2-2-12-jar",
       "name": "javax.faces-2.2.12.jar",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/albertogilf/ceuMassMediator",
       "license_spdx": "",
       "evidence_text": "The next library is needed in the app server: javax.faces-2.2.12.jar",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/javax-faces-2-2-12-jar.yaml",
-      "search_text": "javax-faces-2-2-12-jar javax.faces-2.2.12.jar The next library is needed in the app server: javax.faces-2.2.12.jar metabolomics/v2"
+      "search_text": "javax-faces-2-2-12-jar javax.faces-2.2.12.jar The next library is needed in the app server: javax.faces-2.2.12.jar metabolomics/v2 https://github.com/albertogilf/ceuMassMediator"
     },
     {
       "slug": "jdk-25",
@@ -117283,112 +117331,112 @@
     {
       "slug": "jfreechart",
       "name": "jfreechart",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rformassspectrometry/Spectra",
       "license_spdx": "",
       "evidence_text": "jfreechart-1.0.17-experimental",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jfreechart.yaml",
-      "search_text": "jfreechart jfreechart jfreechart-1.0.17-experimental metabolomics/v2"
+      "search_text": "jfreechart jfreechart jfreechart-1.0.17-experimental metabolomics/v2 https://github.com/rformassspectrometry/Spectra"
     },
     {
       "slug": "jms",
       "name": "JMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "The empirical compounds are searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS).",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jms.yaml",
-      "search_text": "jms JMS The empirical compounds are searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS). metabolomics/v2"
+      "search_text": "jms JMS The empirical compounds are searched against known compound database (default HMDB 4) via another package JMS (https://github.com/shuzhao-li/JMS). metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "joblib",
       "name": "joblib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "For parallel processing of multiple spectra or/and sequence files, MetaMiner requires `joblib` Python library joblib==0.15.1",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/joblib.yaml",
-      "search_text": "joblib joblib For parallel processing of multiple spectra or/and sequence files, MetaMiner requires `joblib` Python library joblib==0.15.1 metabolomics/v2"
+      "search_text": "joblib joblib For parallel processing of multiple spectra or/and sequence files, MetaMiner requires `joblib` Python library joblib==0.15.1 metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "jopt-simple",
       "name": "jopt-simple",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rformassspectrometry/Spectra",
       "license_spdx": "",
       "evidence_text": "jopt-simple-4.3",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jopt-simple.yaml",
-      "search_text": "jopt-simple jopt-simple jopt-simple-4.3 metabolomics/v2"
+      "search_text": "jopt-simple jopt-simple jopt-simple-4.3 metabolomics/v2 https://github.com/rformassspectrometry/Spectra"
     },
     {
       "slug": "jorhelp-docker-image",
       "name": "jorhelp Docker Image",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/xfcui/IsoFusion",
       "license_spdx": "",
       "evidence_text": "you can directly use the Docker Image we provide, or you can build your own running environment: #### Run with docker Pull the docker image: `docker pull jorhelp/",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jorhelp-docker-image.yaml",
-      "search_text": "jorhelp-docker-image jorhelp Docker Image you can directly use the Docker Image we provide, or you can build your own running environment: #### Run with docker Pull the docker image: `docker pull jorhelp/ metabolomics/v2"
+      "search_text": "jorhelp-docker-image jorhelp Docker Image you can directly use the Docker Image we provide, or you can build your own running environment: #### Run with docker Pull the docker image: `docker pull jorhelp/ metabolomics/v2 https://github.com/xfcui/IsoFusion"
     },
     {
       "slug": "jpa-r-package",
       "name": "JPA R Package",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/JPA",
       "license_spdx": "",
       "evidence_text": "'JPA' is written in R and its source code is publicly available at <https://github.com/HuanLab/JPA.git>.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jpa-r-package.yaml",
-      "search_text": "jpa-r-package JPA R Package 'JPA' is written in R and its source code is publicly available at <https://github.com/HuanLab/JPA.git>. metabolomics/v2"
+      "search_text": "jpa-r-package JPA R Package 'JPA' is written in R and its source code is publicly available at <https://github.com/HuanLab/JPA.git>. metabolomics/v2 https://github.com/HuanLab/JPA"
     },
     {
       "slug": "jpa",
       "name": "JPA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/JPA",
       "license_spdx": "",
       "evidence_text": "JPA is a comprehensive and integrated metabolomics data processing software. JPA is a comprehensive and integrated metabolomics data processing software",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jpa.yaml",
-      "search_text": "jpa JPA JPA is a comprehensive and integrated metabolomics data processing software. JPA is a comprehensive and integrated metabolomics data processing software metabolomics/v2"
+      "search_text": "jpa JPA JPA is a comprehensive and integrated metabolomics data processing software. JPA is a comprehensive and integrated metabolomics data processing software metabolomics/v2 https://github.com/HuanLab/JPA"
     },
     {
       "slug": "jsonschema",
       "name": "jsonschema",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MoseleyBioinformaticsLab/mwtab",
       "license_spdx": "",
       "evidence_text": "utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) This is done largely through utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) jsonschema_ for validating functionality of ``mwTab`` files based on ``JSON`` schema",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jsonschema.yaml",
-      "search_text": "jsonschema jsonschema utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) This is done largely through utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) jsonschema_ for validating functionality of ``mwTab`` files based on ``JSON`` schema metabolomics/v2"
+      "search_text": "jsonschema jsonschema utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) This is done largely through utilizing `JSON Schema <https://json-schema.org/understanding-json-schema/>`_ (`jsonschema <https://pypi.org/project/jsonschema/>`_) jsonschema_ for validating functionality of ``mwTab`` files based on ``JSON`` schema metabolomics/v2 https://github.com/MoseleyBioinformaticsLab/mwtab"
     },
     {
       "slug": "jupyter-lab",
       "name": "Jupyter Lab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/facundof2016/CCSP2.0",
       "license_spdx": "",
       "evidence_text": "a Jupyter Lab compatible notebook with a Tk interface",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jupyter-lab.yaml",
-      "search_text": "jupyter-lab Jupyter Lab a Jupyter Lab compatible notebook with a Tk interface metabolomics/v2"
+      "search_text": "jupyter-lab Jupyter Lab a Jupyter Lab compatible notebook with a Tk interface metabolomics/v2 https://github.com/facundof2016/CCSP2.0"
     },
     {
       "slug": "jupyter-notebook",
       "name": "jupyter-notebook",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kevinmildau/msFeaST",
       "license_spdx": "",
       "evidence_text": "The jupyter-notebook pipeline produces the a text file in json format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jupyter-notebook.yaml",
-      "search_text": "jupyter-notebook jupyter-notebook The jupyter-notebook pipeline produces the a text file in json format metabolomics/v2"
+      "search_text": "jupyter-notebook jupyter-notebook The jupyter-notebook pipeline produces the a text file in json format metabolomics/v2 https://github.com/kevinmildau/msFeaST"
     },
     {
       "slug": "jupyter-notebooks",
@@ -117404,13 +117452,13 @@
     {
       "slug": "jupyter",
       "name": "Jupyter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/griquelme/tidyms",
       "license_spdx": "",
       "evidence_text": "The Python code to generate the results is contained within the Jupyter notebook Jupyter notebook **src/reproducible_simulations.ipynb** This is done in interactive Jupyter notebooks using the specXplore importing pipeline.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/jupyter.yaml",
-      "search_text": "jupyter Jupyter The Python code to generate the results is contained within the Jupyter notebook Jupyter notebook **src/reproducible_simulations.ipynb** This is done in interactive Jupyter notebooks using the specXplore importing pipeline. metabolomics/v2"
+      "search_text": "jupyter Jupyter The Python code to generate the results is contained within the Jupyter notebook Jupyter notebook **src/reproducible_simulations.ipynb** This is done in interactive Jupyter notebooks using the specXplore importing pipeline. metabolomics/v2 https://github.com/griquelme/tidyms"
     },
     {
       "slug": "kableextra",
@@ -117426,145 +117474,145 @@
     {
       "slug": "kaleido",
       "name": "Kaleido",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pmartR/PMart_ShinyApp",
       "license_spdx": "",
       "evidence_text": "Remove orca in favor of Kaleido",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/kaleido.yaml",
-      "search_text": "kaleido Kaleido Remove orca in favor of Kaleido metabolomics/v2"
+      "search_text": "kaleido Kaleido Remove orca in favor of Kaleido metabolomics/v2 https://github.com/pmartR/PMart_ShinyApp"
     },
     {
       "slug": "kegg-database",
       "name": "KEGG database",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/b2slab/mWISE",
       "license_spdx": "",
       "evidence_text": "matching mass-to-charge ratio values to KEGG database",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/kegg-database.yaml",
-      "search_text": "kegg-database KEGG database matching mass-to-charge ratio values to KEGG database metabolomics/v2"
+      "search_text": "kegg-database KEGG database matching mass-to-charge ratio values to KEGG database metabolomics/v2 https://github.com/b2slab/mWISE"
     },
     {
       "slug": "kegg",
       "name": "KEGG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biodatalab/enrichmet",
       "license_spdx": "",
       "evidence_text": "curated KEGG data for enrichment using Fisher's Exact Test their metabolic data are retrieved from KEGG and the corresponding networks of metabolic functions are built",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/kegg.yaml",
-      "search_text": "kegg KEGG curated KEGG data for enrichment using Fisher's Exact Test their metabolic data are retrieved from KEGG and the corresponding networks of metabolic functions are built metabolomics/v2"
+      "search_text": "kegg KEGG curated KEGG data for enrichment using Fisher's Exact Test their metabolic data are retrieved from KEGG and the corresponding networks of metabolic functions are built metabolomics/v2 https://github.com/biodatalab/enrichmet"
     },
     {
       "slug": "keggrest",
       "name": "KEGGREST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biodatalab/enrichmet",
       "license_spdx": "",
       "evidence_text": "pathway to metabolite mappings are obtained from the KEGG resource using the KEGGREST package query the KEGG database [59] using the R package KEGGREST [60] MetaboDirect can use the assigned molecular formulas to query the KEGG database [59] using the R package KEGGREST [60] which retrieves data from the KEGG API using the function ```keggGet``` from the package KEGGREST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/keggrest.yaml",
-      "search_text": "keggrest KEGGREST pathway to metabolite mappings are obtained from the KEGG resource using the KEGGREST package query the KEGG database [59] using the R package KEGGREST [60] MetaboDirect can use the assigned molecular formulas to query the KEGG database [59] using the R package KEGGREST [60] which retrieves data from the KEGG API using the function ```keggGet``` from the package KEGGREST metabolomics/v2"
+      "search_text": "keggrest KEGGREST pathway to metabolite mappings are obtained from the KEGG resource using the KEGGREST package query the KEGG database [59] using the R package KEGGREST [60] MetaboDirect can use the assigned molecular formulas to query the KEGG database [59] using the R package KEGGREST [60] which retrieves data from the KEGG API using the function ```keggGet``` from the package KEGGREST metabolomics/v2 https://github.com/biodatalab/enrichmet"
     },
     {
       "slug": "keras-2-2-0",
       "name": "Keras 2.2.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "Keras (2.2.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/keras-2-2-0.yaml",
-      "search_text": "keras-2-2-0 Keras 2.2.0 Keras (2.2.0) metabolomics/v2"
+      "search_text": "keras-2-2-0 Keras 2.2.0 Keras (2.2.0) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "keras",
       "name": "Keras",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JainLab/Manuscript-DNNs-for-Classification-of-LCMS-Peaks",
       "license_spdx": "",
       "evidence_text": "convert the keras models into HDF5 TF2 models Deep Neural Networks for Classification of LC-MS Spectral Peaks Keras (2.2.0) from keras.optimizers import SGD, Adam packageVersion(\"keras\") [1] ‘2.7.0’",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/keras.yaml",
-      "search_text": "keras Keras convert the keras models into HDF5 TF2 models Deep Neural Networks for Classification of LC-MS Spectral Peaks Keras (2.2.0) from keras.optimizers import SGD, Adam packageVersion(\"keras\") [1] ‘2.7.0’ metabolomics/v2"
+      "search_text": "keras Keras convert the keras models into HDF5 TF2 models Deep Neural Networks for Classification of LC-MS Spectral Peaks Keras (2.2.0) from keras.optimizers import SGD, Adam packageVersion(\"keras\") [1] ‘2.7.0’ metabolomics/v2 https://github.com/JainLab/Manuscript-DNNs-for-Classification-of-LCMS-Peaks"
     },
     {
       "slug": "khipu",
       "name": "khipu",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) freely available on GitHub (https://github.com/shuzhao-li/khipu) under a BSD 3-Clause License pre-annotation to group featues to empirical compounds (khipu)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/khipu.yaml",
-      "search_text": "khipu khipu The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) freely available on GitHub (https://github.com/shuzhao-li/khipu) under a BSD 3-Clause License pre-annotation to group featues to empirical compounds (khipu) metabolomics/v2"
+      "search_text": "khipu khipu The preannotaion is done via another package khipu (https://github.com/shuzhao-li-lab/khipu) freely available on GitHub (https://github.com/shuzhao-li/khipu) under a BSD 3-Clause License pre-annotation to group featues to empirical compounds (khipu) metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "knime",
       "name": "KNIME",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MolecularCartography/Optimus",
       "license_spdx": "",
       "evidence_text": "KNIME Basics how you installed OpenMS (e.g., from within KNIME, binary installers, self compiled)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/knime.yaml",
-      "search_text": "knime KNIME KNIME Basics how you installed OpenMS (e.g., from within KNIME, binary installers, self compiled) metabolomics/v2"
+      "search_text": "knime KNIME KNIME Basics how you installed OpenMS (e.g., from within KNIME, binary installers, self compiled) metabolomics/v2 https://github.com/MolecularCartography/Optimus"
     },
     {
       "slug": "knitr",
       "name": "knitr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MRCIEU/metaboprep",
       "license_spdx": "",
       "evidence_text": "%\\VignetteEngine{knitr::rmarkdown} knitr::include_graphics",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/knitr.yaml",
-      "search_text": "knitr knitr %\\VignetteEngine{knitr::rmarkdown} knitr::include_graphics metabolomics/v2"
+      "search_text": "knitr knitr %\\VignetteEngine{knitr::rmarkdown} knitr::include_graphics metabolomics/v2 https://github.com/MRCIEU/metaboprep"
     },
     {
       "slug": "largemetabo",
       "name": "LargeMetabo",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LargeMetabo/LargeMetabo",
       "license_spdx": "",
       "evidence_text": "install_github(\"LargeMetabo/LargeMetabo\", force = TRUE, build_vignettes = TRUE)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/largemetabo.yaml",
-      "search_text": "largemetabo LargeMetabo install_github(\"LargeMetabo/LargeMetabo\", force = TRUE, build_vignettes = TRUE) metabolomics/v2"
+      "search_text": "largemetabo LargeMetabo install_github(\"LargeMetabo/LargeMetabo\", force = TRUE, build_vignettes = TRUE) metabolomics/v2 https://github.com/LargeMetabo/LargeMetabo"
     },
     {
       "slug": "latent-dirichlet-allocation-lda",
       "name": "Latent Dirichlet Allocation (LDA)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "Apply LDA to the processed spectra MS2LDA uses **Latent Dirichlet Allocation (LDA)** to infer which motifs are most likely to explain the observed fragmentation patterns.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/latent-dirichlet-allocation-lda.yaml",
-      "search_text": "latent-dirichlet-allocation-lda Latent Dirichlet Allocation (LDA) Apply LDA to the processed spectra MS2LDA uses **Latent Dirichlet Allocation (LDA)** to infer which motifs are most likely to explain the observed fragmentation patterns. metabolomics/v2"
+      "search_text": "latent-dirichlet-allocation-lda Latent Dirichlet Allocation (LDA) Apply LDA to the processed spectra MS2LDA uses **Latent Dirichlet Allocation (LDA)** to infer which motifs are most likely to explain the observed fragmentation patterns. metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "lcmsworld",
       "name": "lcmsWorld",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PGB-LIV/lcmsWorld",
       "license_spdx": "",
       "evidence_text": "lcmsWorld is a 3d viewer for LC-MS data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lcmsworld.yaml",
-      "search_text": "lcmsworld lcmsWorld lcmsWorld is a 3d viewer for LC-MS data metabolomics/v2"
+      "search_text": "lcmsworld lcmsWorld lcmsWorld is a 3d viewer for LC-MS data metabolomics/v2 https://github.com/PGB-LIV/lcmsWorld"
     },
     {
       "slug": "lda-latent-dirichlet-allocation",
       "name": "LDA (Latent Dirichlet Allocation)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/ESP",
       "license_spdx": "",
       "evidence_text": "spectral topic labels obtained using LDA (Latent Dirichlet Allocation)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lda-latent-dirichlet-allocation.yaml",
-      "search_text": "lda-latent-dirichlet-allocation LDA (Latent Dirichlet Allocation) spectral topic labels obtained using LDA (Latent Dirichlet Allocation) metabolomics/v2"
+      "search_text": "lda-latent-dirichlet-allocation LDA (Latent Dirichlet Allocation) spectral topic labels obtained using LDA (Latent Dirichlet Allocation) metabolomics/v2 https://github.com/HassounLab/ESP"
     },
     {
       "slug": "lib2nist",
@@ -117580,24 +117628,24 @@
     {
       "slug": "lilikoi-v2-0",
       "name": "Lilikoi v2.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lanagarmire/lilikoi2",
       "license_spdx": "",
       "evidence_text": "The new Lilikoi v2.0 R package has implemented a deep-learning method for classification, in addition to popular machine learning methods.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lilikoi-v2-0.yaml",
-      "search_text": "lilikoi-v2-0 Lilikoi v2.0 The new Lilikoi v2.0 R package has implemented a deep-learning method for classification, in addition to popular machine learning methods. metabolomics/v2"
+      "search_text": "lilikoi-v2-0 Lilikoi v2.0 The new Lilikoi v2.0 R package has implemented a deep-learning method for classification, in addition to popular machine learning methods. metabolomics/v2 https://github.com/lanagarmire/lilikoi2"
     },
     {
       "slug": "limma",
       "name": "limma",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "allows the identification of differentially abundant lipids in simple and complex experimental designs This step of the workflow requires the `limma` package to be installed. Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva BiocManager::install(\"limma\") can be performed on the feature matrix using functionality from other R packages, such as `r Biocpkg(\"limma\")`.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/limma.yaml",
-      "search_text": "limma limma allows the identification of differentially abundant lipids in simple and complex experimental designs This step of the workflow requires the `limma` package to be installed. Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva BiocManager::install(\"limma\") can be performed on the feature matrix using functionality from other R packages, such as `r Biocpkg(\"limma\")`. metabolomics/v2"
+      "search_text": "limma limma allows the identification of differentially abundant lipids in simple and complex experimental designs This step of the workflow requires the `limma` package to be installed. Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva BiocManager::install(\"limma\") can be performed on the feature matrix using functionality from other R packages, such as `r Biocpkg(\"limma\")`. metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "lipid-map",
@@ -117613,79 +117661,79 @@
     {
       "slug": "lipid-maps",
       "name": "LIPID MAPS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ShinyFabio/ADViSELipidomics",
       "license_spdx": "",
       "evidence_text": "parsing lipid species (using LIPID MAPS classification)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipid-maps.yaml",
-      "search_text": "lipid-maps LIPID MAPS parsing lipid species (using LIPID MAPS classification) metabolomics/v2"
+      "search_text": "lipid-maps LIPID MAPS parsing lipid species (using LIPID MAPS classification) metabolomics/v2 https://github.com/ShinyFabio/ADViSELipidomics"
     },
     {
       "slug": "lipidlynxx",
       "name": "LipidLynxX",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SysMedOs/LipidLynxX",
       "license_spdx": "",
       "evidence_text": "The LipidLynxX project is aimed to provide a unified identifier for major lipids",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidlynxx.yaml",
-      "search_text": "lipidlynxx LipidLynxX The LipidLynxX project is aimed to provide a unified identifier for major lipids metabolomics/v2"
+      "search_text": "lipidlynxx LipidLynxX The LipidLynxX project is aimed to provide a unified identifier for major lipids metabolomics/v2 https://github.com/SysMedOs/LipidLynxX"
     },
     {
       "slug": "lipidmatch",
       "name": "LipidMatch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "put Modular.r into two directories (replace existing code): `LipidMatch-4.2\\Flow\\LipidMatch_Distribution` LipidMatch identifications are obtained by matching experimental fragment m/z values with simulated library m/z values",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidmatch.yaml",
-      "search_text": "lipidmatch LipidMatch put Modular.r into two directories (replace existing code): `LipidMatch-4.2\\Flow\\LipidMatch_Distribution` LipidMatch identifications are obtained by matching experimental fragment m/z values with simulated library m/z values metabolomics/v2"
+      "search_text": "lipidmatch LipidMatch put Modular.r into two directories (replace existing code): `LipidMatch-4.2\\Flow\\LipidMatch_Distribution` LipidMatch identifications are obtained by matching experimental fragment m/z values with simulated library m/z values metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "lipidqmap",
       "name": "LipidQMap",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/swinnenteam/LipidQMap",
       "license_spdx": "",
       "evidence_text": "LipidQMap writes MSI exports as HDF5 containers LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. LipidQMap is a program to support accurate quantitation of Mass Spectrometry Imaging data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidqmap.yaml",
-      "search_text": "lipidqmap LipidQMap LipidQMap writes MSI exports as HDF5 containers LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. LipidQMap is a program to support accurate quantitation of Mass Spectrometry Imaging data metabolomics/v2"
+      "search_text": "lipidqmap LipidQMap LipidQMap writes MSI exports as HDF5 containers LipidQMap writes MSI exports as HDF5 containers that follow the [`Cardinal::HDF5`](https://cardinalmsi.org) conventions. LipidQMap is a program to support accurate quantitation of Mass Spectrometry Imaging data metabolomics/v2 https://github.com/swinnenteam/LipidQMap"
     },
     {
       "slug": "lipidr",
       "name": "lipidr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ahmohamed/lipidr",
       "license_spdx": "",
       "evidence_text": "Datasets can be easily downloaded and parsed into `LipidomicsExperiment` object using `lipidr` function `fetch_mw_study()` `lipidr` allows users, to quickly explore public lipidomics experiments. `lipidr` provides an easy way to re-analyze and visualize these datasets. lipidr allows users, to quickly explore public lipidomics experiments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidr.yaml",
-      "search_text": "lipidr lipidr Datasets can be easily downloaded and parsed into `LipidomicsExperiment` object using `lipidr` function `fetch_mw_study()` `lipidr` allows users, to quickly explore public lipidomics experiments. `lipidr` provides an easy way to re-analyze and visualize these datasets. lipidr allows users, to quickly explore public lipidomics experiments metabolomics/v2"
+      "search_text": "lipidr lipidr Datasets can be easily downloaded and parsed into `LipidomicsExperiment` object using `lipidr` function `fetch_mw_study()` `lipidr` allows users, to quickly explore public lipidomics experiments. `lipidr` provides an easy way to re-analyze and visualize these datasets. lipidr allows users, to quickly explore public lipidomics experiments metabolomics/v2 https://github.com/ahmohamed/lipidr"
     },
     {
       "slug": "lipidsearch",
       "name": "LipidSearch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ShinyFabio/ADViSELipidomics",
       "license_spdx": "",
       "evidence_text": "outputs from LipidSearch and LIQUID for lipid identification and quantification",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidsearch.yaml",
-      "search_text": "lipidsearch LipidSearch outputs from LipidSearch and LIQUID for lipid identification and quantification metabolomics/v2"
+      "search_text": "lipidsearch LipidSearch outputs from LipidSearch and LIQUID for lipid identification and quantification metabolomics/v2 https://github.com/ShinyFabio/ADViSELipidomics"
     },
     {
       "slug": "lipidspace",
       "name": "LipidSpace",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lifs-tools/lipidspace",
       "license_spdx": "",
       "evidence_text": "LipidSpace is a stand-alone tool to analyze and compare lipidomes",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lipidspace.yaml",
-      "search_text": "lipidspace LipidSpace LipidSpace is a stand-alone tool to analyze and compare lipidomes metabolomics/v2"
+      "search_text": "lipidspace LipidSpace LipidSpace is a stand-alone tool to analyze and compare lipidomes metabolomics/v2 https://github.com/lifs-tools/lipidspace"
     },
     {
       "slug": "lipoclean",
@@ -117701,112 +117749,112 @@
     {
       "slug": "liquid",
       "name": "LIQUID",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ShinyFabio/ADViSELipidomics",
       "license_spdx": "",
       "evidence_text": "outputs from LipidSearch and LIQUID for lipid identification and quantification",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/liquid.yaml",
-      "search_text": "liquid LIQUID outputs from LipidSearch and LIQUID for lipid identification and quantification metabolomics/v2"
+      "search_text": "liquid LIQUID outputs from LipidSearch and LIQUID for lipid identification and quantification metabolomics/v2 https://github.com/ShinyFabio/ADViSELipidomics"
     },
     {
       "slug": "lme4",
       "name": "lme4",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FrigerioGianfranco/GetFeatistics",
       "license_spdx": "",
       "evidence_text": "linear models with mixed effects (random and fixed), using the _lmer_ function from the lme4 package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lme4.yaml",
-      "search_text": "lme4 lme4 linear models with mixed effects (random and fixed), using the _lmer_ function from the lme4 package metabolomics/v2"
+      "search_text": "lme4 lme4 linear models with mixed effects (random and fixed), using the _lmer_ function from the lme4 package metabolomics/v2 https://github.com/FrigerioGianfranco/GetFeatistics"
     },
     {
       "slug": "local-code-artifact",
       "name": "local code artifact",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/CNIC-Proteomics/TurboPutative",
       "license_spdx": "",
       "evidence_text": "",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/local-code-artifact.yaml",
-      "search_text": "local-code-artifact local code artifact metabolomics/v2"
+      "search_text": "local-code-artifact local code artifact metabolomics/v2 https://github.com/CNIC-Proteomics/TurboPutative"
     },
     {
       "slug": "lotus-database",
       "name": "Lotus Database",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "the Lotus Dabase uses the NPClassifyre ontology and Sirius uses the Classifyre ontology",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lotus-database.yaml",
-      "search_text": "lotus-database Lotus Database the Lotus Dabase uses the NPClassifyre ontology and Sirius uses the Classifyre ontology metabolomics/v2"
+      "search_text": "lotus-database Lotus Database the Lotus Dabase uses the NPClassifyre ontology and Sirius uses the Classifyre ontology metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "lowess",
       "name": "LOWESS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "Perform a LOWESS (Locally Weighted Scatterplot Smoothing) regression to obtain a function to describe the relationship of the RT values",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lowess.yaml",
-      "search_text": "lowess LOWESS Perform a LOWESS (Locally Weighted Scatterplot Smoothing) regression to obtain a function to describe the relationship of the RT values metabolomics/v2"
+      "search_text": "lowess LOWESS Perform a LOWESS (Locally Weighted Scatterplot Smoothing) regression to obtain a function to describe the relationship of the RT values metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "lsg-lipid-spectrum-generator",
       "name": "LSG (Lipid Spectrum Generator)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/98104781/LSG",
       "license_spdx": "",
       "evidence_text": "https://github.com/98104781/LSG/releases/tag/v1.3.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lsg-lipid-spectrum-generator.yaml",
-      "search_text": "lsg-lipid-spectrum-generator LSG (Lipid Spectrum Generator) https://github.com/98104781/LSG/releases/tag/v1.3.0 metabolomics/v2"
+      "search_text": "lsg-lipid-spectrum-generator LSG (Lipid Spectrum Generator) https://github.com/98104781/LSG/releases/tag/v1.3.0 metabolomics/v2 https://github.com/98104781/LSG"
     },
     {
       "slug": "lsg",
       "name": "LSG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/98104781/LSG",
       "license_spdx": "",
       "evidence_text": "https://github.com/98104781/LSG/releases/tag/v1.3.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/lsg.yaml",
-      "search_text": "lsg LSG https://github.com/98104781/LSG/releases/tag/v1.3.0 metabolomics/v2"
+      "search_text": "lsg LSG https://github.com/98104781/LSG/releases/tag/v1.3.0 metabolomics/v2 https://github.com/98104781/LSG"
     },
     {
       "slug": "madbyte",
       "name": "MADByTE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/liningtonlab/madbyte",
       "license_spdx": "",
       "evidence_text": "MADByTE stands for **M**etabolomics **A**nd **D**ereplication **By** **T**wo-dimensional **E**xperiments.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/madbyte.yaml",
-      "search_text": "madbyte MADByTE MADByTE stands for **M**etabolomics **A**nd **D**ereplication **By** **T**wo-dimensional **E**xperiments. metabolomics/v2"
+      "search_text": "madbyte MADByTE MADByTE stands for **M**etabolomics **A**nd **D**ereplication **By** **T**wo-dimensional **E**xperiments. metabolomics/v2 https://github.com/liningtonlab/madbyte"
     },
     {
       "slug": "mag-mass2motif-annotation-guidance",
       "name": "MAG (Mass2Motif Annotation Guidance)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "Automated annotation of M2M using MAG",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mag-mass2motif-annotation-guidance.yaml",
-      "search_text": "mag-mass2motif-annotation-guidance MAG (Mass2Motif Annotation Guidance) Automated annotation of M2M using MAG metabolomics/v2"
+      "search_text": "mag-mass2motif-annotation-guidance MAG (Mass2Motif Annotation Guidance) Automated annotation of M2M using MAG metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "mag",
       "name": "MAG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "Automated annotation of **M2M** using **MAG**",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mag.yaml",
-      "search_text": "mag MAG Automated annotation of **M2M** using **MAG** metabolomics/v2"
+      "search_text": "mag MAG Automated annotation of **M2M** using **MAG** metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "magma",
@@ -117822,24 +117870,24 @@
     {
       "slug": "magrittr",
       "name": "magrittr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" maplet is designed to work with a pipe operator - either the popular %>% operator from the magrittr package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/magrittr.yaml",
-      "search_text": "magrittr magrittr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" maplet is designed to work with a pipe operator - either the popular %>% operator from the magrittr package metabolomics/v2"
+      "search_text": "magrittr magrittr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" maplet is designed to work with a pipe operator - either the popular %>% operator from the magrittr package metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "make",
       "name": "Make",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Please make sure to have [Make](https://www.gnu.org/software/make) installed. make -j4",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/make.yaml",
-      "search_text": "make Make Please make sure to have [Make](https://www.gnu.org/software/make) installed. make -j4 metabolomics/v2"
+      "search_text": "make Make Please make sure to have [Make](https://www.gnu.org/software/make) installed. make -j4 metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "mamsi-mamsistructsearch",
@@ -117888,79 +117936,79 @@
     {
       "slug": "maplet",
       "name": "maplet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/krumsieklab/maplet",
       "license_spdx": "",
       "evidence_text": "maplet is an R package for statistical data analysis with a special focus on metabolomics datasets.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/maplet.yaml",
-      "search_text": "maplet maplet maplet is an R package for statistical data analysis with a special focus on metabolomics datasets. metabolomics/v2"
+      "search_text": "maplet maplet maplet is an R package for statistical data analysis with a special focus on metabolomics datasets. metabolomics/v2 https://github.com/krumsieklab/maplet"
     },
     {
       "slug": "margherita",
       "name": "margheRita",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/emosca-cnr/margheRita",
       "license_spdx": "",
       "evidence_text": "The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies based on liquid chromatography (LC) coupled with tandem mass spectrometry (MS/MS) The R package margheRita addresses the complete workflow for metabolomic profiling The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/margherita.yaml",
-      "search_text": "margherita margheRita The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies based on liquid chromatography (LC) coupled with tandem mass spectrometry (MS/MS) The R package margheRita addresses the complete workflow for metabolomic profiling The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies metabolomics/v2"
+      "search_text": "margherita margheRita The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies based on liquid chromatography (LC) coupled with tandem mass spectrometry (MS/MS) The R package margheRita addresses the complete workflow for metabolomic profiling The R package margheRita addresses the complete workflow for metabolomic profiling in untargeted studies metabolomics/v2 https://github.com/emosca-cnr/margheRita"
     },
     {
       "slug": "mariadb-10",
       "name": "MariaDB 10",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "Application is developed for Mysql 8 /MariaDB 10",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mariadb-10.yaml",
-      "search_text": "mariadb-10 MariaDB 10 Application is developed for Mysql 8 /MariaDB 10 metabolomics/v2"
+      "search_text": "mariadb-10 MariaDB 10 Application is developed for Mysql 8 /MariaDB 10 metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "marr",
       "name": "marr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Ghoshlab/marr",
       "license_spdx": "",
       "evidence_text": "devtools::install_github(\"Ghoshlab/marr\") marr (Maximum Rank Reproducibility) is a nonparametric approach that detects reproducible signals using a maximal rank statistic for high-dimensional biological data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/marr.yaml",
-      "search_text": "marr marr devtools::install_github(\"Ghoshlab/marr\") marr (Maximum Rank Reproducibility) is a nonparametric approach that detects reproducible signals using a maximal rank statistic for high-dimensional biological data metabolomics/v2"
+      "search_text": "marr marr devtools::install_github(\"Ghoshlab/marr\") marr (Maximum Rank Reproducibility) is a nonparametric approach that detects reproducible signals using a maximal rank statistic for high-dimensional biological data metabolomics/v2 https://github.com/Ghoshlab/marr"
     },
     {
       "slug": "mascot-generic-format-mgf",
       "name": "Mascot Generic Format (mgf)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/beherasan/MS2Compound",
       "license_spdx": "",
       "evidence_text": "Mascot Generic Format (mgf) files can be used as query input file and search against in-built or cusotm database.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mascot-generic-format-mgf.yaml",
-      "search_text": "mascot-generic-format-mgf Mascot Generic Format (mgf) Mascot Generic Format (mgf) files can be used as query input file and search against in-built or cusotm database. metabolomics/v2"
+      "search_text": "mascot-generic-format-mgf Mascot Generic Format (mgf) Mascot Generic Format (mgf) files can be used as query input file and search against in-built or cusotm database. metabolomics/v2 https://github.com/beherasan/MS2Compound"
     },
     {
       "slug": "mass-functions-nn-cluster-by-mz-seeds",
       "name": "mass_functions.nn_cluster_by_mz_seeds",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "nearest neighbor (NN) clustering is performed to establish the number of mass tracks. The NN clustering assigns each data point to its nearest 'peak mz value'.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mass-functions-nn-cluster-by-mz-seeds.yaml",
-      "search_text": "mass-functions-nn-cluster-by-mz-seeds mass_functions.nn_cluster_by_mz_seeds nearest neighbor (NN) clustering is performed to establish the number of mass tracks. The NN clustering assigns each data point to its nearest 'peak mz value'. metabolomics/v2"
+      "search_text": "mass-functions-nn-cluster-by-mz-seeds mass_functions.nn_cluster_by_mz_seeds nearest neighbor (NN) clustering is performed to establish the number of mass tracks. The NN clustering assigns each data point to its nearest 'peak mz value'. metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "mass-query-language-massql",
       "name": "Mass Query Language (MassQL)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biorack/chemecho",
       "license_spdx": "",
       "evidence_text": "The Mass Query Language (MassQL) is a domain specific language used to describe fragmentation patterns",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mass-query-language-massql.yaml",
-      "search_text": "mass-query-language-massql Mass Query Language (MassQL) The Mass Query Language (MassQL) is a domain specific language used to describe fragmentation patterns metabolomics/v2"
+      "search_text": "mass-query-language-massql Mass Query Language (MassQL) The Mass Query Language (MassQL) is a domain specific language used to describe fragmentation patterns metabolomics/v2 https://github.com/biorack/chemecho"
     },
     {
       "slug": "mass2adduct",
@@ -117976,123 +118024,123 @@
     {
       "slug": "mass2chem",
       "name": "mass2chem",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/khipu",
       "license_spdx": "",
       "evidence_text": "Khipu uses our package mass2chem for search functions",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mass2chem.yaml",
-      "search_text": "mass2chem mass2chem Khipu uses our package mass2chem for search functions metabolomics/v2"
+      "search_text": "mass2chem mass2chem Khipu uses our package mass2chem for search functions metabolomics/v2 https://github.com/shuzhao-li-lab/khipu"
     },
     {
       "slug": "massbank-web-validator",
       "name": "MassBank-web Validator",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MassBank/MassBank-data",
       "license_spdx": "",
       "evidence_text": "Validator from MassBank-web",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massbank-web-validator.yaml",
-      "search_text": "massbank-web-validator MassBank-web Validator Validator from MassBank-web metabolomics/v2"
+      "search_text": "massbank-web-validator MassBank-web Validator Validator from MassBank-web metabolomics/v2 https://github.com/MassBank/MassBank-data"
     },
     {
       "slug": "massbank-web",
       "name": "MassBank-web",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MassBank/MassBank-data",
       "license_spdx": "",
       "evidence_text": "Validator from MassBank-web",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massbank-web.yaml",
-      "search_text": "massbank-web MassBank-web Validator from MassBank-web metabolomics/v2"
+      "search_text": "massbank-web MassBank-web Validator from MassBank-web metabolomics/v2 https://github.com/MassBank/MassBank-data"
     },
     {
       "slug": "massbank",
       "name": "MassBank",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/daniellyz/meRgeION2",
       "license_spdx": "",
       "evidence_text": "search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK) MassBank Library Spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massbank.yaml",
-      "search_text": "massbank MassBank search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK) MassBank Library Spectra metabolomics/v2"
+      "search_text": "massbank MassBank search and annotate an unknown spectrum in their local database or public databases (i.e. drug structures in GNPS, MASSBANK and DrugBANK) MassBank Library Spectra metabolomics/v2 https://github.com/daniellyz/meRgeION2"
     },
     {
       "slug": "masscube",
       "name": "masscube",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/huaxuyu/masscube",
       "license_spdx": "",
       "evidence_text": "masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing. masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/masscube.yaml",
-      "search_text": "masscube masscube masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing. masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing metabolomics/v2"
+      "search_text": "masscube masscube masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing. masscube is an integrated Python package for liquid chromatography-mass spectrometry (LC-MS) data processing metabolomics/v2 https://github.com/huaxuyu/masscube"
     },
     {
       "slug": "massdash-loaders-resultsloader",
       "name": "massdash.loaders.ResultsLoader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "ResultsLoader",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash-loaders-resultsloader.yaml",
-      "search_text": "massdash-loaders-resultsloader massdash.loaders.ResultsLoader ResultsLoader metabolomics/v2"
+      "search_text": "massdash-loaders-resultsloader massdash.loaders.ResultsLoader ResultsLoader metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "massdash-peakpickers-mrmtransitiongrouppicker",
       "name": "massdash.peakPickers.MRMTransitionGroupPicker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "MRMTransitionGroupPicker",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash-peakpickers-mrmtransitiongrouppicker.yaml",
-      "search_text": "massdash-peakpickers-mrmtransitiongrouppicker massdash.peakPickers.MRMTransitionGroupPicker MRMTransitionGroupPicker metabolomics/v2"
+      "search_text": "massdash-peakpickers-mrmtransitiongrouppicker massdash.peakPickers.MRMTransitionGroupPicker MRMTransitionGroupPicker metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "massdash-peakpickers-pymrmtransitiongrouppicker",
       "name": "massdash.peakPickers.pyMRMTransitionGroupPicker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "pyMRMTransitionGroupPicker",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash-peakpickers-pymrmtransitiongrouppicker.yaml",
-      "search_text": "massdash-peakpickers-pymrmtransitiongrouppicker massdash.peakPickers.pyMRMTransitionGroupPicker pyMRMTransitionGroupPicker metabolomics/v2"
+      "search_text": "massdash-peakpickers-pymrmtransitiongrouppicker massdash.peakPickers.pyMRMTransitionGroupPicker pyMRMTransitionGroupPicker metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "massdash-plotting-interactiveplotter",
       "name": "massdash.plotting.InteractivePlotter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "InteractivePlotter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash-plotting-interactiveplotter.yaml",
-      "search_text": "massdash-plotting-interactiveplotter massdash.plotting.InteractivePlotter InteractivePlotter metabolomics/v2"
+      "search_text": "massdash-plotting-interactiveplotter massdash.plotting.InteractivePlotter InteractivePlotter metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "massdash-structs-featuremap",
       "name": "massdash.structs.FeatureMap",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "FeatureMap",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash-structs-featuremap.yaml",
-      "search_text": "massdash-structs-featuremap massdash.structs.FeatureMap FeatureMap metabolomics/v2"
+      "search_text": "massdash-structs-featuremap massdash.structs.FeatureMap FeatureMap metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "massdash",
       "name": "MassDash",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "MassDash is a modular and flexible python package that has a streamlit graphical user interface (GUI) :mod:`massdash.loaders`: Classes for loading data MassDash is a modular and flexible python package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massdash.yaml",
-      "search_text": "massdash MassDash MassDash is a modular and flexible python package that has a streamlit graphical user interface (GUI) :mod:`massdash.loaders`: Classes for loading data MassDash is a modular and flexible python package metabolomics/v2"
+      "search_text": "massdash MassDash MassDash is a modular and flexible python package that has a streamlit graphical user interface (GUI) :mod:`massdash.loaders`: Classes for loading data MassDash is a modular and flexible python package metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "masshunter-profinder",
@@ -118108,112 +118156,112 @@
     {
       "slug": "massive",
       "name": "MassIVE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/ReDU-MS2-Documentation",
       "license_spdx": "",
       "evidence_text": "ReDU only interacts with MassIVE data uploaded to MassIVE as a public dataset",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massive.yaml",
-      "search_text": "massive MassIVE ReDU only interacts with MassIVE data uploaded to MassIVE as a public dataset metabolomics/v2"
+      "search_text": "massive MassIVE ReDU only interacts with MassIVE data uploaded to MassIVE as a public dataset metabolomics/v2 https://github.com/mwang87/ReDU-MS2-Documentation"
     },
     {
       "slug": "massql",
       "name": "MassQL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JohnsonDylan/MassQLab",
       "license_spdx": "",
       "evidence_text": "The Mass Spec Query Language (MassQL) is a domain specific language meant to be a succinct way to express a query in a mass spectrometry centric fashion. MassQLab applies a series of queries (written in the language of MassQL) Integration with MassQL-searchable MotifDB",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massql.yaml",
-      "search_text": "massql MassQL The Mass Spec Query Language (MassQL) is a domain specific language meant to be a succinct way to express a query in a mass spectrometry centric fashion. MassQLab applies a series of queries (written in the language of MassQL) Integration with MassQL-searchable MotifDB metabolomics/v2"
+      "search_text": "massql MassQL The Mass Spec Query Language (MassQL) is a domain specific language meant to be a succinct way to express a query in a mass spectrometry centric fashion. MassQLab applies a series of queries (written in the language of MassQL) Integration with MassQL-searchable MotifDB metabolomics/v2 https://github.com/JohnsonDylan/MassQLab"
     },
     {
       "slug": "massqlab",
       "name": "MassQLab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JohnsonDylan/MassQLab",
       "license_spdx": "",
       "evidence_text": "github.com__JohnsonDylan__MassQLab",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massqlab.yaml",
-      "search_text": "massqlab MassQLab github.com__JohnsonDylan__MassQLab metabolomics/v2"
+      "search_text": "massqlab MassQLab github.com__JohnsonDylan__MassQLab metabolomics/v2 https://github.com/JohnsonDylan/MassQLab"
     },
     {
       "slug": "massspecwavelet",
       "name": "MassSpecWavelet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sneumann/xcms",
       "license_spdx": "",
       "evidence_text": "`r Biocpkg(\"xcms\")` uses functionality from the *MassSpecWavelet* package to identify such peaks",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/massspecwavelet.yaml",
-      "search_text": "massspecwavelet MassSpecWavelet `r Biocpkg(\"xcms\")` uses functionality from the *MassSpecWavelet* package to identify such peaks metabolomics/v2"
+      "search_text": "massspecwavelet MassSpecWavelet `r Biocpkg(\"xcms\")` uses functionality from the *MassSpecWavelet* package to identify such peaks metabolomics/v2 https://github.com/sneumann/xcms"
     },
     {
       "slug": "masst",
       "name": "MASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mohimanilab/MASSTplus",
       "license_spdx": "",
       "evidence_text": "MASST+ is an improvement on GNPS Mass Spectrometry Search Tool (MASST) MASST+ is an improvement on GNPS Mass Spectrometry Search Tool",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/masst.yaml",
-      "search_text": "masst MASST MASST+ is an improvement on GNPS Mass Spectrometry Search Tool (MASST) MASST+ is an improvement on GNPS Mass Spectrometry Search Tool metabolomics/v2"
+      "search_text": "masst MASST MASST+ is an improvement on GNPS Mass Spectrometry Search Tool (MASST) MASST+ is an improvement on GNPS Mass Spectrometry Search Tool metabolomics/v2 https://github.com/mohimanilab/MASSTplus"
     },
     {
       "slug": "matchms",
       "name": "matchms",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/matchms/MS2DeepScore",
       "license_spdx": "",
       "evidence_text": "the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] (https://github.com/matchms/matchms) the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] - [matchms](https://matchms.readthedocs.io/en/latest/) Matchms offers an array of tools for metadata cleaning and validation Matchms is a versatile open-source Python package developed for importing, processing, cleaning, and comparing mass spectrometry data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/matchms.yaml",
-      "search_text": "matchms matchms the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] (https://github.com/matchms/matchms) the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] - [matchms](https://matchms.readthedocs.io/en/latest/) Matchms offers an array of tools for metadata cleaning and validation Matchms is a versatile open-source Python package developed for importing, processing, cleaning, and comparing mass spectrometry data metabolomics/v2"
+      "search_text": "matchms matchms the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] (https://github.com/matchms/matchms) the implementations for the cosine score and the modified cosine score used can be found in the Python package matchms [31] - [matchms](https://matchms.readthedocs.io/en/latest/) Matchms offers an array of tools for metadata cleaning and validation Matchms is a versatile open-source Python package developed for importing, processing, cleaning, and comparing mass spectrometry data metabolomics/v2 https://github.com/matchms/MS2DeepScore"
     },
     {
       "slug": "math-distance",
       "name": "math_distance",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuanyueLi/SpectralEntropy",
       "license_spdx": "",
       "evidence_text": ".. automodule:: math_distance :members:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/math-distance.yaml",
-      "search_text": "math-distance math_distance .. automodule:: math_distance :members: metabolomics/v2"
+      "search_text": "math-distance math_distance .. automodule:: math_distance :members: metabolomics/v2 https://github.com/YuanyueLi/SpectralEntropy"
     },
     {
       "slug": "matlab-compiler-runtime-8-3",
       "name": "MATLAB Compiler Runtime 8.3",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Viant-Metabolomics/Galaxy-M",
       "license_spdx": "",
       "evidence_text": "[MATLAB Compiler Runtime (MCR) (version 8.3)]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/matlab-compiler-runtime-8-3.yaml",
-      "search_text": "matlab-compiler-runtime-8-3 MATLAB Compiler Runtime 8.3 [MATLAB Compiler Runtime (MCR) (version 8.3)] metabolomics/v2"
+      "search_text": "matlab-compiler-runtime-8-3 MATLAB Compiler Runtime 8.3 [MATLAB Compiler Runtime (MCR) (version 8.3)] metabolomics/v2 https://github.com/Viant-Metabolomics/Galaxy-M"
     },
     {
       "slug": "matlab-r2024a",
       "name": "MATLAB R2024a",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "MATLAB R2024a or newer",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/matlab-r2024a.yaml",
-      "search_text": "matlab-r2024a MATLAB R2024a MATLAB R2024a or newer metabolomics/v2"
+      "search_text": "matlab-r2024a MATLAB R2024a MATLAB R2024a or newer metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "matlab",
       "name": "Matlab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/KechrisLab/DisCoPad",
       "license_spdx": "",
       "evidence_text": "cdf files and available Matlab workspaces are provided example R and MATLAB codes (for one data sub-sample scenario) used for the simulation Matlab package to match untargeted metabolomic features",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/matlab.yaml",
-      "search_text": "matlab Matlab cdf files and available Matlab workspaces are provided example R and MATLAB codes (for one data sub-sample scenario) used for the simulation Matlab package to match untargeted metabolomic features metabolomics/v2"
+      "search_text": "matlab Matlab cdf files and available Matlab workspaces are provided example R and MATLAB codes (for one data sub-sample scenario) used for the simulation Matlab package to match untargeted metabolomic features metabolomics/v2 https://github.com/KechrisLab/DisCoPad"
     },
     {
       "slug": "matplotlib-or-seaborn-for-visualization",
@@ -118229,35 +118277,35 @@
     {
       "slug": "matplotlib",
       "name": "matplotlib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mzapy",
       "license_spdx": "",
       "evidence_text": "streamline various tasks such as data parsing, matching, statistical analysis, and visualization from matplotlib import pyplot For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries matplotlib==3.1.3 from matplotlib import pyplot as plt Dependencies: matplotlib",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/matplotlib.yaml",
-      "search_text": "matplotlib matplotlib streamline various tasks such as data parsing, matching, statistical analysis, and visualization from matplotlib import pyplot For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries matplotlib==3.1.3 from matplotlib import pyplot as plt Dependencies: matplotlib metabolomics/v2"
+      "search_text": "matplotlib matplotlib streamline various tasks such as data parsing, matching, statistical analysis, and visualization from matplotlib import pyplot For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries matplotlib==3.1.3 from matplotlib import pyplot as plt Dependencies: matplotlib metabolomics/v2 https://github.com/PNNL-m-q/mzapy"
     },
     {
       "slug": "maven-gui",
       "name": "Maven GUI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Maven GUI: Metabolomics Analysis and Visualization Engine",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/maven-gui.yaml",
-      "search_text": "maven-gui Maven GUI Maven GUI: Metabolomics Analysis and Visualization Engine metabolomics/v2"
+      "search_text": "maven-gui Maven GUI Maven GUI: Metabolomics Analysis and Visualization Engine metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "maxquant",
       "name": "MaxQuant",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fgcz/rawrr",
       "license_spdx": "",
       "evidence_text": "In the academic environment, MaxQuant and Skyline are by far the most popular ones. In the academic environment, [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline] ... are by far the most popular ones.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/maxquant.yaml",
-      "search_text": "maxquant MaxQuant In the academic environment, MaxQuant and Skyline are by far the most popular ones. In the academic environment, [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline] ... are by far the most popular ones. metabolomics/v2"
+      "search_text": "maxquant MaxQuant In the academic environment, MaxQuant and Skyline are by far the most popular ones. In the academic environment, [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline] ... are by far the most popular ones. metabolomics/v2 https://github.com/fgcz/rawrr"
     },
     {
       "slug": "mbpls",
@@ -118273,24 +118321,24 @@
     {
       "slug": "mcfnmr",
       "name": "mcfNMR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GeoMetabolomics-ICBM/mcfNMR",
       "license_spdx": "",
       "evidence_text": "mcfNMR is a tool for recovering constituent compounds from an NMR spectrum",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mcfnmr.yaml",
-      "search_text": "mcfnmr mcfNMR mcfNMR is a tool for recovering constituent compounds from an NMR spectrum metabolomics/v2"
+      "search_text": "mcfnmr mcfNMR mcfNMR is a tool for recovering constituent compounds from an NMR spectrum metabolomics/v2 https://github.com/GeoMetabolomics-ICBM/mcfNMR"
     },
     {
       "slug": "meister",
       "name": "MEISTER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/richardxie1119/MEISTER",
       "license_spdx": "",
       "evidence_text": "github.com/richardxie1119/MEISTER",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/meister.yaml",
-      "search_text": "meister MEISTER github.com/richardxie1119/MEISTER metabolomics/v2"
+      "search_text": "meister MEISTER github.com/richardxie1119/MEISTER metabolomics/v2 https://github.com/richardxie1119/MEISTER"
     },
     {
       "slug": "melonnpan-elastic-net-linear-regression",
@@ -118328,24 +118376,24 @@
     {
       "slug": "memo",
       "name": "MEMO",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "Similarity Component (SC): a score considering the spectral dissimilarity of the samples within the set **M**\\ s2 bas\\ **E**\\ d sa\\ **M**\\ ple vect\\ **O**\\ rization (**MEMO**) is a method allowing a Retention Time (RT) agnostic alignment",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/memo.yaml",
-      "search_text": "memo MEMO Similarity Component (SC): a score considering the spectral dissimilarity of the samples within the set **M**\\ s2 bas\\ **E**\\ d sa\\ **M**\\ ple vect\\ **O**\\ rization (**MEMO**) is a method allowing a Retention Time (RT) agnostic alignment metabolomics/v2"
+      "search_text": "memo MEMO Similarity Component (SC): a score considering the spectral dissimilarity of the samples within the set **M**\\ s2 bas\\ **E**\\ d sa\\ **M**\\ ple vect\\ **O**\\ rization (**MEMO**) is a method allowing a Retention Time (RT) agnostic alignment metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "mergeion2",
       "name": "meRgeION2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/daniellyz/meRgeION2",
       "license_spdx": "",
       "evidence_text": "github.com__daniellyz__meRgeION2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mergeion2.yaml",
-      "search_text": "mergeion2 meRgeION2 github.com__daniellyz__meRgeION2 metabolomics/v2"
+      "search_text": "mergeion2 meRgeION2 github.com__daniellyz__meRgeION2 metabolomics/v2 https://github.com/daniellyz/meRgeION2"
     },
     {
       "slug": "messes",
@@ -118361,35 +118409,35 @@
     {
       "slug": "metabcombiner",
       "name": "metabCombiner",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/hhabra/metabCombiner",
       "license_spdx": "",
       "evidence_text": "Combine LC-MS Metabolomics Datasets with metabCombiner",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabcombiner.yaml",
-      "search_text": "metabcombiner metabCombiner Combine LC-MS Metabolomics Datasets with metabCombiner metabolomics/v2"
+      "search_text": "metabcombiner metabCombiner Combine LC-MS Metabolomics Datasets with metabCombiner metabolomics/v2 https://github.com/hhabra/metabCombiner"
     },
     {
       "slug": "metaboanalyst",
       "name": "MetaboAnalyst",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/13479776/statTarget",
       "license_spdx": "",
       "evidence_text": "web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29] web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29], and DropMS [30] head to <a href='https://www.metaboanalyst.ca/MetaboAnalyst/upload/ConvertView.xhtml' target='_blank'>MetaboAnalyst</a> for the ID conversion transition from MetaboAnalyst to Jacobian analysis MInfer represents a novel computational framework that effectively facilitates the transition from MetaboAnalyst to Jacobian analysis Outputs are intended to be immediately usable for downstream analysis (e.g. MetaboAnalyst or common tools in R, Python etc.).",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaboanalyst.yaml",
-      "search_text": "metaboanalyst MetaboAnalyst web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29] web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29], and DropMS [30] head to <a href='https://www.metaboanalyst.ca/MetaboAnalyst/upload/ConvertView.xhtml' target='_blank'>MetaboAnalyst</a> for the ID conversion transition from MetaboAnalyst to Jacobian analysis MInfer represents a novel computational framework that effectively facilitates the transition from MetaboAnalyst to Jacobian analysis Outputs are intended to be immediately usable for downstream analysis (e.g. MetaboAnalyst or common tools in R, Python etc.). metabolomics/v2"
+      "search_text": "metaboanalyst MetaboAnalyst web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29] web-based applications such as UltraMassExplorer (UME) [27], FREDA [28], MetaboAnalyst [29], and DropMS [30] head to <a href='https://www.metaboanalyst.ca/MetaboAnalyst/upload/ConvertView.xhtml' target='_blank'>MetaboAnalyst</a> for the ID conversion transition from MetaboAnalyst to Jacobian analysis MInfer represents a novel computational framework that effectively facilitates the transition from MetaboAnalyst to Jacobian analysis Outputs are intended to be immediately usable for downstream analysis (e.g. MetaboAnalyst or common tools in R, Python etc.). metabolomics/v2 https://github.com/13479776/statTarget"
     },
     {
       "slug": "metaboanalystr",
       "name": "MetaboAnalystR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/xia-lab/MetaboAnalystR",
       "license_spdx": "",
       "evidence_text": "MetaboAnalystR 4.0: a unified LC-MS workflow for global metabolomics",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaboanalystr.yaml",
-      "search_text": "metaboanalystr MetaboAnalystR MetaboAnalystR 4.0: a unified LC-MS workflow for global metabolomics metabolomics/v2"
+      "search_text": "metaboanalystr MetaboAnalystR MetaboAnalystR 4.0: a unified LC-MS workflow for global metabolomics metabolomics/v2 https://github.com/xia-lab/MetaboAnalystR"
     },
     {
       "slug": "metaboannotator",
@@ -118405,24 +118453,24 @@
     {
       "slug": "metabocoreutils",
       "name": "MetaboCoreUtils",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LiesaSalzer/MobilityTransformR",
       "license_spdx": "",
       "evidence_text": "The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MetaboCoreUtils\")` %\\VignetteDepends{xcms,MsDataHub,BiocStyle,pander,Spectra,MsBackendMgf,MetaboCoreUtils}",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabocoreutils.yaml",
-      "search_text": "metabocoreutils MetaboCoreUtils The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MetaboCoreUtils\")` %\\VignetteDepends{xcms,MsDataHub,BiocStyle,pander,Spectra,MsBackendMgf,MetaboCoreUtils} metabolomics/v2"
+      "search_text": "metabocoreutils MetaboCoreUtils The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MetaboCoreUtils\")` %\\VignetteDepends{xcms,MsDataHub,BiocStyle,pander,Spectra,MsBackendMgf,MetaboCoreUtils} metabolomics/v2 https://github.com/LiesaSalzer/MobilityTransformR"
     },
     {
       "slug": "metabodiff",
       "name": "MetaboDiff",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/andreasmock/MetaboDiff",
       "license_spdx": "",
       "evidence_text": "`MetaboDiff` is available for all operating systems and can be installed via Github met = knn_impute(met,cutoff=0.4) library(\"MetaboDiff\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabodiff.yaml",
-      "search_text": "metabodiff MetaboDiff `MetaboDiff` is available for all operating systems and can be installed via Github met = knn_impute(met,cutoff=0.4) library(\"MetaboDiff\") metabolomics/v2"
+      "search_text": "metabodiff MetaboDiff `MetaboDiff` is available for all operating systems and can be installed via Github met = knn_impute(met,cutoff=0.4) library(\"MetaboDiff\") metabolomics/v2 https://github.com/andreasmock/MetaboDiff"
     },
     {
       "slug": "metabodirect",
@@ -118438,310 +118486,310 @@
     {
       "slug": "metabolabpy",
       "name": "metabolabpy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ludwigc/metabolabpy",
       "license_spdx": "",
       "evidence_text": "github.com__ludwigc__metabolabpy",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabolabpy.yaml",
-      "search_text": "metabolabpy metabolabpy github.com__ludwigc__metabolabpy metabolomics/v2"
+      "search_text": "metabolabpy metabolabpy github.com__ludwigc__metabolabpy metabolomics/v2 https://github.com/ludwigc/metabolabpy"
     },
     {
       "slug": "metabolights",
       "name": "MetaboLights",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "MetaboLights Dataset Spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabolights.yaml",
-      "search_text": "metabolights MetaboLights MetaboLights Dataset Spectra metabolomics/v2"
+      "search_text": "metabolights MetaboLights MetaboLights Dataset Spectra metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "metabolomics-workbench-api",
       "name": "Metabolomics Workbench API",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ahmohamed/lipidr",
       "license_spdx": "",
       "evidence_text": "Through integration with Metabolomics Workbench API, `lipidr` allows users, to quickly explore public lipidomics experiments.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabolomics-workbench-api.yaml",
-      "search_text": "metabolomics-workbench-api Metabolomics Workbench API Through integration with Metabolomics Workbench API, `lipidr` allows users, to quickly explore public lipidomics experiments. metabolomics/v2"
+      "search_text": "metabolomics-workbench-api Metabolomics Workbench API Through integration with Metabolomics Workbench API, `lipidr` allows users, to quickly explore public lipidomics experiments. metabolomics/v2 https://github.com/ahmohamed/lipidr"
     },
     {
       "slug": "metabolomics-workbench",
       "name": "Metabolomics Workbench",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "Metabolomics Workbench Dataset Spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metabolomics-workbench.yaml",
-      "search_text": "metabolomics-workbench Metabolomics Workbench Metabolomics Workbench Dataset Spectra metabolomics/v2"
+      "search_text": "metabolomics-workbench Metabolomics Workbench Metabolomics Workbench Dataset Spectra metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "metaboprep",
       "name": "metaboprep",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MRCIEU/metaboprep",
       "license_spdx": "",
       "evidence_text": "library(metaboprep) quality_control(m, source_layer = \"input\", sample_missingness = 0.2, feature_missingness = 0.2) pc_analysis <- pc_and_outliers(metaboprep = mydata,",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaboprep.yaml",
-      "search_text": "metaboprep metaboprep library(metaboprep) quality_control(m, source_layer = \"input\", sample_missingness = 0.2, feature_missingness = 0.2) pc_analysis <- pc_and_outliers(metaboprep = mydata, metabolomics/v2"
+      "search_text": "metaboprep metaboprep library(metaboprep) quality_control(m, source_layer = \"input\", sample_missingness = 0.2, feature_missingness = 0.2) pc_analysis <- pc_and_outliers(metaboprep = mydata, metabolomics/v2 https://github.com/MRCIEU/metaboprep"
     },
     {
       "slug": "metaboshiny",
       "name": "MetaboShiny",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/joannawolthuis/MetaboShiny",
       "license_spdx": "",
       "evidence_text": "Welcome to the info page on MetaboShiny Welcome to the info page on MetaboShiny! We are currently on BioRXiv Settings - Global, Project, Search, Adducts, Formula prediction and lookup",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaboshiny.yaml",
-      "search_text": "metaboshiny MetaboShiny Welcome to the info page on MetaboShiny Welcome to the info page on MetaboShiny! We are currently on BioRXiv Settings - Global, Project, Search, Adducts, Formula prediction and lookup metabolomics/v2"
+      "search_text": "metaboshiny MetaboShiny Welcome to the info page on MetaboShiny Welcome to the info page on MetaboShiny! We are currently on BioRXiv Settings - Global, Project, Search, Adducts, Formula prediction and lookup metabolomics/v2 https://github.com/joannawolthuis/MetaboShiny"
     },
     {
       "slug": "metaclean",
       "name": "MetaClean",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/KelseyChetnik/MetaClean",
       "license_spdx": "",
       "evidence_text": "MetaClean is a package for building classifiers to identify low quality integrations in untargeted metabolomics data. `MetaClean` provides 8 classification algorithms (implemented with the R package `caret`) for building a predictive model. the user can optionally filter out EICs by RSD % using the rsdFilter() function.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaclean.yaml",
-      "search_text": "metaclean MetaClean MetaClean is a package for building classifiers to identify low quality integrations in untargeted metabolomics data. `MetaClean` provides 8 classification algorithms (implemented with the R package `caret`) for building a predictive model. the user can optionally filter out EICs by RSD % using the rsdFilter() function. metabolomics/v2"
+      "search_text": "metaclean MetaClean MetaClean is a package for building classifiers to identify low quality integrations in untargeted metabolomics data. `MetaClean` provides 8 classification algorithms (implemented with the R package `caret`) for building a predictive model. the user can optionally filter out EICs by RSD % using the rsdFilter() function. metabolomics/v2 https://github.com/KelseyChetnik/MetaClean"
     },
     {
       "slug": "metadatamasst",
       "name": "metadataMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "Aggregated search outputs can be generated and visualized using metadataMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metadatamasst.yaml",
-      "search_text": "metadatamasst metadataMASST Aggregated search outputs can be generated and visualized using metadataMASST metabolomics/v2"
+      "search_text": "metadatamasst metadataMASST Aggregated search outputs can be generated and visualized using metadataMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "metamapr",
       "name": "MetaMapR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/dgrapov/MetaMapR",
       "license_spdx": "",
       "evidence_text": "MetaMapR - A metabolomic network mapping tool",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metamapr.yaml",
-      "search_text": "metamapr MetaMapR MetaMapR - A metabolomic network mapping tool metabolomics/v2"
+      "search_text": "metamapr MetaMapR MetaMapR - A metabolomic network mapping tool metabolomics/v2 https://github.com/dgrapov/MetaMapR"
     },
     {
       "slug": "metaminer",
       "name": "MetaMiner",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel RiPPs MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel Ribosmally synthesized and Post-translationally modified Peptides (RiPPs) MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaminer.yaml",
-      "search_text": "metaminer MetaMiner MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel RiPPs MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel Ribosmally synthesized and Post-translationally modified Peptides (RiPPs) MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data metabolomics/v2"
+      "search_text": "metaminer MetaMiner MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel RiPPs MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data to identify novel Ribosmally synthesized and Post-translationally modified Peptides (RiPPs) MetaMiner is a metabologenomic pipeline which integrates metabolomic (tandem mass spectra) and genomic data metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "metams",
       "name": "metaMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/DaDIA",
       "license_spdx": "",
       "evidence_text": "metaMS Version 1.25.1",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metams.yaml",
-      "search_text": "metams metaMS metaMS Version 1.25.1 metabolomics/v2"
+      "search_text": "metams metaMS metaMS Version 1.25.1 metabolomics/v2 https://github.com/HuanLab/DaDIA"
     },
     {
       "slug": "metanet",
       "name": "MetaNet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Asa12138/MetaNet",
       "license_spdx": "",
       "evidence_text": "MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers. MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metanet.yaml",
-      "search_text": "metanet MetaNet MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers. MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers metabolomics/v2"
+      "search_text": "metanet MetaNet MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers. MetaNet, a high-performance R package that unifies network construction, visualization, and analysis across diverse omics layers metabolomics/v2 https://github.com/Asa12138/MetaNet"
     },
     {
       "slug": "metanorm-r-package",
       "name": "Metanorm R package",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/UGent-LIMET/Metanorm",
       "license_spdx": "",
       "evidence_text": "The R package implements three (new) robust normalization methods (tGAM, rGAM and rLOESS)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metanorm-r-package.yaml",
-      "search_text": "metanorm-r-package Metanorm R package The R package implements three (new) robust normalization methods (tGAM, rGAM and rLOESS) metabolomics/v2"
+      "search_text": "metanorm-r-package Metanorm R package The R package implements three (new) robust normalization methods (tGAM, rGAM and rLOESS) metabolomics/v2 https://github.com/UGent-LIMET/Metanorm"
     },
     {
       "slug": "metanorm",
       "name": "Metanorm",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/UGent-LIMET/Metanorm",
       "license_spdx": "",
       "evidence_text": "Metanorm supports robust metabolomics data normalization across scales and experimental designs",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metanorm.yaml",
-      "search_text": "metanorm Metanorm Metanorm supports robust metabolomics data normalization across scales and experimental designs metabolomics/v2"
+      "search_text": "metanorm Metanorm Metanorm supports robust metabolomics data normalization across scales and experimental designs metabolomics/v2 https://github.com/UGent-LIMET/Metanorm"
     },
     {
       "slug": "metaxtract",
       "name": "MetaXtract",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Rappsilber-Laboratory/MetaXtract",
       "license_spdx": "",
       "evidence_text": "MetaXtract is a hybrid tool for extracting, analysing, and visualising data from **Thermo Fisher RAW** mass spectrometry files.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metaxtract.yaml",
-      "search_text": "metaxtract MetaXtract MetaXtract is a hybrid tool for extracting, analysing, and visualising data from **Thermo Fisher RAW** mass spectrometry files. metabolomics/v2"
+      "search_text": "metaxtract MetaXtract MetaXtract is a hybrid tool for extracting, analysing, and visualising data from **Thermo Fisher RAW** mass spectrometry files. metabolomics/v2 https://github.com/Rappsilber-Laboratory/MetaXtract"
     },
     {
       "slug": "metcohort",
       "name": "MetCohort",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JunYang2021/MetCohort",
       "license_spdx": "",
       "evidence_text": "MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool for large-scale metabolomics and exposomics MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metcohort.yaml",
-      "search_text": "metcohort MetCohort MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool for large-scale metabolomics and exposomics MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool metabolomics/v2"
+      "search_text": "metcohort MetCohort MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool for large-scale metabolomics and exposomics MetCohort is an untargeted liquid chromatography-mass spectrometry (LC-MS) data processing tool metabolomics/v2 https://github.com/JunYang2021/MetCohort"
     },
     {
       "slug": "metcorr",
       "name": "MetCorR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/plyush1993/OUKS",
       "license_spdx": "",
       "evidence_text": "New QC-GAM method (MetCorR) with associated scripts were introduced.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metcorr.yaml",
-      "search_text": "metcorr MetCorR New QC-GAM method (MetCorR) with associated scripts were introduced. metabolomics/v2"
+      "search_text": "metcorr MetCorR New QC-GAM method (MetCorR) with associated scripts were introduced. metabolomics/v2 https://github.com/plyush1993/OUKS"
     },
     {
       "slug": "metdatamodel",
       "name": "metDataModel",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/khipu",
       "license_spdx": "",
       "evidence_text": "The data model of “empirical compound” is described in the metDataModel package.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metdatamodel.yaml",
-      "search_text": "metdatamodel metDataModel The data model of “empirical compound” is described in the metDataModel package. metabolomics/v2"
+      "search_text": "metdatamodel metDataModel The data model of “empirical compound” is described in the metDataModel package. metabolomics/v2 https://github.com/shuzhao-li-lab/khipu"
     },
     {
       "slug": "metdna2-r-package",
       "name": "MetDNA2 R package",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ZhuMetLab/MetDNA2",
       "license_spdx": "",
       "evidence_text": "library(MetDNA2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metdna2-r-package.yaml",
-      "search_text": "metdna2-r-package MetDNA2 R package library(MetDNA2) metabolomics/v2"
+      "search_text": "metdna2-r-package MetDNA2 R package library(MetDNA2) metabolomics/v2 https://github.com/ZhuMetLab/MetDNA2"
     },
     {
       "slug": "meteor",
       "name": "MeTEor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/scibiome/meteor",
       "license_spdx": "",
       "evidence_text": "library(MeTEor) You can perform binary classification using three different algorithms: logistic regression (LR), random forest (RF), and XGBoost (XGB).",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/meteor.yaml",
-      "search_text": "meteor MeTEor library(MeTEor) You can perform binary classification using three different algorithms: logistic regression (LR), random forest (RF), and XGBoost (XGB). metabolomics/v2"
+      "search_text": "meteor MeTEor library(MeTEor) You can perform binary classification using three different algorithms: logistic regression (LR), random forest (RF), and XGBoost (XGB). metabolomics/v2 https://github.com/scibiome/meteor"
     },
     {
       "slug": "metfrag",
       "name": "metFrag",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FrigerioGianfranco/GetFeatistics",
       "license_spdx": "",
       "evidence_text": "such as metFrag for example, check it out: https://github.com/rickhelmus/patRoon compound database dereplication using SIRIUS OR MetFrag This container packages the MetFrag (https://github.com/ipb-halle/MetFragRelaunched) webapp convertToMFDB | Generates a [MetFrag] database for all TPs (and optionally parents, only for TPs with structural information) Generates a [MetFrag] database for all TPs if MetFrag analysis is enabled, a comprehensive summary of all entries can be generated using the corresponding export option.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metfrag.yaml",
-      "search_text": "metfrag metFrag such as metFrag for example, check it out: https://github.com/rickhelmus/patRoon compound database dereplication using SIRIUS OR MetFrag This container packages the MetFrag (https://github.com/ipb-halle/MetFragRelaunched) webapp convertToMFDB | Generates a [MetFrag] database for all TPs (and optionally parents, only for TPs with structural information) Generates a [MetFrag] database for all TPs if MetFrag analysis is enabled, a comprehensive summary of all entries can be generated using the corresponding export option. metabolomics/v2"
+      "search_text": "metfrag metFrag such as metFrag for example, check it out: https://github.com/rickhelmus/patRoon compound database dereplication using SIRIUS OR MetFrag This container packages the MetFrag (https://github.com/ipb-halle/MetFragRelaunched) webapp convertToMFDB | Generates a [MetFrag] database for all TPs (and optionally parents, only for TPs with structural information) Generates a [MetFrag] database for all TPs if MetFrag analysis is enabled, a comprehensive summary of all entries can be generated using the corresponding export option. metabolomics/v2 https://github.com/FrigerioGianfranco/GetFeatistics"
     },
     {
       "slug": "metnet",
       "name": "MetNet",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/simeoni-biolab/MetNet",
       "license_spdx": "",
       "evidence_text": "MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network of two organisms selected in KEGG MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metnet.yaml",
-      "search_text": "metnet MetNet MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network of two organisms selected in KEGG MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network metabolomics/v2"
+      "search_text": "metnet MetNet MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network of two organisms selected in KEGG MetNet is a Java tool that makes it possible to automatically reconstruct the metabolic network metabolomics/v2 https://github.com/simeoni-biolab/MetNet"
     },
     {
       "slug": "metscriber",
       "name": "metScribeR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ncats/metScribeR",
       "license_spdx": "",
       "evidence_text": "This package provides an automated workflow for processing in-house metabolite library standards data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/metscriber.yaml",
-      "search_text": "metscriber metScribeR This package provides an automated workflow for processing in-house metabolite library standards data metabolomics/v2"
+      "search_text": "metscriber metScribeR This package provides an automated workflow for processing in-house metabolite library standards data metabolomics/v2 https://github.com/ncats/metScribeR"
     },
     {
       "slug": "mgcv",
       "name": "mgcv",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/hhabra/metabCombiner",
       "license_spdx": "",
       "evidence_text": "a modified form of the `gam` function implemented in the *mgcv* R package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mgcv.yaml",
-      "search_text": "mgcv mgcv a modified form of the `gam` function implemented in the *mgcv* R package metabolomics/v2"
+      "search_text": "mgcv mgcv a modified form of the `gam` function implemented in the *mgcv* R package metabolomics/v2 https://github.com/hhabra/metabCombiner"
     },
     {
       "slug": "mibig",
       "name": "MIBiG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "To assign one or more molecular structures to BGCs, according to how many high-scoring matches are found in MIBiG Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit established homology to a particular MIBiG BGC mibig directory contains the MIBiG metadata antiSMASH to score the correspondence between the MIBiG entries and the detected BGCs the MIBiG database [32] has emerged as a central repository of characterised microbial BGCs",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mibig.yaml",
-      "search_text": "mibig MIBiG To assign one or more molecular structures to BGCs, according to how many high-scoring matches are found in MIBiG Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit established homology to a particular MIBiG BGC mibig directory contains the MIBiG metadata antiSMASH to score the correspondence between the MIBiG entries and the detected BGCs the MIBiG database [32] has emerged as a central repository of characterised microbial BGCs metabolomics/v2"
+      "search_text": "mibig MIBiG To assign one or more molecular structures to BGCs, according to how many high-scoring matches are found in MIBiG Molecular fingerprints are extracted from SMILES strings using the Chemistry Development Kit established homology to a particular MIBiG BGC mibig directory contains the MIBiG metadata antiSMASH to score the correspondence between the MIBiG entries and the detected BGCs the MIBiG database [32] has emerged as a central repository of characterised microbial BGCs metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "microbemasst",
       "name": "microbeMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/microbemasst.yaml",
-      "search_text": "microbemasst microbeMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2"
+      "search_text": "microbemasst microbeMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "microbiomemasst",
       "name": "microbiomeMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/microbiomemasst.yaml",
-      "search_text": "microbiomemasst microbiomeMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2"
+      "search_text": "microbiomemasst microbiomeMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "microsoft-visual-c-runtime-x64",
       "name": "Microsoft Visual C++ Runtime x64",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor",
       "license_spdx": "",
       "evidence_text": "Microsoft Visual C++ Runtime x64 (may already be installed, if the program doesn't work then you can download vcredist_x64.exe",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/microsoft-visual-c-runtime-x64.yaml",
-      "search_text": "microsoft-visual-c-runtime-x64 Microsoft Visual C++ Runtime x64 Microsoft Visual C++ Runtime x64 (may already be installed, if the program doesn't work then you can download vcredist_x64.exe metabolomics/v2"
+      "search_text": "microsoft-visual-c-runtime-x64 Microsoft Visual C++ Runtime x64 Microsoft Visual C++ Runtime x64 (may already be installed, if the program doesn't work then you can download vcredist_x64.exe metabolomics/v2 https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
     },
     {
       "slug": "mimenet",
@@ -118757,13 +118805,13 @@
     {
       "slug": "mimir",
       "name": "MiMIR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DanieleBizzarri/MiMIR",
       "license_spdx": "",
       "evidence_text": "github.com/DanieleBizzarri/MiMIR",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mimir.yaml",
-      "search_text": "mimir MiMIR github.com/DanieleBizzarri/MiMIR metabolomics/v2"
+      "search_text": "mimir MiMIR github.com/DanieleBizzarri/MiMIR metabolomics/v2 https://github.com/DanieleBizzarri/MiMIR"
     },
     {
       "slug": "minems2",
@@ -118779,46 +118827,46 @@
     {
       "slug": "minfer",
       "name": "MInfer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/cellbiomaths/MInfer",
       "license_spdx": "",
       "evidence_text": "MInfer is an R package designed for analyzing metabolomics data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/minfer.yaml",
-      "search_text": "minfer MInfer MInfer is an R package designed for analyzing metabolomics data metabolomics/v2"
+      "search_text": "minfer MInfer MInfer is an R package designed for analyzing metabolomics data metabolomics/v2 https://github.com/cellbiomaths/MInfer"
     },
     {
       "slug": "miniconda",
       "name": "Miniconda",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LabLaskin/MSIGen",
       "license_spdx": "",
       "evidence_text": "you can instead download Miniconda from https://www.anaconda.com/download/success",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/miniconda.yaml",
-      "search_text": "miniconda Miniconda you can instead download Miniconda from https://www.anaconda.com/download/success metabolomics/v2"
+      "search_text": "miniconda Miniconda you can instead download Miniconda from https://www.anaconda.com/download/success metabolomics/v2 https://github.com/LabLaskin/MSIGen"
     },
     {
       "slug": "mirador",
       "name": "Mirador",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "Mirador: Raw MS data visualization and export (PDF, CSV) including extracted ion chromatograms (XIC), extracted ion mobility (XIM) heatmaps, and MS/MS mirror plots",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mirador.yaml",
-      "search_text": "mirador Mirador Mirador: Raw MS data visualization and export (PDF, CSV) including extracted ion chromatograms (XIC), extracted ion mobility (XIM) heatmaps, and MS/MS mirror plots metabolomics/v2"
+      "search_text": "mirador Mirador Mirador: Raw MS data visualization and export (PDF, CSV) including extracted ion chromatograms (XIC), extracted ion mobility (XIM) heatmaps, and MS/MS mirror plots metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "missforest",
       "name": "missForest",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/antonvsdata/notame",
       "license_spdx": "",
       "evidence_text": "The implementation we use (from the missForest package) can be parallelized",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/missforest.yaml",
-      "search_text": "missforest missForest The implementation we use (from the missForest package) can be parallelized metabolomics/v2"
+      "search_text": "missforest missForest The implementation we use (from the missForest package) can be parallelized metabolomics/v2 https://github.com/antonvsdata/notame"
     },
     {
       "slug": "mist-cf",
@@ -118834,24 +118882,24 @@
     {
       "slug": "mist",
       "name": "MIST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/mist",
       "license_spdx": "",
       "evidence_text": "and, when trained in a contrastive learning framework, enable embedding and structure annotation by database lookup. an extension of MIST for annotating MS1 precursor masses from MS/MS data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mist.yaml",
-      "search_text": "mist MIST and, when trained in a contrastive learning framework, enable embedding and structure annotation by database lookup. an extension of MIST for annotating MS1 precursor masses from MS/MS data metabolomics/v2"
+      "search_text": "mist MIST and, when trained in a contrastive learning framework, enable embedding and structure annotation by database lookup. an extension of MIST for annotating MS1 precursor masses from MS/MS data metabolomics/v2 https://github.com/samgoldman97/mist"
     },
     {
       "slug": "mixomics",
       "name": "mixOmics",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DanielQuiroz97/RGCxGC",
       "license_spdx": "",
       "evidence_text": "\"igraph\", \"MASS\", \"mixOmics\", \"SOMbrero\", \"varSelRF\" Supervised models can be done with the [mixOmics](https://bioconductor.org/packages/release/bioc/html/mixOmics.html) functions.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mixomics.yaml",
-      "search_text": "mixomics mixOmics \"igraph\", \"MASS\", \"mixOmics\", \"SOMbrero\", \"varSelRF\" Supervised models can be done with the [mixOmics](https://bioconductor.org/packages/release/bioc/html/mixOmics.html) functions. metabolomics/v2"
+      "search_text": "mixomics mixOmics \"igraph\", \"MASS\", \"mixOmics\", \"SOMbrero\", \"varSelRF\" Supervised models can be done with the [mixOmics](https://bioconductor.org/packages/release/bioc/html/mixOmics.html) functions. metabolomics/v2 https://github.com/DanielQuiroz97/RGCxGC"
     },
     {
       "slug": "mobilipid",
@@ -118867,13 +118915,13 @@
     {
       "slug": "mobilitytransformr",
       "name": "MobilityTransformR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LiesaSalzer/MobilityTransformR",
       "license_spdx": "",
       "evidence_text": "Description and usage of MobilityTransformR compute Procaine's effective mobility using mobilityTransform",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mobilitytransformr.yaml",
-      "search_text": "mobilitytransformr MobilityTransformR Description and usage of MobilityTransformR compute Procaine's effective mobility using mobilityTransform metabolomics/v2"
+      "search_text": "mobilitytransformr MobilityTransformR Description and usage of MobilityTransformR compute Procaine's effective mobility using mobilityTransform metabolomics/v2 https://github.com/LiesaSalzer/MobilityTransformR"
     },
     {
       "slug": "moccal",
@@ -118889,79 +118937,79 @@
     {
       "slug": "mode-shinyapp",
       "name": "MODE ShinyApp",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pmartR/MODE_ShinyApp",
       "license_spdx": "",
       "evidence_text": "github.com__pmartR__MODE_ShinyApp",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mode-shinyapp.yaml",
-      "search_text": "mode-shinyapp MODE ShinyApp github.com__pmartR__MODE_ShinyApp metabolomics/v2"
+      "search_text": "mode-shinyapp MODE ShinyApp github.com__pmartR__MODE_ShinyApp metabolomics/v2 https://github.com/pmartR/MODE_ShinyApp"
     },
     {
       "slug": "modifinder",
       "name": "ModiFinder",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base",
       "license_spdx": "",
       "evidence_text": "mf = ModiFinder(known_compound, modified_compound, mz_tolerance=0.01, ppm_tolerance=40) mf = ModiFinder(known_compound, modified_compound, helpers=helpers_array, **args) from modifinder import ModiFinder, Compound",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/modifinder.yaml",
-      "search_text": "modifinder ModiFinder mf = ModiFinder(known_compound, modified_compound, mz_tolerance=0.01, ppm_tolerance=40) mf = ModiFinder(known_compound, modified_compound, helpers=helpers_array, **args) from modifinder import ModiFinder, Compound metabolomics/v2"
+      "search_text": "modifinder ModiFinder mf = ModiFinder(known_compound, modified_compound, mz_tolerance=0.01, ppm_tolerance=40) mf = ModiFinder(known_compound, modified_compound, helpers=helpers_array, **args) from modifinder import ModiFinder, Compound metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base"
     },
     {
       "slug": "molbar",
       "name": "molbar",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "**molbar** (version >= 1.1.3)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/molbar.yaml",
-      "search_text": "molbar molbar **molbar** (version >= 1.1.3) metabolomics/v2"
+      "search_text": "molbar molbar **molbar** (version >= 1.1.3) metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "moldiscovery",
       "name": "molDiscovery",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mohimanilab/molDiscovery",
       "license_spdx": "",
       "evidence_text": "To test molDiscovery for academic users, please visit",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/moldiscovery.yaml",
-      "search_text": "moldiscovery molDiscovery To test molDiscovery for academic users, please visit metabolomics/v2"
+      "search_text": "moldiscovery molDiscovery To test molDiscovery for academic users, please visit metabolomics/v2 https://github.com/mohimanilab/molDiscovery"
     },
     {
       "slug": "moletrans",
       "name": "MoleTrans",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JibaoLiu/MoleTrans",
       "license_spdx": "",
       "evidence_text": "MoleTrans is a webtool for post analysis and data mining on the formula assigned datasets from FT-ICR MS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/moletrans.yaml",
-      "search_text": "moletrans MoleTrans MoleTrans is a webtool for post analysis and data mining on the formula assigned datasets from FT-ICR MS metabolomics/v2"
+      "search_text": "moletrans MoleTrans MoleTrans is a webtool for post analysis and data mining on the formula assigned datasets from FT-ICR MS metabolomics/v2 https://github.com/JibaoLiu/MoleTrans"
     },
     {
       "slug": "molmass",
       "name": "molmass",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FanzhouKong/spectral_denoising",
       "license_spdx": "",
       "evidence_text": "molmass==2021.6.18 - ``molmass==2021.6.18``",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/molmass.yaml",
-      "search_text": "molmass molmass molmass==2021.6.18 - ``molmass==2021.6.18`` metabolomics/v2"
+      "search_text": "molmass molmass molmass==2021.6.18 - ``molmass==2021.6.18`` metabolomics/v2 https://github.com/FanzhouKong/spectral_denoising"
     },
     {
       "slug": "molnotator",
       "name": "MolNotator",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ZzakB/MolNotator",
       "license_spdx": "",
       "evidence_text": "from MolNotator.duplicate_filter import duplicate_filter from MolNotator.sample_slicer import sample_slicer",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/molnotator.yaml",
-      "search_text": "molnotator MolNotator from MolNotator.duplicate_filter import duplicate_filter from MolNotator.sample_slicer import sample_slicer metabolomics/v2"
+      "search_text": "molnotator MolNotator from MolNotator.duplicate_filter import duplicate_filter from MolNotator.sample_slicer import sample_slicer metabolomics/v2 https://github.com/ZzakB/MolNotator"
     },
     {
       "slug": "mona",
@@ -118977,13 +119025,13 @@
     {
       "slug": "mongodb",
       "name": "MongoDB",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/tyo-nu/MINE-Database",
       "license_spdx": "",
       "evidence_text": "The URI of the mongo database to connect to. Defaults to mongodb://localhost:27017",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mongodb.yaml",
-      "search_text": "mongodb MongoDB The URI of the mongo database to connect to. Defaults to mongodb://localhost:27017 metabolomics/v2"
+      "search_text": "mongodb MongoDB The URI of the mongo database to connect to. Defaults to mongodb://localhost:27017 metabolomics/v2 https://github.com/tyo-nu/MINE-Database"
     },
     {
       "slug": "monte-carlo-dropout",
@@ -118999,90 +119047,90 @@
     {
       "slug": "mordred",
       "name": "mordred",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HopkinsLaboratory/Graphormer-RT",
       "license_spdx": "",
       "evidence_text": "import mordred from mordred import Calculator, descriptors",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mordred.yaml",
-      "search_text": "mordred mordred import mordred from mordred import Calculator, descriptors metabolomics/v2"
+      "search_text": "mordred mordred import mordred from mordred import Calculator, descriptors metabolomics/v2 https://github.com/HopkinsLaboratory/Graphormer-RT"
     },
     {
       "slug": "motifdb",
       "name": "MotifDB",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "Compare motifs to known entries in MotifDB",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/motifdb.yaml",
-      "search_text": "motifdb MotifDB Compare motifs to known entries in MotifDB metabolomics/v2"
+      "search_text": "motifdb MotifDB Compare motifs to known entries in MotifDB metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "mozilla-firefox",
       "name": "Mozilla Firefox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lidawei1975/colmarvista",
       "license_spdx": "",
       "evidence_text": "For Mozilla Firefox: 1. Enter about:config in the browser's address bar.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mozilla-firefox.yaml",
-      "search_text": "mozilla-firefox Mozilla Firefox For Mozilla Firefox: 1. Enter about:config in the browser's address bar. metabolomics/v2"
+      "search_text": "mozilla-firefox Mozilla Firefox For Mozilla Firefox: 1. Enter about:config in the browser's address bar. metabolomics/v2 https://github.com/lidawei1975/colmarvista"
     },
     {
       "slug": "mpactr",
       "name": "mpactr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BalunasLab/mpact",
       "license_spdx": "",
       "evidence_text": "library(mpactr) The goal of mpactr is to correct for errors that occur during the pre-processing of raw tandem MS/MS data. Next, we need to extract the ion status with `mpactr` function `qc_summary()`.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mpactr.yaml",
-      "search_text": "mpactr mpactr library(mpactr) The goal of mpactr is to correct for errors that occur during the pre-processing of raw tandem MS/MS data. Next, we need to extract the ion status with `mpactr` function `qc_summary()`. metabolomics/v2"
+      "search_text": "mpactr mpactr library(mpactr) The goal of mpactr is to correct for errors that occur during the pre-processing of raw tandem MS/MS data. Next, we need to extract the ion status with `mpactr` function `qc_summary()`. metabolomics/v2 https://github.com/BalunasLab/mpact"
     },
     {
       "slug": "mrmquant",
       "name": "MRMQuant",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kslynn128171/MRMQuant",
       "license_spdx": "",
       "evidence_text": "Be sure to use the latest version (currently MRMQuant v2.7).",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mrmquant.yaml",
-      "search_text": "mrmquant MRMQuant Be sure to use the latest version (currently MRMQuant v2.7). metabolomics/v2"
+      "search_text": "mrmquant MRMQuant Be sure to use the latest version (currently MRMQuant v2.7). metabolomics/v2 https://github.com/kslynn128171/MRMQuant"
     },
     {
       "slug": "mrmtransitiongrouppicker",
       "name": "MRMTransitionGroupPicker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "MRMTransitionGroupPicker",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mrmtransitiongrouppicker.yaml",
-      "search_text": "mrmtransitiongrouppicker MRMTransitionGroupPicker MRMTransitionGroupPicker metabolomics/v2"
+      "search_text": "mrmtransitiongrouppicker MRMTransitionGroupPicker MRMTransitionGroupPicker metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "mrnannoalgo3-metdna3",
       "name": "MrnAnnoAlgo3 (MetDNA3)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ZhuMetLab/MrnAnnoAlgo3",
       "license_spdx": "",
       "evidence_text": "`MrnAnnoAlgo3` is the core algorithm module of **MetDNA3**, designed to annotate metabolites",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mrnannoalgo3-metdna3.yaml",
-      "search_text": "mrnannoalgo3-metdna3 MrnAnnoAlgo3 (MetDNA3) `MrnAnnoAlgo3` is the core algorithm module of **MetDNA3**, designed to annotate metabolites metabolomics/v2"
+      "search_text": "mrnannoalgo3-metdna3 MrnAnnoAlgo3 (MetDNA3) `MrnAnnoAlgo3` is the core algorithm module of **MetDNA3**, designed to annotate metabolites metabolomics/v2 https://github.com/ZhuMetLab/MrnAnnoAlgo3"
     },
     {
       "slug": "ms-cleanr",
       "name": "MS-CleanR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eMetaboHUB/MS-CleanR",
       "license_spdx": "",
       "evidence_text": "MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-cleanr.yaml",
-      "search_text": "ms-cleanr MS-CleanR MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis metabolomics/v2"
+      "search_text": "ms-cleanr MS-CleanR MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis metabolomics/v2 https://github.com/eMetaboHUB/MS-CleanR"
     },
     {
       "slug": "ms-dial-4",
@@ -119109,112 +119157,112 @@
     {
       "slug": "ms-dial-or-higher",
       "name": "MS-DIAL or higher",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eMetaboHUB/MS-CleanR",
       "license_spdx": "",
       "evidence_text": "Needs MS-DIAL (v4.00 or higher) and MS-FINDER (3.30 or higher)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-dial-or-higher.yaml",
-      "search_text": "ms-dial-or-higher MS-DIAL or higher Needs MS-DIAL (v4.00 or higher) and MS-FINDER (3.30 or higher) metabolomics/v2"
+      "search_text": "ms-dial-or-higher MS-DIAL or higher Needs MS-DIAL (v4.00 or higher) and MS-FINDER (3.30 or higher) metabolomics/v2 https://github.com/eMetaboHUB/MS-CleanR"
     },
     {
       "slug": "ms-dial-v4-00-or-higher",
       "name": "MS-DIAL v4.00 or higher",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eMetaboHUB/MS-CleanR",
       "license_spdx": "",
       "evidence_text": "Needs MS-DIAL (v4.00 or higher) Needs MS-DIAL (v4.00 or higher) ... MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis (DDA) or data independent analysis (DIA)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-dial-v4-00-or-higher.yaml",
-      "search_text": "ms-dial-v4-00-or-higher MS-DIAL v4.00 or higher Needs MS-DIAL (v4.00 or higher) Needs MS-DIAL (v4.00 or higher) ... MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis (DDA) or data independent analysis (DIA) metabolomics/v2"
+      "search_text": "ms-dial-v4-00-or-higher MS-DIAL v4.00 or higher Needs MS-DIAL (v4.00 or higher) Needs MS-DIAL (v4.00 or higher) ... MS-CleanR use as input MS-DIAL peak list processed in data dependent analysis (DDA) or data independent analysis (DIA) metabolomics/v2 https://github.com/eMetaboHUB/MS-CleanR"
     },
     {
       "slug": "ms-dial",
       "name": "MS-DIAL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FrigerioGianfranco/GetFeatistics",
       "license_spdx": "",
       "evidence_text": "`MS-DIAL <http://prime.psc.riken.jp/compms/msdial/main.html>`_ open source tools such as XCMS and MS-Dial after obtaining a feature table using open source tools such as XCMS and MS-Dial. LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) for example MZmine, XCMS, MS-DIAL, and Compound Discoverer quality filter for lipid identifications from MS-DIAL",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-dial.yaml",
-      "search_text": "ms-dial MS-DIAL `MS-DIAL <http://prime.psc.riken.jp/compms/msdial/main.html>`_ open source tools such as XCMS and MS-Dial after obtaining a feature table using open source tools such as XCMS and MS-Dial. LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) for example MZmine, XCMS, MS-DIAL, and Compound Discoverer quality filter for lipid identifications from MS-DIAL metabolomics/v2"
+      "search_text": "ms-dial MS-DIAL `MS-DIAL <http://prime.psc.riken.jp/compms/msdial/main.html>`_ open source tools such as XCMS and MS-Dial after obtaining a feature table using open source tools such as XCMS and MS-Dial. LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) for example MZmine, XCMS, MS-DIAL, and Compound Discoverer quality filter for lipid identifications from MS-DIAL metabolomics/v2 https://github.com/FrigerioGianfranco/GetFeatistics"
     },
     {
       "slug": "ms-distance",
       "name": "ms_distance",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuanyueLi/SpectralEntropy",
       "license_spdx": "",
       "evidence_text": ".. automodule:: ms_distance :members:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-distance.yaml",
-      "search_text": "ms-distance ms_distance .. automodule:: ms_distance :members: metabolomics/v2"
+      "search_text": "ms-distance ms_distance .. automodule:: ms_distance :members: metabolomics/v2 https://github.com/YuanyueLi/SpectralEntropy"
     },
     {
       "slug": "ms-entropy",
       "name": "ms_entropy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FanzhouKong/spectral_denoising",
       "license_spdx": "",
       "evidence_text": "ms_entropy==1.3.3 - ``ms_entropy==1.3.3``",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-entropy.yaml",
-      "search_text": "ms-entropy ms_entropy ms_entropy==1.3.3 - ``ms_entropy==1.3.3`` metabolomics/v2"
+      "search_text": "ms-entropy ms_entropy ms_entropy==1.3.3 - ``ms_entropy==1.3.3`` metabolomics/v2 https://github.com/FanzhouKong/spectral_denoising"
     },
     {
       "slug": "ms-finder",
       "name": "MS-FINDER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eMetaboHUB/MS-CleanR",
       "license_spdx": "",
       "evidence_text": "all selected features are exported to MS-FINDER program for in silico-based annotation using hydrogen rearrangement rules (HRR) scoring system",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-finder.yaml",
-      "search_text": "ms-finder MS-FINDER all selected features are exported to MS-FINDER program for in silico-based annotation using hydrogen rearrangement rules (HRR) scoring system metabolomics/v2"
+      "search_text": "ms-finder MS-FINDER all selected features are exported to MS-FINDER program for in silico-based annotation using hydrogen rearrangement rules (HRR) scoring system metabolomics/v2 https://github.com/eMetaboHUB/MS-CleanR"
     },
     {
       "slug": "ms-pred-iceberg",
       "name": "ms-pred ICEBERG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "github.com__samgoldman97__ms-pred",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-pred-iceberg.yaml",
-      "search_text": "ms-pred-iceberg ms-pred ICEBERG github.com__samgoldman97__ms-pred metabolomics/v2"
+      "search_text": "ms-pred-iceberg ms-pred ICEBERG github.com__samgoldman97__ms-pred metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "ms-pred-scarf-model",
       "name": "ms-pred (SCARF model)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "github.com/samgoldman97/ms-pred",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-pred-scarf-model.yaml",
-      "search_text": "ms-pred-scarf-model ms-pred (SCARF model) github.com/samgoldman97/ms-pred metabolomics/v2"
+      "search_text": "ms-pred-scarf-model ms-pred (SCARF model) github.com/samgoldman97/ms-pred metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "ms-pred",
       "name": "ms-pred",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/samgoldman97/ms-pred",
       "license_spdx": "",
       "evidence_text": "github.com__samgoldman97__ms-pred",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-pred.yaml",
-      "search_text": "ms-pred ms-pred github.com__samgoldman97__ms-pred metabolomics/v2"
+      "search_text": "ms-pred ms-pred github.com__samgoldman97__ms-pred metabolomics/v2 https://github.com/samgoldman97/ms-pred"
     },
     {
       "slug": "ms-rescore",
       "name": "MS²Rescore",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/compomics/ms2rescore",
       "license_spdx": "",
       "evidence_text": "MS²Rescore is a tool for rescoring peptide-spectrum matches",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms-rescore.yaml",
-      "search_text": "ms-rescore MS²Rescore MS²Rescore is a tool for rescoring peptide-spectrum matches metabolomics/v2"
+      "search_text": "ms-rescore MS²Rescore MS²Rescore is a tool for rescoring peptide-spectrum matches metabolomics/v2 https://github.com/compomics/ms2rescore"
     },
     {
       "slug": "ms-search",
@@ -119230,101 +119278,101 @@
     {
       "slug": "ms2compound",
       "name": "MS2Compound",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/beherasan/MS2Compound",
       "license_spdx": "",
       "evidence_text": "MS2Compound (v1.0.2) is a user friendly Graphical User Interface (GUI) for the identification of the compounds from LC-MS and MS/MS metabolomics data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2compound.yaml",
-      "search_text": "ms2compound MS2Compound MS2Compound (v1.0.2) is a user friendly Graphical User Interface (GUI) for the identification of the compounds from LC-MS and MS/MS metabolomics data metabolomics/v2"
+      "search_text": "ms2compound MS2Compound MS2Compound (v1.0.2) is a user friendly Graphical User Interface (GUI) for the identification of the compounds from LC-MS and MS/MS metabolomics data metabolomics/v2 https://github.com/beherasan/MS2Compound"
     },
     {
       "slug": "ms2deepscore",
       "name": "MS2DeepScore",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/matchms/MS2DeepScore",
       "license_spdx": "",
       "evidence_text": "MS2DeepScore to predict structural similarity scores for spe we used the MS2DeepScore base network (Fig. 1) to compute the 200-dimensional spectral embeddings for all 3601 spectra in the test set Our MS2DeepScore Python library offers two types of data generators `ms2deepscore` provides a Siamese neural network that is trained to predict molecular structural similarities To estimate the uncertainty of a prediction we used Monte-Carlo Dropout ensembles t-SNE embedding that serves as an overview representation of mass spectral similarities based on ms2deepscore",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2deepscore.yaml",
-      "search_text": "ms2deepscore MS2DeepScore MS2DeepScore to predict structural similarity scores for spe we used the MS2DeepScore base network (Fig. 1) to compute the 200-dimensional spectral embeddings for all 3601 spectra in the test set Our MS2DeepScore Python library offers two types of data generators `ms2deepscore` provides a Siamese neural network that is trained to predict molecular structural similarities To estimate the uncertainty of a prediction we used Monte-Carlo Dropout ensembles t-SNE embedding that serves as an overview representation of mass spectral similarities based on ms2deepscore metabolomics/v2"
+      "search_text": "ms2deepscore MS2DeepScore MS2DeepScore to predict structural similarity scores for spe we used the MS2DeepScore base network (Fig. 1) to compute the 200-dimensional spectral embeddings for all 3601 spectra in the test set Our MS2DeepScore Python library offers two types of data generators `ms2deepscore` provides a Siamese neural network that is trained to predict molecular structural similarities To estimate the uncertainty of a prediction we used Monte-Carlo Dropout ensembles t-SNE embedding that serves as an overview representation of mass spectral similarities based on ms2deepscore metabolomics/v2 https://github.com/matchms/MS2DeepScore"
     },
     {
       "slug": "ms2lda-preprocessing-generate-corpus",
       "name": "MS2LDA.Preprocessing.generate_corpus",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "Generate Corpus",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2lda-preprocessing-generate-corpus.yaml",
-      "search_text": "ms2lda-preprocessing-generate-corpus MS2LDA.Preprocessing.generate_corpus Generate Corpus metabolomics/v2"
+      "search_text": "ms2lda-preprocessing-generate-corpus MS2LDA.Preprocessing.generate_corpus Generate Corpus metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "ms2lda-preprocessing-load-and-clean",
       "name": "MS2LDA.Preprocessing.load_and_clean",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "from MS2LDA.Preprocessing import load_and_clean ::: MS2LDA.Preprocessing.load_and_clean",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2lda-preprocessing-load-and-clean.yaml",
-      "search_text": "ms2lda-preprocessing-load-and-clean MS2LDA.Preprocessing.load_and_clean from MS2LDA.Preprocessing import load_and_clean ::: MS2LDA.Preprocessing.load_and_clean metabolomics/v2"
+      "search_text": "ms2lda-preprocessing-load-and-clean MS2LDA.Preprocessing.load_and_clean from MS2LDA.Preprocessing import load_and_clean ::: MS2LDA.Preprocessing.load_and_clean metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "ms2lda",
       "name": "MS2LDA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/glasgowcompbio/PALS",
       "license_spdx": "",
       "evidence_text": "MS2LDA Reference Motifs Map MS2LDA substructural information to mass spectral molecular networks MS2LDA (Mass Spectrometry–Latent Dirichlet Allocation) is a framework MS2LDA uses Latent Dirichlet Allocation (LDA) to infer which motifs are most likely to explain the observed fragmentation patterns MS2LDA expects preprocessed MS/MS data **MS2LDA** applies *probabilistic topic modeling*, originally developed for natural language processing (NLP), to **tandem mass spectrometry (MS/MS)** data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2lda.yaml",
-      "search_text": "ms2lda MS2LDA MS2LDA Reference Motifs Map MS2LDA substructural information to mass spectral molecular networks MS2LDA (Mass Spectrometry–Latent Dirichlet Allocation) is a framework MS2LDA uses Latent Dirichlet Allocation (LDA) to infer which motifs are most likely to explain the observed fragmentation patterns MS2LDA expects preprocessed MS/MS data **MS2LDA** applies *probabilistic topic modeling*, originally developed for natural language processing (NLP), to **tandem mass spectrometry (MS/MS)** data. metabolomics/v2"
+      "search_text": "ms2lda MS2LDA MS2LDA Reference Motifs Map MS2LDA substructural information to mass spectral molecular networks MS2LDA (Mass Spectrometry–Latent Dirichlet Allocation) is a framework MS2LDA uses Latent Dirichlet Allocation (LDA) to infer which motifs are most likely to explain the observed fragmentation patterns MS2LDA expects preprocessed MS/MS data **MS2LDA** applies *probabilistic topic modeling*, originally developed for natural language processing (NLP), to **tandem mass spectrometry (MS/MS)** data. metabolomics/v2 https://github.com/glasgowcompbio/PALS"
     },
     {
       "slug": "ms2mp",
       "name": "MS2MP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ucasaccn/MS2MP",
       "license_spdx": "",
       "evidence_text": "MS2MP is a novel deep learning-based framework for KEGG pathway prediction directly from untargeted tandem mass spectrometry(MS2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2mp.yaml",
-      "search_text": "ms2mp MS2MP MS2MP is a novel deep learning-based framework for KEGG pathway prediction directly from untargeted tandem mass spectrometry(MS2) metabolomics/v2"
+      "search_text": "ms2mp MS2MP MS2MP is a novel deep learning-based framework for KEGG pathway prediction directly from untargeted tandem mass spectrometry(MS2) metabolomics/v2 https://github.com/ucasaccn/MS2MP"
     },
     {
       "slug": "ms2query",
       "name": "MS2Query",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/iomega/ms2query",
       "license_spdx": "",
       "evidence_text": "MS2Query - Reliable and fast MS/MS spectral-based analogue search you want to make some kind of change to the code base",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ms2query.yaml",
-      "search_text": "ms2query MS2Query MS2Query - Reliable and fast MS/MS spectral-based analogue search you want to make some kind of change to the code base metabolomics/v2"
+      "search_text": "ms2query MS2Query MS2Query - Reliable and fast MS/MS spectral-based analogue search you want to make some kind of change to the code base metabolomics/v2 https://github.com/iomega/ms2query"
     },
     {
       "slug": "msbackendmgf",
       "name": "MsBackendMgf",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sneumann/xcms",
       "license_spdx": "",
       "evidence_text": "library(MsBackendMgf)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msbackendmgf.yaml",
-      "search_text": "msbackendmgf MsBackendMgf library(MsBackendMgf) metabolomics/v2"
+      "search_text": "msbackendmgf MsBackendMgf library(MsBackendMgf) metabolomics/v2 https://github.com/sneumann/xcms"
     },
     {
       "slug": "msbackendmzr",
       "name": "MsBackendMzR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rformassspectrometry/Spectra",
       "license_spdx": "",
       "evidence_text": "Backends such as the `MsBackendMzR` for example retrieve the data on the fly from the raw MS data files",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msbackendmzr.yaml",
-      "search_text": "msbackendmzr MsBackendMzR Backends such as the `MsBackendMzR` for example retrieve the data on the fly from the raw MS data files metabolomics/v2"
+      "search_text": "msbackendmzr MsBackendMzR Backends such as the `MsBackendMzR` for example retrieve the data on the fly from the raw MS data files metabolomics/v2 https://github.com/rformassspectrometry/Spectra"
     },
     {
       "slug": "msconvert-proteowizard",
@@ -119340,46 +119388,46 @@
     {
       "slug": "msconvert",
       "name": "msconvert",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "For MS Data conversion to .mzXML or .mzML file format use msconvert, distributed with the ProteoWizard Project AutoTuner is designed to work directly with raw mass spectral data that has been processed by using MSconvert. uses msConvert for file conversion to extracted precursor ion chromatogram (PIC) imzML Writer relies on MS convert to convert raw instrument data into the open format mzML, requiring a working install. imzML Writer relies on MS convert to convert raw instrument data into the open format mzML. The conversion tool can use MSConvert, which you need to download and install yourself.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msconvert.yaml",
-      "search_text": "msconvert msconvert For MS Data conversion to .mzXML or .mzML file format use msconvert, distributed with the ProteoWizard Project AutoTuner is designed to work directly with raw mass spectral data that has been processed by using MSconvert. uses msConvert for file conversion to extracted precursor ion chromatogram (PIC) imzML Writer relies on MS convert to convert raw instrument data into the open format mzML, requiring a working install. imzML Writer relies on MS convert to convert raw instrument data into the open format mzML. The conversion tool can use MSConvert, which you need to download and install yourself. metabolomics/v2"
+      "search_text": "msconvert msconvert For MS Data conversion to .mzXML or .mzML file format use msconvert, distributed with the ProteoWizard Project AutoTuner is designed to work directly with raw mass spectral data that has been processed by using MSconvert. uses msConvert for file conversion to extracted precursor ion chromatogram (PIC) imzML Writer relies on MS convert to convert raw instrument data into the open format mzML, requiring a working install. imzML Writer relies on MS convert to convert raw instrument data into the open format mzML. The conversion tool can use MSConvert, which you need to download and install yourself. metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "msdata",
       "name": "msdata",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LiesaSalzer/MobilityTransformR",
       "license_spdx": "",
       "evidence_text": "The CE-MS test data are from the `r BiocStyle::Biocpkg(\"msdata\")` package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msdata.yaml",
-      "search_text": "msdata msdata The CE-MS test data are from the `r BiocStyle::Biocpkg(\"msdata\")` package metabolomics/v2"
+      "search_text": "msdata msdata The CE-MS test data are from the `r BiocStyle::Biocpkg(\"msdata\")` package metabolomics/v2 https://github.com/LiesaSalzer/MobilityTransformR"
     },
     {
       "slug": "msdatahub",
       "name": "MsDataHub",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sneumann/xcms",
       "license_spdx": "",
       "evidence_text": "library(MsDataHub)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msdatahub.yaml",
-      "search_text": "msdatahub MsDataHub library(MsDataHub) metabolomics/v2"
+      "search_text": "msdatahub MsDataHub library(MsDataHub) metabolomics/v2 https://github.com/sneumann/xcms"
     },
     {
       "slug": "msentropy",
       "name": "msentropy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "msentropy we provide a Python implementation of the algorithm in the `MSEntropy` repository These are all integrated into the [MSEntropy package These are all integrated into the MSEntropy package (https://github.com/YuanyueLi/MSEntropy)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msentropy.yaml",
-      "search_text": "msentropy msentropy msentropy we provide a Python implementation of the algorithm in the `MSEntropy` repository These are all integrated into the [MSEntropy package These are all integrated into the MSEntropy package (https://github.com/YuanyueLi/MSEntropy) metabolomics/v2"
+      "search_text": "msentropy msentropy msentropy we provide a Python implementation of the algorithm in the `MSEntropy` repository These are all integrated into the [MSEntropy package These are all integrated into the MSEntropy package (https://github.com/YuanyueLi/MSEntropy) metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "msexperiment",
@@ -119395,24 +119443,24 @@
     {
       "slug": "msfeast",
       "name": "msFeaST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kevinmildau/msFeaST",
       "license_spdx": "",
       "evidence_text": "github.com__kevinmildau__msFeaST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msfeast.yaml",
-      "search_text": "msfeast msFeaST github.com__kevinmildau__msFeaST metabolomics/v2"
+      "search_text": "msfeast msFeaST github.com__kevinmildau__msFeaST metabolomics/v2 https://github.com/kevinmildau/msFeaST"
     },
     {
       "slug": "msfeatures",
       "name": "MsFeatures",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sneumann/xcms",
       "license_spdx": "",
       "evidence_text": "General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package with additional functionality being implemented VignetteDepends{xcms,BiocStyle,faahKO,pheatmap,MsFeatures}",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msfeatures.yaml",
-      "search_text": "msfeatures MsFeatures General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package with additional functionality being implemented VignetteDepends{xcms,BiocStyle,faahKO,pheatmap,MsFeatures} metabolomics/v2"
+      "search_text": "msfeatures MsFeatures General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package General MS feature grouping functionality if defined by the `r Biocpkg(\"MsFeatures\")` package with additional functionality being implemented VignetteDepends{xcms,BiocStyle,faahKO,pheatmap,MsFeatures} metabolomics/v2 https://github.com/sneumann/xcms"
     },
     {
       "slug": "msfiddle",
@@ -119428,13 +119476,13 @@
     {
       "slug": "msfinder",
       "name": "MSFinder",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/cbroeckl/RAMClustR",
       "license_spdx": "",
       "evidence_text": "The 'mat' contains spectra in .mat format suitable for import into MSFinder software",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msfinder.yaml",
-      "search_text": "msfinder MSFinder The 'mat' contains spectra in .mat format suitable for import into MSFinder software metabolomics/v2"
+      "search_text": "msfinder MSFinder The 'mat' contains spectra in .mat format suitable for import into MSFinder software metabolomics/v2 https://github.com/cbroeckl/RAMClustR"
     },
     {
       "slug": "msflo",
@@ -119450,112 +119498,112 @@
     {
       "slug": "msfragger",
       "name": "MSFragger",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/laurenfields/MSIght",
       "license_spdx": "",
       "evidence_text": ".. automodule:: MSIght.refactor_fragger_process",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msfragger.yaml",
-      "search_text": "msfragger MSFragger .. automodule:: MSIght.refactor_fragger_process metabolomics/v2"
+      "search_text": "msfragger MSFragger .. automodule:: MSIght.refactor_fragger_process metabolomics/v2 https://github.com/laurenfields/MSIght"
     },
     {
       "slug": "msgo-model",
       "name": "MSGO model",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/aaronma2020/MSGO",
       "license_spdx": "",
       "evidence_text": "github.com__aaronma2020__MSGO",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msgo-model.yaml",
-      "search_text": "msgo-model MSGO model github.com__aaronma2020__MSGO metabolomics/v2"
+      "search_text": "msgo-model MSGO model github.com__aaronma2020__MSGO metabolomics/v2 https://github.com/aaronma2020/MSGO"
     },
     {
       "slug": "mshub",
       "name": "MSHub",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bittremieux/GNPS_GC",
       "license_spdx": "",
       "evidence_text": "MSHub auto-deconvolution Auto-deconvolution and molecular networking of gas chromatography–mass spectrometry data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mshub.yaml",
-      "search_text": "mshub MSHub MSHub auto-deconvolution Auto-deconvolution and molecular networking of gas chromatography–mass spectrometry data metabolomics/v2"
+      "search_text": "mshub MSHub MSHub auto-deconvolution Auto-deconvolution and molecular networking of gas chromatography–mass spectrometry data metabolomics/v2 https://github.com/bittremieux/GNPS_GC"
     },
     {
       "slug": "msi-explorer",
       "name": "MSI-Explorer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MMV-Lab/MSI-Explorer",
       "license_spdx": "",
       "evidence_text": "The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msi-explorer.yaml",
-      "search_text": "msi-explorer MSI-Explorer The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data. metabolomics/v2"
+      "search_text": "msi-explorer MSI-Explorer The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data. metabolomics/v2 https://github.com/MMV-Lab/MSI-Explorer"
     },
     {
       "slug": "msigen",
       "name": "MSIGen",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LabLaskin/MSIGen",
       "license_spdx": "",
       "evidence_text": "MSIGen provides tools for processing mass spectrometry imaging data acquired in line-scan mode into images and figures. from MSIGen import msigen",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msigen.yaml",
-      "search_text": "msigen MSIGen MSIGen provides tools for processing mass spectrometry imaging data acquired in line-scan mode into images and figures. from MSIGen import msigen metabolomics/v2"
+      "search_text": "msigen MSIGen MSIGen provides tools for processing mass spectrometry imaging data acquired in line-scan mode into images and figures. from MSIGen import msigen metabolomics/v2 https://github.com/LabLaskin/MSIGen"
     },
     {
       "slug": "msmetaenhancer",
       "name": "MSMetaEnhancer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "MSMetaEnhancer is a tool used for `.msp` files annotation Converter Builder: Automatically discovers and instantiates available converters MSMetaEnhancer is a tool used for `.msp` files annotation. **MSMetaEnhancer** is a tool used for `.msp` files annotation `MSMetaEnhancer/libs/converters/web/` named after your service",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msmetaenhancer.yaml",
-      "search_text": "msmetaenhancer MSMetaEnhancer MSMetaEnhancer is a tool used for `.msp` files annotation Converter Builder: Automatically discovers and instantiates available converters MSMetaEnhancer is a tool used for `.msp` files annotation. **MSMetaEnhancer** is a tool used for `.msp` files annotation `MSMetaEnhancer/libs/converters/web/` named after your service metabolomics/v2"
+      "search_text": "msmetaenhancer MSMetaEnhancer MSMetaEnhancer is a tool used for `.msp` files annotation Converter Builder: Automatically discovers and instantiates available converters MSMetaEnhancer is a tool used for `.msp` files annotation. **MSMetaEnhancer** is a tool used for `.msp` files annotation `MSMetaEnhancer/libs/converters/web/` named after your service metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "msmssim",
       "name": "MSMSsim",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "MSMSsim",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msmssim.yaml",
-      "search_text": "msmssim MSMSsim MSMSsim metabolomics/v2"
+      "search_text": "msmssim MSMSsim MSMSsim metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "msnbase",
       "name": "MSnbase",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LiesaSalzer/MobilityTransformR",
       "license_spdx": "",
       "evidence_text": "The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MSnbase\")` extension of the of *in-memory* and *on-disk* data representations from the `r Biocpkg(\"MSnbase\")` package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msnbase.yaml",
-      "search_text": "msnbase MSnbase The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MSnbase\")` extension of the of *in-memory* and *on-disk* data representations from the `r Biocpkg(\"MSnbase\")` package metabolomics/v2"
+      "search_text": "msnbase MSnbase The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"MSnbase\")` extension of the of *in-memory* and *on-disk* data representations from the `r Biocpkg(\"MSnbase\")` package metabolomics/v2 https://github.com/LiesaSalzer/MobilityTransformR"
     },
     {
       "slug": "msnovelist",
       "name": "MSNovelist",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/meowcat/MSNovelist",
       "license_spdx": "",
       "evidence_text": "The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) singularity build $SCRATCH_PATH/MSNovelist-image/msnovelist.sif docker://stravsm/msnovelist6 run_train.sh: run MSNovelist Singularity container and start `train.sh`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msnovelist.yaml",
-      "search_text": "msnovelist MSNovelist The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) singularity build $SCRATCH_PATH/MSNovelist-image/msnovelist.sif docker://stravsm/msnovelist6 run_train.sh: run MSNovelist Singularity container and start `train.sh` metabolomics/v2"
+      "search_text": "msnovelist MSNovelist The SIRIUS web services (CSI:FingerID, CANOPUS, MSNovelist and others) singularity build $SCRATCH_PATH/MSNovelist-image/msnovelist.sif docker://stravsm/msnovelist6 run_train.sh: run MSNovelist Singularity container and start `train.sh` metabolomics/v2 https://github.com/meowcat/MSNovelist"
     },
     {
       "slug": "mspack",
       "name": "mspack",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fhanau/mspack",
       "license_spdx": "",
       "evidence_text": "mspack is a C++ program for lossless and lossy mass spectrometry data compression",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mspack.yaml",
-      "search_text": "mspack mspack mspack is a C++ program for lossless and lossy mass spectrometry data compression metabolomics/v2"
+      "search_text": "mspack mspack mspack is a C++ program for lossless and lossy mass spectrometry data compression metabolomics/v2 https://github.com/fhanau/mspack"
     },
     {
       "slug": "mspcompiler",
@@ -119571,112 +119619,112 @@
     {
       "slug": "msprep",
       "name": "MSPrep",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Ghoshlab/marr",
       "license_spdx": "",
       "evidence_text": "The **msprepCOPD** data in the **marr** package was pre-processed using the MSPrep software",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msprep.yaml",
-      "search_text": "msprep MSPrep The **msprepCOPD** data in the **marr** package was pre-processed using the MSPrep software metabolomics/v2"
+      "search_text": "msprep MSPrep The **msprepCOPD** data in the **marr** package was pre-processed using the MSPrep software metabolomics/v2 https://github.com/Ghoshlab/marr"
     },
     {
       "slug": "msroiaug",
       "name": "MSroiaug",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msroiaug.yaml",
-      "search_text": "msroiaug MSroiaug functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot metabolomics/v2"
+      "search_text": "msroiaug MSroiaug functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "mssearchr",
       "name": "mssearchr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AndreySamokhin/mssearchr",
       "license_spdx": "",
       "evidence_text": "The primary goal of the `mssearchr` package is to enhance the capabilities of R users for conducting library searches against electron ionization mass spectral databases. The primary goal of the `mssearchr` package is to enhance the capabilities of R users",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mssearchr.yaml",
-      "search_text": "mssearchr mssearchr The primary goal of the `mssearchr` package is to enhance the capabilities of R users for conducting library searches against electron ionization mass spectral databases. The primary goal of the `mssearchr` package is to enhance the capabilities of R users metabolomics/v2"
+      "search_text": "mssearchr mssearchr The primary goal of the `mssearchr` package is to enhance the capabilities of R users for conducting library searches against electron ionization mass spectral databases. The primary goal of the `mssearchr` package is to enhance the capabilities of R users metabolomics/v2 https://github.com/AndreySamokhin/mssearchr"
     },
     {
       "slug": "msthunder",
       "name": "MSThunder",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LQZ0123/MSThunder",
       "license_spdx": "",
       "evidence_text": "MSThunder provide a deep learning-based nontargeted analytical framework for the accurate and rapid identification of unknown organic pollutants in water",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msthunder.yaml",
-      "search_text": "msthunder MSThunder MSThunder provide a deep learning-based nontargeted analytical framework for the accurate and rapid identification of unknown organic pollutants in water metabolomics/v2"
+      "search_text": "msthunder MSThunder MSThunder provide a deep learning-based nontargeted analytical framework for the accurate and rapid identification of unknown organic pollutants in water metabolomics/v2 https://github.com/LQZ0123/MSThunder"
     },
     {
       "slug": "msys2",
       "name": "MSYS2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Install the MSYS2 platform for Windows",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/msys2.yaml",
-      "search_text": "msys2 MSYS2 Install the MSYS2 platform for Windows metabolomics/v2"
+      "search_text": "msys2 MSYS2 Install the MSYS2 platform for Windows metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "mtbls2",
       "name": "mtbls2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/KujawinskiLaboratory/Autotuner",
       "license_spdx": "",
       "evidence_text": "library(mtbls2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mtbls2.yaml",
-      "search_text": "mtbls2 mtbls2 library(mtbls2) metabolomics/v2"
+      "search_text": "mtbls2 mtbls2 library(mtbls2) metabolomics/v2 https://github.com/KujawinskiLaboratory/Autotuner"
     },
     {
       "slug": "multiabler",
       "name": "MultiABLER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/holab-hku/MultiABLER",
       "license_spdx": "",
       "evidence_text": "MultiABLER is a set of R functions forms a seamless workflow",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/multiabler.yaml",
-      "search_text": "multiabler MultiABLER MultiABLER is a set of R functions forms a seamless workflow metabolomics/v2"
+      "search_text": "multiabler MultiABLER MultiABLER is a set of R functions forms a seamless workflow metabolomics/v2 https://github.com/holab-hku/MultiABLER"
     },
     {
       "slug": "multiassayexperiment",
       "name": "MultiAssayExperiment",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/andreasmock/MetaboDiff",
       "license_spdx": "",
       "evidence_text": "The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object to simplify all downstream analysis.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/multiassayexperiment.yaml",
-      "search_text": "multiassayexperiment MultiAssayExperiment The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object to simplify all downstream analysis. metabolomics/v2"
+      "search_text": "multiassayexperiment MultiAssayExperiment The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object The function `create_mae` merges all objects into a so called `MultiAssayExperiment` object to simplify all downstream analysis. metabolomics/v2 https://github.com/andreasmock/MetaboDiff"
     },
     {
       "slug": "multimodalspectraltransformer",
       "name": "MultiModalSpectralTransformer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mpriessner/MultiModalSpectralTransformer",
       "license_spdx": "",
       "evidence_text": "github.com/mpriessner/MultiModalSpectralTransformer",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/multimodalspectraltransformer.yaml",
-      "search_text": "multimodalspectraltransformer MultiModalSpectralTransformer github.com/mpriessner/MultiModalSpectralTransformer metabolomics/v2"
+      "search_text": "multimodalspectraltransformer MultiModalSpectralTransformer github.com/mpriessner/MultiModalSpectralTransformer metabolomics/v2 https://github.com/mpriessner/MultiModalSpectralTransformer"
     },
     {
       "slug": "multiprocessing",
       "name": "multiprocessing",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "| **Local** (`online_deployment: false`) | None | `multiprocessing.Process`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/multiprocessing.yaml",
-      "search_text": "multiprocessing multiprocessing | **Local** (`online_deployment: false`) | None | `multiprocessing.Process` metabolomics/v2"
+      "search_text": "multiprocessing multiprocessing | **Local** (`online_deployment: false`) | None | `multiprocessing.Process` metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "multtest",
@@ -119692,68 +119740,68 @@
     {
       "slug": "mwastools",
       "name": "MWASTools",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AndreaRMICL/MWASTools",
       "license_spdx": "",
       "evidence_text": "Here, we present a package to perform MWAS using univariate hypothesis testing \"MWASTools\" is an R package designed to provide an integrated and user-friendly pipeline we present a package to perform MWAS using univariate hypothesis testing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mwastools.yaml",
-      "search_text": "mwastools MWASTools Here, we present a package to perform MWAS using univariate hypothesis testing \"MWASTools\" is an R package designed to provide an integrated and user-friendly pipeline we present a package to perform MWAS using univariate hypothesis testing metabolomics/v2"
+      "search_text": "mwastools MWASTools Here, we present a package to perform MWAS using univariate hypothesis testing \"MWASTools\" is an R package designed to provide an integrated and user-friendly pipeline we present a package to perform MWAS using univariate hypothesis testing metabolomics/v2 https://github.com/AndreaRMICL/MWASTools"
     },
     {
       "slug": "mwise",
       "name": "mWISE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/b2slab/mWISE",
       "license_spdx": "",
       "evidence_text": "mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data. mWISE (metabolomics Wise Inference of Speck Entities) is an R package mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mwise.yaml",
-      "search_text": "mwise mWISE mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data. mWISE (metabolomics Wise Inference of Speck Entities) is an R package mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data metabolomics/v2"
+      "search_text": "mwise mWISE mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data. mWISE (metabolomics Wise Inference of Speck Entities) is an R package mWISE (metabolomics Wise Inference of Speck Entities) is an R package that provides tools for context-based annotation of untargeted LC-MS data metabolomics/v2 https://github.com/b2slab/mWISE"
     },
     {
       "slug": "mwtab",
       "name": "mwtab",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MoseleyBioinformaticsLab/mwtab",
       "license_spdx": "",
       "evidence_text": "The ``mwtab`` package is a Python library that facilitates reading and writing files in",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mwtab.yaml",
-      "search_text": "mwtab mwtab The ``mwtab`` package is a Python library that facilitates reading and writing files in metabolomics/v2"
+      "search_text": "mwtab mwtab The ``mwtab`` package is a Python library that facilitates reading and writing files in metabolomics/v2 https://github.com/MoseleyBioinformaticsLab/mwtab"
     },
     {
       "slug": "mysql-8",
       "name": "MySQL 8",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "Application is developed for Mysql 8 /MariaDB 10",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mysql-8.yaml",
-      "search_text": "mysql-8 MySQL 8 Application is developed for Mysql 8 /MariaDB 10 metabolomics/v2"
+      "search_text": "mysql-8 MySQL 8 Application is developed for Mysql 8 /MariaDB 10 metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "mza",
       "name": "MZA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mza",
       "license_spdx": "",
       "evidence_text": "MZA is a stand-alone and self-contained command-line executable which converts multidimensional mass spectrometry (MS) data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mza.yaml",
-      "search_text": "mza MZA MZA is a stand-alone and self-contained command-line executable which converts multidimensional mass spectrometry (MS) data metabolomics/v2"
+      "search_text": "mza MZA MZA is a stand-alone and self-contained command-line executable which converts multidimensional mass spectrometry (MS) data metabolomics/v2 https://github.com/PNNL-m-q/mza"
     },
     {
       "slug": "mzembed",
       "name": "mzEmbed",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ReviveMed/mzEmbed",
       "license_spdx": "",
       "evidence_text": "mzEmbed, a framework for developing pre-trained generative models and fine-tuning them for specific tasks for untargeted metabolomics datasets",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzembed.yaml",
-      "search_text": "mzembed mzEmbed mzEmbed, a framework for developing pre-trained generative models and fine-tuning them for specific tasks for untargeted metabolomics datasets metabolomics/v2"
+      "search_text": "mzembed mzEmbed mzEmbed, a framework for developing pre-trained generative models and fine-tuning them for specific tasks for untargeted metabolomics datasets metabolomics/v2 https://github.com/ReviveMed/mzEmbed"
     },
     {
       "slug": "mzexacto",
@@ -119769,68 +119817,68 @@
     {
       "slug": "mzmine-2",
       "name": "MZmine 2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YasinEl/mzRAPP",
       "license_spdx": "",
       "evidence_text": "IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2 IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2, *xcms Below we provided one more example for MZmine2 Download the XCMS- and MZmine 2-output files from [ucloud]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmine-2.yaml",
-      "search_text": "mzmine-2 MZmine 2 IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2 IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2, *xcms Below we provided one more example for MZmine2 Download the XCMS- and MZmine 2-output files from [ucloud] metabolomics/v2"
+      "search_text": "mzmine-2 MZmine 2 IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2 IDSL.IPA is able to outperform similar peak picking tools such as MZmine 2, *xcms Below we provided one more example for MZmine2 Download the XCMS- and MZmine 2-output files from [ucloud] metabolomics/v2 https://github.com/YasinEl/mzRAPP"
     },
     {
       "slug": "mzmine-3",
       "name": "MZmine 3",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/huaxuyu/bago",
       "license_spdx": "",
       "evidence_text": "`MZmine 3 <http://mzmine.github.io/>`_",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmine-3.yaml",
-      "search_text": "mzmine-3 MZmine 3 `MZmine 3 <http://mzmine.github.io/>`_ metabolomics/v2"
+      "search_text": "mzmine-3 MZmine 3 `MZmine 3 <http://mzmine.github.io/>`_ metabolomics/v2 https://github.com/huaxuyu/bago"
     },
     {
       "slug": "mzmine",
       "name": "mzmine",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "mzmine is an open-source software for mass spectrometry data processing Getting started with the [Documentation](https://mzmine.github.io/mzmine_documentation/index.html) The evaluation helpers rely on peak picking using MZMine parameters defined in `PeakPicking.py`. -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/) LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) Duplicate filtering on MZmine's MGF and CSV files (NEG)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmine.yaml",
-      "search_text": "mzmine mzmine mzmine is an open-source software for mass spectrometry data processing Getting started with the [Documentation](https://mzmine.github.io/mzmine_documentation/index.html) The evaluation helpers rely on peak picking using MZMine parameters defined in `PeakPicking.py`. -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/) LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) Duplicate filtering on MZmine's MGF and CSV files (NEG) metabolomics/v2"
+      "search_text": "mzmine mzmine mzmine is an open-source software for mass spectrometry data processing Getting started with the [Documentation](https://mzmine.github.io/mzmine_documentation/index.html) The evaluation helpers rely on peak picking using MZMine parameters defined in `PeakPicking.py`. -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/) LipidMatch can be used with various peak picking software (for example MZmine, XCMS, MS-DIAL, and Compound Discoverer) Duplicate filtering on MZmine's MGF and CSV files (NEG) metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "mzmine2",
       "name": "MZmine2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks",
       "license_spdx": "",
       "evidence_text": "open bioinformatic tools, such [MZmine2](http://mzmine.github.io/) MZmine output format using only the 'Peak area', 'row m/z' and 'row retention time' columns. -Inventa takes input directly from MZmine2 Inventa takes input directly from MZmine2 or MZmine 3",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmine2.yaml",
-      "search_text": "mzmine2 MZmine2 open bioinformatic tools, such [MZmine2](http://mzmine.github.io/) MZmine output format using only the 'Peak area', 'row m/z' and 'row retention time' columns. -Inventa takes input directly from MZmine2 Inventa takes input directly from MZmine2 or MZmine 3 metabolomics/v2"
+      "search_text": "mzmine2 MZmine2 open bioinformatic tools, such [MZmine2](http://mzmine.github.io/) MZmine output format using only the 'Peak area', 'row m/z' and 'row retention time' columns. -Inventa takes input directly from MZmine2 Inventa takes input directly from MZmine2 or MZmine 3 metabolomics/v2 https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks"
     },
     {
       "slug": "mzmine3",
       "name": "MZmine3",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Functional-Metabolomics-Lab/FBMN-STATS",
       "license_spdx": "",
       "evidence_text": "MASSIVE Datasets from which all the files were selected for MZmine3 -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/), is possible to use other processing sofwares Inventa takes input directly from MZmine2 or MZmine 3",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmine3.yaml",
-      "search_text": "mzmine3 MZmine3 MASSIVE Datasets from which all the files were selected for MZmine3 -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/), is possible to use other processing sofwares Inventa takes input directly from MZmine2 or MZmine 3 metabolomics/v2"
+      "search_text": "mzmine3 MZmine3 MASSIVE Datasets from which all the files were selected for MZmine3 -Inventa takes input directly from MZmine2 or [MZmine 3](http://mzmine.github.io/), is possible to use other processing sofwares Inventa takes input directly from MZmine2 or MZmine 3 metabolomics/v2 https://github.com/Functional-Metabolomics-Lab/FBMN-STATS"
     },
     {
       "slug": "mzmldataloader",
       "name": "MzMLDataLoader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "MzMLDataLoader",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzmldataloader.yaml",
-      "search_text": "mzmldataloader MzMLDataLoader MzMLDataLoader metabolomics/v2"
+      "search_text": "mzmldataloader MzMLDataLoader MzMLDataLoader metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "mzquality",
@@ -119846,79 +119894,79 @@
     {
       "slug": "mzr",
       "name": "mzR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/jcapelladesto/isoSCAN",
       "license_spdx": "",
       "evidence_text": "Integration with the mzR package from Bioconductor allows direct parsing of mzML and MGF files isoSCAN uses `mzR` package in order to read MS files",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzr.yaml",
-      "search_text": "mzr mzR Integration with the mzR package from Bioconductor allows direct parsing of mzML and MGF files isoSCAN uses `mzR` package in order to read MS files metabolomics/v2"
+      "search_text": "mzr mzR Integration with the mzR package from Bioconductor allows direct parsing of mzML and MGF files isoSCAN uses `mzR` package in order to read MS files metabolomics/v2 https://github.com/jcapelladesto/isoSCAN"
     },
     {
       "slug": "mzrapp",
       "name": "mzRAPP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YasinEl/mzRAPP",
       "license_spdx": "",
       "evidence_text": "You can now start mzRAPP using: library(mzRAPP); callmzRAPP() The goal of mzRAPP is to allow reliability assessment of non-targeted data pre-processing (NPP)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzrapp.yaml",
-      "search_text": "mzrapp mzRAPP You can now start mzRAPP using: library(mzRAPP); callmzRAPP() The goal of mzRAPP is to allow reliability assessment of non-targeted data pre-processing (NPP) metabolomics/v2"
+      "search_text": "mzrapp mzRAPP You can now start mzRAPP using: library(mzRAPP); callmzRAPP() The goal of mzRAPP is to allow reliability assessment of non-targeted data pre-processing (NPP) metabolomics/v2 https://github.com/YasinEl/mzRAPP"
     },
     {
       "slug": "mzrtsim",
       "name": "mzrtsim",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/yufree/mzrtsim",
       "license_spdx": "",
       "evidence_text": "github.com__yufree__mzrtsim",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/mzrtsim.yaml",
-      "search_text": "mzrtsim mzrtsim github.com__yufree__mzrtsim metabolomics/v2"
+      "search_text": "mzrtsim mzrtsim github.com__yufree__mzrtsim metabolomics/v2 https://github.com/yufree/mzrtsim"
     },
     {
       "slug": "nanobind",
       "name": "nanobind",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "nanobind binding files are in `src/pyOpenMS/bindings/`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nanobind.yaml",
-      "search_text": "nanobind nanobind nanobind binding files are in `src/pyOpenMS/bindings/` metabolomics/v2"
+      "search_text": "nanobind nanobind nanobind binding files are in `src/pyOpenMS/bindings/` metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "napari",
       "name": "napari",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MMV-Lab/MSI-Explorer",
       "license_spdx": "",
       "evidence_text": "The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/napari.yaml",
-      "search_text": "napari napari The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data. metabolomics/v2"
+      "search_text": "napari napari The MSI-Explorer napari plugin is a powerful tool designed for targeted biochemical annotations in MSI data. metabolomics/v2 https://github.com/MMV-Lab/MSI-Explorer"
     },
     {
       "slug": "ncbi-e-utilities",
       "name": "NCBI E-utilities",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mibig-secmet/mibig-json",
       "license_spdx": "",
       "evidence_text": "NCBI's GenBank/RefSeq databases",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ncbi-e-utilities.yaml",
-      "search_text": "ncbi-e-utilities NCBI E-utilities NCBI's GenBank/RefSeq databases metabolomics/v2"
+      "search_text": "ncbi-e-utilities NCBI E-utilities NCBI's GenBank/RefSeq databases metabolomics/v2 https://github.com/mibig-secmet/mibig-json"
     },
     {
       "slug": "ncgtw",
       "name": "ncGTW",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ChiungTingWu/ncGTW",
       "license_spdx": "",
       "evidence_text": "Neighbor-wise Compound-specific Graphical Time Warping (ncGTW) [@ncgtw19] is an alignment algorithm",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ncgtw.yaml",
-      "search_text": "ncgtw ncGTW Neighbor-wise Compound-specific Graphical Time Warping (ncGTW) [@ncgtw19] is an alignment algorithm metabolomics/v2"
+      "search_text": "ncgtw ncGTW Neighbor-wise Compound-specific Graphical Time Warping (ncGTW) [@ncgtw19] is an alignment algorithm metabolomics/v2 https://github.com/ChiungTingWu/ncGTW"
     },
     {
       "slug": "neatms",
@@ -119945,24 +119993,24 @@
     {
       "slug": "net-6",
       "name": ".NET 6",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/net-6.yaml",
-      "search_text": "net-6 .NET 6 we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6 metabolomics/v2"
+      "search_text": "net-6 .NET 6 we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6 metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "net-8-0",
       "name": ".NET 8.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fgcz/rawrr",
       "license_spdx": "",
       "evidence_text": "In case you prefer to compile `rawrr.exe` from C# source code, please install the .NET 8.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/net-8-0.yaml",
-      "search_text": "net-8-0 .NET 8.0 In case you prefer to compile `rawrr.exe` from C# source code, please install the .NET 8.0 metabolomics/v2"
+      "search_text": "net-8-0 .NET 8.0 In case you prefer to compile `rawrr.exe` from C# source code, please install the .NET 8.0 metabolomics/v2 https://github.com/fgcz/rawrr"
     },
     {
       "slug": "net-framework-4-8",
@@ -119978,46 +120026,46 @@
     {
       "slug": "net-framework",
       "name": ".NET Framework",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor",
       "license_spdx": "",
       "evidence_text": ".NET Framework 4.8 the main MsdialGuiApp project can be built using .NET Framework 4.7.2 we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6 .NET Framework 4.7.2 or later (included with Windows 10 update 1803 and later releases",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/net-framework.yaml",
-      "search_text": "net-framework .NET Framework .NET Framework 4.8 the main MsdialGuiApp project can be built using .NET Framework 4.7.2 we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6 .NET Framework 4.7.2 or later (included with Windows 10 update 1803 and later releases metabolomics/v2"
+      "search_text": "net-framework .NET Framework .NET Framework 4.8 the main MsdialGuiApp project can be built using .NET Framework 4.7.2 we primarily utilize the frameworks of .NET Framework 4.7.2, .NET Core 3.1, and .NET 6 .NET Framework 4.7.2 or later (included with Windows 10 update 1803 and later releases metabolomics/v2 https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
     },
     {
       "slug": "net-standard",
       "name": ".NET Standard",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "The .NET class libraries adhere at least to the specifications of .NET Standard 2.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/net-standard.yaml",
-      "search_text": "net-standard .NET Standard The .NET class libraries adhere at least to the specifications of .NET Standard 2.0 metabolomics/v2"
+      "search_text": "net-standard .NET Standard The .NET class libraries adhere at least to the specifications of .NET Standard 2.0 metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "netgsa-r-package",
       "name": "netgsa R package",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Karnovsky-Lab/DNEA",
       "license_spdx": "",
       "evidence_text": "subsequently test them for enrichment across experimental conditions using the [netgsa R package](https://cran.rstudio.com/web/packages/netgsa/index.html)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/netgsa-r-package.yaml",
-      "search_text": "netgsa-r-package netgsa R package subsequently test them for enrichment across experimental conditions using the [netgsa R package](https://cran.rstudio.com/web/packages/netgsa/index.html) metabolomics/v2"
+      "search_text": "netgsa-r-package netgsa R package subsequently test them for enrichment across experimental conditions using the [netgsa R package](https://cran.rstudio.com/web/packages/netgsa/index.html) metabolomics/v2 https://github.com/Karnovsky-Lab/DNEA"
     },
     {
       "slug": "networkx",
       "name": "networkx",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries The graph operations are supported by the networkx library networkx import ... networkx Dependencies: networkx",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/networkx.yaml",
-      "search_text": "networkx networkx For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries The graph operations are supported by the networkx library networkx import ... networkx Dependencies: networkx metabolomics/v2"
+      "search_text": "networkx networkx For presenting Spectral Network propagation graphs, MetaMiner also requires `matplotlib` and `networkx` Python libraries The graph operations are supported by the networkx library networkx import ... networkx Dependencies: networkx metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "neural-networks-mlpnn-with-relu-activation",
@@ -120055,13 +120103,13 @@
     {
       "slug": "nextflow",
       "name": "Nextflow",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 (IMPORTANT), a workflow tool to run tasks across multiple compute infrastructures [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A522.10.0-brightgreen.svg)](https://www.nextflow.io/) nextflow4ms-dial To learn NextFlow checkout this documentation To learn NextFlow checkout this documentation: https://www.nextflow.io/docs/latest/index.html",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nextflow.yaml",
-      "search_text": "nextflow Nextflow The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 (IMPORTANT), a workflow tool to run tasks across multiple compute infrastructures [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A522.10.0-brightgreen.svg)](https://www.nextflow.io/) nextflow4ms-dial To learn NextFlow checkout this documentation To learn NextFlow checkout this documentation: https://www.nextflow.io/docs/latest/index.html metabolomics/v2"
+      "search_text": "nextflow Nextflow The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 The pipeline is built using [Nextflow](https://www.nextflow.io) version 23.04.2.5870 (IMPORTANT), a workflow tool to run tasks across multiple compute infrastructures [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A522.10.0-brightgreen.svg)](https://www.nextflow.io/) nextflow4ms-dial To learn NextFlow checkout this documentation To learn NextFlow checkout this documentation: https://www.nextflow.io/docs/latest/index.html metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "nist",
@@ -120077,35 +120125,35 @@
     {
       "slug": "nmrbox",
       "name": "NMRBox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/edisonomics/SAND",
       "license_spdx": "",
       "evidence_text": "latest interface to NMRBox (SAND_V7)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nmrbox.yaml",
-      "search_text": "nmrbox NMRBox latest interface to NMRBox (SAND_V7) metabolomics/v2"
+      "search_text": "nmrbox NMRBox latest interface to NMRBox (SAND_V7) metabolomics/v2 https://github.com/edisonomics/SAND"
     },
     {
       "slug": "nmrfx",
       "name": "NMRFx",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/nanalysis/nmrfx",
       "license_spdx": "",
       "evidence_text": "github.com__nanalysis__nmrfx github.com/nanalysis/nmrfx",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nmrfx.yaml",
-      "search_text": "nmrfx NMRFx github.com__nanalysis__nmrfx github.com/nanalysis/nmrfx metabolomics/v2"
+      "search_text": "nmrfx NMRFx github.com__nanalysis__nmrfx github.com/nanalysis/nmrfx metabolomics/v2 https://github.com/nanalysis/nmrfx"
     },
     {
       "slug": "nmrpipe",
       "name": "NMRPipe",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/edisonomics/SAND",
       "license_spdx": "",
       "evidence_text": "interface to NMRPipe (pipe_scripts/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nmrpipe.yaml",
-      "search_text": "nmrpipe NMRPipe interface to NMRPipe (pipe_scripts/) metabolomics/v2"
+      "search_text": "nmrpipe NMRPipe interface to NMRPipe (pipe_scripts/) metabolomics/v2 https://github.com/edisonomics/SAND"
     },
     {
       "slug": "noreva",
@@ -120121,24 +120169,24 @@
     {
       "slug": "norine",
       "name": "Norine",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "find structures on other chemical projects like Norine",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/norine.yaml",
-      "search_text": "norine Norine find structures on other chemical projects like Norine metabolomics/v2"
+      "search_text": "norine Norine find structures on other chemical projects like Norine metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "normalizemets",
       "name": "NormalizeMets",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/metabolomicstats/NormalizeMets",
       "license_spdx": "",
       "evidence_text": "Install the NormalizeMets package by using the following function: `install.packages(\"NormalizeMets\")`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/normalizemets.yaml",
-      "search_text": "normalizemets NormalizeMets Install the NormalizeMets package by using the following function: `install.packages(\"NormalizeMets\")` metabolomics/v2"
+      "search_text": "normalizemets NormalizeMets Install the NormalizeMets package by using the following function: `install.packages(\"NormalizeMets\")` metabolomics/v2 https://github.com/metabolomicstats/NormalizeMets"
     },
     {
       "slug": "norvisualization",
@@ -120154,24 +120202,24 @@
     {
       "slug": "notame",
       "name": "notame",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/antonvsdata/notame",
       "license_spdx": "",
       "evidence_text": "This package can be used to analyze preprocessed LC-MS data in non-targeted metabolomics library(notame) ```flag_quality``` is used to flag features based on the other quality metrics",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/notame.yaml",
-      "search_text": "notame notame This package can be used to analyze preprocessed LC-MS data in non-targeted metabolomics library(notame) ```flag_quality``` is used to flag features based on the other quality metrics metabolomics/v2"
+      "search_text": "notame notame This package can be used to analyze preprocessed LC-MS data in non-targeted metabolomics library(notame) ```flag_quality``` is used to flag features based on the other quality metrics metabolomics/v2 https://github.com/antonvsdata/notame"
     },
     {
       "slug": "np-atlas",
       "name": "NP Atlas",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "find structures on other chemical projects like NP Atlas",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/np-atlas.yaml",
-      "search_text": "np-atlas NP Atlas find structures on other chemical projects like NP Atlas metabolomics/v2"
+      "search_text": "np-atlas NP Atlas find structures on other chemical projects like NP Atlas metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "npanalyst",
@@ -120187,57 +120235,57 @@
     {
       "slug": "npclassifier",
       "name": "NPClassifier",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zquinlan/concise",
       "license_spdx": "",
       "evidence_text": "use NPClassifier instead of ClassyFire by checking the box in the GUI",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/npclassifier.yaml",
-      "search_text": "npclassifier NPClassifier use NPClassifier instead of ClassyFire by checking the box in the GUI metabolomics/v2"
+      "search_text": "npclassifier NPClassifier use NPClassifier instead of ClassyFire by checking the box in the GUI metabolomics/v2 https://github.com/zquinlan/concise"
     },
     {
       "slug": "npdtools-2-5-0",
       "name": "NPDtools 2.5.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/npdtools-2-5-0.yaml",
-      "search_text": "npdtools-2-5-0 NPDtools 2.5.0 The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools metabolomics/v2"
+      "search_text": "npdtools-2-5-0 NPDtools 2.5.0 The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "npdtools",
       "name": "NPDtools",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ablab/npdtools",
       "license_spdx": "",
       "evidence_text": "The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/npdtools.yaml",
-      "search_text": "npdtools NPDtools The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools metabolomics/v2"
+      "search_text": "npdtools NPDtools The latest version is available in the Natural Product Discovery toolkit (NPDtools) at https://github.com/ablab/npdtools metabolomics/v2 https://github.com/ablab/npdtools"
     },
     {
       "slug": "npfimg",
       "name": "NPFimg",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/poomcj/NPFimg",
       "license_spdx": "",
       "evidence_text": "github.com__poomcj__NPFimg We present a method named NPFimg, which automatically identifies multivariate chemo-/biomarker features of analytes in chromatography–mass spectrometry (MS) data by combining image processing and",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/npfimg.yaml",
-      "search_text": "npfimg NPFimg github.com__poomcj__NPFimg We present a method named NPFimg, which automatically identifies multivariate chemo-/biomarker features of analytes in chromatography–mass spectrometry (MS) data by combining image processing and metabolomics/v2"
+      "search_text": "npfimg NPFimg github.com__poomcj__NPFimg We present a method named NPFimg, which automatically identifies multivariate chemo-/biomarker features of analytes in chromatography–mass spectrometry (MS) data by combining image processing and metabolomics/v2 https://github.com/poomcj/NPFimg"
     },
     {
       "slug": "nplinker",
       "name": "nplinker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "It provides the tools [`GNPSDownloader`][nplinker.metabolomics.gnps.GNPSDownloader] and [`GNPSExtractor`][nplinker.metabolomics.gnps.GNPSExtractor] [![github repo badge](https://img.shields.io/badge/github-nplinker-000.svg?color=blue)](https://github.com/NPLinker/nplinker) from nplinker import NPLinker NPLinker, a software framework to link genomic and metabolomic data NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set NPLinker is a python framework for data mining microbial natural products",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/nplinker.yaml",
-      "search_text": "nplinker nplinker It provides the tools [`GNPSDownloader`][nplinker.metabolomics.gnps.GNPSDownloader] and [`GNPSExtractor`][nplinker.metabolomics.gnps.GNPSExtractor] [![github repo badge](https://img.shields.io/badge/github-nplinker-000.svg?color=blue)](https://github.com/NPLinker/nplinker) from nplinker import NPLinker NPLinker, a software framework to link genomic and metabolomic data NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set NPLinker is a python framework for data mining microbial natural products metabolomics/v2"
+      "search_text": "nplinker nplinker It provides the tools [`GNPSDownloader`][nplinker.metabolomics.gnps.GNPSDownloader] and [`GNPSExtractor`][nplinker.metabolomics.gnps.GNPSExtractor] [![github repo badge](https://img.shields.io/badge/github-nplinker-000.svg?color=blue)](https://github.com/NPLinker/nplinker) from nplinker import NPLinker NPLinker, a software framework to link genomic and metabolomic data NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set NPLinker is a python framework for data mining microbial natural products metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "npm",
@@ -120253,123 +120301,123 @@
     {
       "slug": "numba",
       "name": "Numba",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/sword-nan/SpecEmbedding",
       "license_spdx": "",
       "evidence_text": "making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25], the library by making extensive use of Numpy [24] and Numba [25] 该装饰器来自 numba optimized for computational efficiency using [NumPy](https://www.numpy.org/) and [Numba](http://numba.pydata.org/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/numba.yaml",
-      "search_text": "numba Numba making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25], the library by making extensive use of Numpy [24] and Numba [25] 该装饰器来自 numba optimized for computational efficiency using [NumPy](https://www.numpy.org/) and [Numba](http://numba.pydata.org/) metabolomics/v2"
+      "search_text": "numba Numba making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25], the library by making extensive use of Numpy [24] and Numba [25] 该装饰器来自 numba optimized for computational efficiency using [NumPy](https://www.numpy.org/) and [Numba](http://numba.pydata.org/) metabolomics/v2 https://github.com/sword-nan/SpecEmbedding"
     },
     {
       "slug": "numpy-1-15-4",
       "name": "numpy 1.15.4",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "numpy(1.15.4)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/numpy-1-15-4.yaml",
-      "search_text": "numpy-1-15-4 numpy 1.15.4 numpy(1.15.4) metabolomics/v2"
+      "search_text": "numpy-1-15-4 numpy 1.15.4 numpy(1.15.4) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "numpy-or-scipy",
       "name": "NumPy or SciPy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "follows the hypergeometric distribution as previously stated",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/numpy-or-scipy.yaml",
-      "search_text": "numpy-or-scipy NumPy or SciPy follows the hypergeometric distribution as previously stated metabolomics/v2"
+      "search_text": "numpy-or-scipy NumPy or SciPy follows the hypergeometric distribution as previously stated metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "numpy",
       "name": "NumPy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FangYuan717/ROASMI",
       "license_spdx": "",
       "evidence_text": "Spec2Vec was optimised by making extensive use of Numpy [24] Spec2Vec by making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25] **NumPy** intensity_track is np.array(full RT length). requires _SciPy_, _NumPy_, _h5py_ libraries.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/numpy.yaml",
-      "search_text": "numpy NumPy Spec2Vec was optimised by making extensive use of Numpy [24] Spec2Vec by making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25] **NumPy** intensity_track is np.array(full RT length). requires _SciPy_, _NumPy_, _h5py_ libraries. metabolomics/v2"
+      "search_text": "numpy NumPy Spec2Vec was optimised by making extensive use of Numpy [24] Spec2Vec by making extensive use of Numpy [24] and Numba [25] by making extensive use of Numpy [24] and Numba [25] **NumPy** intensity_track is np.array(full RT length). requires _SciPy_, _NumPy_, _h5py_ libraries. metabolomics/v2 https://github.com/FangYuan717/ROASMI"
     },
     {
       "slug": "omu-omu-summary-function",
       "name": "omu (omu_summary function)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/connor-reid-tiffany/Omu",
       "license_spdx": "",
       "evidence_text": "Omu supports two univariate statistical models, t test and anova, using the functions ```omu_summary``` and ```anova_function``` respectively",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/omu-omu-summary-function.yaml",
-      "search_text": "omu-omu-summary-function omu (omu_summary function) Omu supports two univariate statistical models, t test and anova, using the functions ```omu_summary``` and ```anova_function``` respectively metabolomics/v2"
+      "search_text": "omu-omu-summary-function omu (omu_summary function) Omu supports two univariate statistical models, t test and anova, using the functions ```omu_summary``` and ```anova_function``` respectively metabolomics/v2 https://github.com/connor-reid-tiffany/Omu"
     },
     {
       "slug": "onnxruntime",
       "name": "onnxruntime",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "optional dependencies are also required and can be installed with pip install -r requirements-optional.txt",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/onnxruntime.yaml",
-      "search_text": "onnxruntime onnxruntime optional dependencies are also required and can be installed with pip install -r requirements-optional.txt metabolomics/v2"
+      "search_text": "onnxruntime onnxruntime optional dependencies are also required and can be installed with pip install -r requirements-optional.txt metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "open-tree-of-life",
       "name": "Open Tree of Life",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "The taxonomy should be cleaned to uptoday recognized names, you can use the Open Tree of Life",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/open-tree-of-life.yaml",
-      "search_text": "open-tree-of-life Open Tree of Life The taxonomy should be cleaned to uptoday recognized names, you can use the Open Tree of Life metabolomics/v2"
+      "search_text": "open-tree-of-life Open Tree of Life The taxonomy should be cleaned to uptoday recognized names, you can use the Open Tree of Life metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "openms-topp-tools",
       "name": "OpenMS TOPP tools",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "complex workflows utilizing **OpenMS TOPP tools** with parallel execution",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/openms-topp-tools.yaml",
-      "search_text": "openms-topp-tools OpenMS TOPP tools complex workflows utilizing **OpenMS TOPP tools** with parallel execution metabolomics/v2"
+      "search_text": "openms-topp-tools OpenMS TOPP tools complex workflows utilizing **OpenMS TOPP tools** with parallel execution metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "openms",
       "name": "OpenMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AutoFlowResearch/SmartPeak",
       "license_spdx": "",
       "evidence_text": "[Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) or [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) Processes mzML output from a simulation (or real acquisition) to compute fragmentation coverage using OpenMS feature detection. pyOpenMS (Python interface to the C++ OpenMS library) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data. projects like OpenMS or pyteomics chose a fundamentally different approach.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/openms.yaml",
-      "search_text": "openms OpenMS [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) or [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) Processes mzML output from a simulation (or real acquisition) to compute fragmentation coverage using OpenMS feature detection. pyOpenMS (Python interface to the C++ OpenMS library) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data. projects like OpenMS or pyteomics chose a fundamentally different approach. metabolomics/v2"
+      "search_text": "openms OpenMS [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) or [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) Processes mzML output from a simulation (or real acquisition) to compute fragmentation coverage using OpenMS feature detection. pyOpenMS (Python interface to the C++ OpenMS library) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data. projects like OpenMS or pyteomics chose a fundamentally different approach. metabolomics/v2 https://github.com/AutoFlowResearch/SmartPeak"
     },
     {
       "slug": "opennau",
       "name": "openNAU",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zjuRong/openNAU",
       "license_spdx": "",
       "evidence_text": "An open-source analysis software for untargeted metabolism data (openNAU) was constructed",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/opennau.yaml",
-      "search_text": "opennau openNAU An open-source analysis software for untargeted metabolism data (openNAU) was constructed metabolomics/v2"
+      "search_text": "opennau openNAU An open-source analysis software for untargeted metabolism data (openNAU) was constructed metabolomics/v2 https://github.com/zjuRong/openNAU"
     },
     {
       "slug": "openpyxl",
       "name": "openpyxl",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Leo-Cheng-Lab/ROIAL-NMR",
       "license_spdx": "",
       "evidence_text": "openpyxl 3.1.5",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/openpyxl.yaml",
-      "search_text": "openpyxl openpyxl openpyxl 3.1.5 metabolomics/v2"
+      "search_text": "openpyxl openpyxl openpyxl 3.1.5 metabolomics/v2 https://github.com/Leo-Cheng-Lab/ROIAL-NMR"
     },
     {
       "slug": "opentims",
@@ -120418,123 +120466,123 @@
     {
       "slug": "optimus",
       "name": "Optimus",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks",
       "license_spdx": "",
       "evidence_text": "[Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/optimus.yaml",
-      "search_text": "optimus Optimus [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) metabolomics/v2"
+      "search_text": "optimus Optimus [Optimus](https://github.com/MolecularCartography/Optimus) (using OpenMS) metabolomics/v2 https://github.com/DorresteinLaboratory/Bioactive_Molecular_Networks"
     },
     {
       "slug": "orca",
       "name": "orca",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "Remove orca in favor of Kaleido **orca** (version >= 6.0.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/orca.yaml",
-      "search_text": "orca orca Remove orca in favor of Kaleido **orca** (version >= 6.0.0) metabolomics/v2"
+      "search_text": "orca orca Remove orca in favor of Kaleido **orca** (version >= 6.0.0) metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "orgmassspecr",
       "name": "OrgMassSpecR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "OrgMassSpecR",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/orgmassspecr.yaml",
-      "search_text": "orgmassspecr OrgMassSpecR OrgMassSpecR metabolomics/v2"
+      "search_text": "orgmassspecr OrgMassSpecR OrgMassSpecR metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "oswdataaccess",
       "name": "OSWDataAccess",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "OSWDataAccess",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/oswdataaccess.yaml",
-      "search_text": "oswdataaccess OSWDataAccess OSWDataAccess metabolomics/v2"
+      "search_text": "oswdataaccess OSWDataAccess OSWDataAccess metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "ouks",
       "name": "OUKS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/plyush1993/OUKS",
       "license_spdx": "",
       "evidence_text": "comprehensive nine step LC-MS untargeted metabolomic profiling data processing toolbox",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ouks.yaml",
-      "search_text": "ouks OUKS comprehensive nine step LC-MS untargeted metabolomic profiling data processing toolbox metabolomics/v2"
+      "search_text": "ouks OUKS comprehensive nine step LC-MS untargeted metabolomic profiling data processing toolbox metabolomics/v2 https://github.com/plyush1993/OUKS"
     },
     {
       "slug": "pacman",
       "name": "pacman",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "pacman -S --needed --noconfirm git",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pacman.yaml",
-      "search_text": "pacman pacman pacman -S --needed --noconfirm git metabolomics/v2"
+      "search_text": "pacman pacman pacman -S --needed --noconfirm git metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "pairkat",
       "name": "PaIRKAT",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/CharlieCarpenter/PaIRKAT",
       "license_spdx": "",
       "evidence_text": "github.com/CharlieCarpenter/PaIRKAT",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pairkat.yaml",
-      "search_text": "pairkat PaIRKAT github.com/CharlieCarpenter/PaIRKAT metabolomics/v2"
+      "search_text": "pairkat PaIRKAT github.com/CharlieCarpenter/PaIRKAT metabolomics/v2 https://github.com/CharlieCarpenter/PaIRKAT"
     },
     {
       "slug": "pals-pathway-activity-level-scoring",
       "name": "PALS (Pathway Activity Level Scoring)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/glasgowcompbio/PALS",
       "license_spdx": "",
       "evidence_text": "we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways, decomposes activity levels in pathways we introduce PALS (Pathway Activity Level Scoring), a complete tool that performs database queries of pathways, decomposes activity levels in pathways PALS (Pathway Activity Level Scoring) we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways,",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pals-pathway-activity-level-scoring.yaml",
-      "search_text": "pals-pathway-activity-level-scoring PALS (Pathway Activity Level Scoring) we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways, decomposes activity levels in pathways we introduce PALS (Pathway Activity Level Scoring), a complete tool that performs database queries of pathways, decomposes activity levels in pathways PALS (Pathway Activity Level Scoring) we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways, metabolomics/v2"
+      "search_text": "pals-pathway-activity-level-scoring PALS (Pathway Activity Level Scoring) we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways, decomposes activity levels in pathways we introduce PALS (Pathway Activity Level Scoring), a complete tool that performs database queries of pathways, decomposes activity levels in pathways PALS (Pathway Activity Level Scoring) we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways, metabolomics/v2 https://github.com/glasgowcompbio/PALS"
     },
     {
       "slug": "pals-viewer",
       "name": "PALS Viewer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/glasgowcompbio/PALS",
       "license_spdx": "",
       "evidence_text": "PALS Viewer To access our interactive Web application PALS Viewer, please visit [https://pals.glasgowcompbio.org/app/]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pals-viewer.yaml",
-      "search_text": "pals-viewer PALS Viewer PALS Viewer To access our interactive Web application PALS Viewer, please visit [https://pals.glasgowcompbio.org/app/] metabolomics/v2"
+      "search_text": "pals-viewer PALS Viewer PALS Viewer To access our interactive Web application PALS Viewer, please visit [https://pals.glasgowcompbio.org/app/] metabolomics/v2 https://github.com/glasgowcompbio/PALS"
     },
     {
       "slug": "pals",
       "name": "PALS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/glasgowcompbio/PALS",
       "license_spdx": "",
       "evidence_text": "we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pals.yaml",
-      "search_text": "pals PALS we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways metabolomics/v2"
+      "search_text": "pals PALS we introduce **PALS (Pathway Activity Level Scoring)**, a complete tool that performs database queries of pathways metabolomics/v2 https://github.com/glasgowcompbio/PALS"
     },
     {
       "slug": "pandas-1-1-1",
       "name": "Pandas 1.1.1",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "Pandas(1.1.1.)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pandas-1-1-1.yaml",
-      "search_text": "pandas-1-1-1 Pandas 1.1.1 Pandas(1.1.1.) metabolomics/v2"
+      "search_text": "pandas-1-1-1 Pandas 1.1.1 Pandas(1.1.1.) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "pandas-for-tabular-data-manipulation-and-aggregation",
@@ -120550,35 +120598,35 @@
     {
       "slug": "pandas-or-equivalent-tabular-data-library",
       "name": "pandas or equivalent tabular data library",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mibig-secmet/mibig-json",
       "license_spdx": "",
       "evidence_text": "entry status is now tracked via the `cluster.status` field",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pandas-or-equivalent-tabular-data-library.yaml",
-      "search_text": "pandas-or-equivalent-tabular-data-library pandas or equivalent tabular data library entry status is now tracked via the `cluster.status` field metabolomics/v2"
+      "search_text": "pandas-or-equivalent-tabular-data-library pandas or equivalent tabular data library entry status is now tracked via the `cluster.status` field metabolomics/v2 https://github.com/mibig-secmet/mibig-json"
     },
     {
       "slug": "pandas",
       "name": "Pandas",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FangYuan717/ROASMI",
       "license_spdx": "",
       "evidence_text": "Spec2Vec was optimised by making extensive use of Numpy [24] and Numba [25], the library matching was implemented using Pandas [40] Spec2Vec by making extensive use of Numpy [24] and Numba [25], the library was optimised by making extensive use of Pandas [40] using Pandas [40] **Pandas** _No usage/docs found._ streamline various tasks such as data parsing, matching, statistical analysis, and visualization",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pandas.yaml",
-      "search_text": "pandas Pandas Spec2Vec was optimised by making extensive use of Numpy [24] and Numba [25], the library matching was implemented using Pandas [40] Spec2Vec by making extensive use of Numpy [24] and Numba [25], the library was optimised by making extensive use of Pandas [40] using Pandas [40] **Pandas** _No usage/docs found._ streamline various tasks such as data parsing, matching, statistical analysis, and visualization metabolomics/v2"
+      "search_text": "pandas Pandas Spec2Vec was optimised by making extensive use of Numpy [24] and Numba [25], the library matching was implemented using Pandas [40] Spec2Vec by making extensive use of Numpy [24] and Numba [25], the library was optimised by making extensive use of Pandas [40] using Pandas [40] **Pandas** _No usage/docs found._ streamline various tasks such as data parsing, matching, statistical analysis, and visualization metabolomics/v2 https://github.com/FangYuan717/ROASMI"
     },
     {
       "slug": "parallel-computing-toolbox",
       "name": "Parallel Computing Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/parallel-computing-toolbox.yaml",
-      "search_text": "parallel-computing-toolbox Parallel Computing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "parallel-computing-toolbox Parallel Computing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "parallel",
@@ -120594,35 +120642,35 @@
     {
       "slug": "paramounter",
       "name": "Paramounter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/Paramounter",
       "license_spdx": "",
       "evidence_text": "github.com/HuanLab/Paramounter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/paramounter.yaml",
-      "search_text": "paramounter Paramounter github.com/HuanLab/Paramounter metabolomics/v2"
+      "search_text": "paramounter Paramounter github.com/HuanLab/Paramounter metabolomics/v2 https://github.com/HuanLab/Paramounter"
     },
     {
       "slug": "patroon",
       "name": "patRoon",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rickhelmus/patRoon",
       "license_spdx": "",
       "evidence_text": "The `generateTPs` function is used to obtain TPs for a particular set of parents. componTP <- generateComponents(algorithm = \"tp\", convertToMFDB | Generates a [MetFrag] database for all TPs",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/patroon.yaml",
-      "search_text": "patroon patRoon The `generateTPs` function is used to obtain TPs for a particular set of parents. componTP <- generateComponents(algorithm = \"tp\", convertToMFDB | Generates a [MetFrag] database for all TPs metabolomics/v2"
+      "search_text": "patroon patRoon The `generateTPs` function is used to obtain TPs for a particular set of parents. componTP <- generateComponents(algorithm = \"tp\", convertToMFDB | Generates a [MetFrag] database for all TPs metabolomics/v2 https://github.com/rickhelmus/patRoon"
     },
     {
       "slug": "pbapply",
       "name": "pbapply",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pbapply.yaml",
-      "search_text": "pbapply pbapply invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2"
+      "search_text": "pbapply pbapply invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "pcamethods",
@@ -120638,200 +120686,200 @@
     {
       "slug": "pcutils",
       "name": "pcutils",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Asa12138/MetaNet",
       "license_spdx": "",
       "evidence_text": "devtools::install_github(\"Asa12138/pcutils\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pcutils.yaml",
-      "search_text": "pcutils pcutils devtools::install_github(\"Asa12138/pcutils\") metabolomics/v2"
+      "search_text": "pcutils pcutils devtools::install_github(\"Asa12138/pcutils\") metabolomics/v2 https://github.com/Asa12138/MetaNet"
     },
     {
       "slug": "peakqc",
       "name": "PeakQC",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "PeakQC: Automated quality control pipeline by PCA analysis on MS1 data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/peakqc.yaml",
-      "search_text": "peakqc PeakQC PeakQC: Automated quality control pipeline by PCA analysis on MS1 data metabolomics/v2"
+      "search_text": "peakqc PeakQC PeakQC: Automated quality control pipeline by PCA analysis on MS1 data metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "peakquant",
       "name": "PeakQuant",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "PeakQuant: Targeted MS1 peak abundance extraction for quantitation.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/peakquant.yaml",
-      "search_text": "peakquant PeakQuant PeakQuant: Targeted MS1 peak abundance extraction for quantitation. metabolomics/v2"
+      "search_text": "peakquant PeakQuant PeakQuant: Targeted MS1 peak abundance extraction for quantitation. metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "perl-prima",
       "name": "Perl Prima",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/matteogiulietti/LipidOne",
       "license_spdx": "",
       "evidence_text": "Graphical User Interface, developed by using Perl Prima",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/perl-prima.yaml",
-      "search_text": "perl-prima Perl Prima Graphical User Interface, developed by using Perl Prima metabolomics/v2"
+      "search_text": "perl-prima Perl Prima Graphical User Interface, developed by using Perl Prima metabolomics/v2 https://github.com/matteogiulietti/LipidOne"
     },
     {
       "slug": "perl",
       "name": "Perl",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/matteogiulietti/LipidOne",
       "license_spdx": "",
       "evidence_text": "stand alone software entirely written in Perl",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/perl.yaml",
-      "search_text": "perl Perl stand alone software entirely written in Perl metabolomics/v2"
+      "search_text": "perl Perl stand alone software entirely written in Perl metabolomics/v2 https://github.com/matteogiulietti/LipidOne"
     },
     {
       "slug": "pewlib",
       "name": "pewlib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/djdt/pewpew",
       "license_spdx": "",
       "evidence_text": "based on the python library pewlib_",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pewlib.yaml",
-      "search_text": "pewlib pewlib based on the python library pewlib_ metabolomics/v2"
+      "search_text": "pewlib pewlib based on the python library pewlib_ metabolomics/v2 https://github.com/djdt/pewpew"
     },
     {
       "slug": "pewpew",
       "name": "pewpew",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/djdt/pewpew",
       "license_spdx": "",
       "evidence_text": "The built in `Filtering Tool` removes spikes by comparing pixel values to a locally defined threshold |pewpew| is an open-source LA-ICP-MS data import and processing application",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pewpew.yaml",
-      "search_text": "pewpew pewpew The built in `Filtering Tool` removes spikes by comparing pixel values to a locally defined threshold |pewpew| is an open-source LA-ICP-MS data import and processing application metabolomics/v2"
+      "search_text": "pewpew pewpew The built in `Filtering Tool` removes spikes by comparing pixel values to a locally defined threshold |pewpew| is an open-source LA-ICP-MS data import and processing application metabolomics/v2 https://github.com/djdt/pewpew"
     },
     {
       "slug": "pfam",
       "name": "PFAM",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "pHMM databases have been updated to __PFAM 35.0__ Functional annotation | CPAT, signalP, pfam",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pfam.yaml",
-      "search_text": "pfam PFAM pHMM databases have been updated to __PFAM 35.0__ Functional annotation | CPAT, signalP, pfam metabolomics/v2"
+      "search_text": "pfam PFAM pHMM databases have been updated to __PFAM 35.0__ Functional annotation | CPAT, signalP, pfam metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "pheatmap",
       "name": "pheatmap",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "pheatmap library(pheatmap)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pheatmap.yaml",
-      "search_text": "pheatmap pheatmap pheatmap library(pheatmap) metabolomics/v2"
+      "search_text": "pheatmap pheatmap pheatmap library(pheatmap) metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "php",
       "name": "PHP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "Backend is written in PHP with Symfony framework",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/php.yaml",
-      "search_text": "php PHP Backend is written in PHP with Symfony framework metabolomics/v2"
+      "search_text": "php PHP Backend is written in PHP with Symfony framework metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "pillow",
       "name": "Pillow",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base",
       "license_spdx": "",
       "evidence_text": "from PIL import Image",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pillow.yaml",
-      "search_text": "pillow Pillow from PIL import Image metabolomics/v2"
+      "search_text": "pillow Pillow from PIL import Image metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/ModiFinder_base"
     },
     {
       "slug": "pip",
       "name": "pip",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/JESTR1",
       "license_spdx": "",
       "evidence_text": "pip install -e .[dev] and [pip](https://pypi.org/project/pip/) Install DEIMoS using pip: pip install -e . Install DEIMoS using `pip <https://pypi.org/project/pip/>`_: ``pip install -e .`` pip install -r requirements.txt Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pip.yaml",
-      "search_text": "pip pip pip install -e .[dev] and [pip](https://pypi.org/project/pip/) Install DEIMoS using pip: pip install -e . Install DEIMoS using `pip <https://pypi.org/project/pip/>`_: ``pip install -e .`` pip install -r requirements.txt Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip] metabolomics/v2"
+      "search_text": "pip pip pip install -e .[dev] and [pip](https://pypi.org/project/pip/) Install DEIMoS using pip: pip install -e . Install DEIMoS using `pip <https://pypi.org/project/pip/>`_: ``pip install -e .`` pip install -r requirements.txt Please set up the environment as per this file using [conda](http://docs.condi.ioen/latest/)/[pip] metabolomics/v2 https://github.com/HassounLab/JESTR1"
     },
     {
       "slug": "plage-method-within-pals",
       "name": "PLAGE method (within PALS)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/glasgowcompbio/PALS",
       "license_spdx": "",
       "evidence_text": "decomposes activity levels in pathways via the PLAGE method",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/plage-method-within-pals.yaml",
-      "search_text": "plage-method-within-pals PLAGE method (within PALS) decomposes activity levels in pathways via the PLAGE method metabolomics/v2"
+      "search_text": "plage-method-within-pals PLAGE method (within PALS) decomposes activity levels in pathways via the PLAGE method metabolomics/v2 https://github.com/glasgowcompbio/PALS"
     },
     {
       "slug": "plantmasst",
       "name": "plantMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/plantmasst.yaml",
-      "search_text": "plantmasst plantMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2"
+      "search_text": "plantmasst plantMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "plotly-or-equivalent-interactive-plotting-library",
       "name": "Plotly or equivalent interactive plotting library",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/czbiohub-sf/Rapid-QC-MS",
       "license_spdx": "",
       "evidence_text": "**Interactive data visualization** of internal standard retention time, _m/z_, and intensity across samples",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/plotly-or-equivalent-interactive-plotting-library.yaml",
-      "search_text": "plotly-or-equivalent-interactive-plotting-library Plotly or equivalent interactive plotting library **Interactive data visualization** of internal standard retention time, _m/z_, and intensity across samples metabolomics/v2"
+      "search_text": "plotly-or-equivalent-interactive-plotting-library Plotly or equivalent interactive plotting library **Interactive data visualization** of internal standard retention time, _m/z_, and intensity across samples metabolomics/v2 https://github.com/czbiohub-sf/Rapid-QC-MS"
     },
     {
       "slug": "plotly",
       "name": "Plotly",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website",
       "license_spdx": "",
       "evidence_text": "interactive visualization integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: PLOTLY Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically slower than the BOKEH backend These plots can be generated by setting the `backend='ms_plotly'`. PLOTLY plots inferfances well with StreamLit WebApps and allow for interactive 3D plots.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/plotly.yaml",
-      "search_text": "plotly Plotly interactive visualization integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: PLOTLY Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically slower than the BOKEH backend These plots can be generated by setting the `backend='ms_plotly'`. PLOTLY plots inferfances well with StreamLit WebApps and allow for interactive 3D plots. metabolomics/v2"
+      "search_text": "plotly Plotly interactive visualization integrates seamlessly with various plotting library backends (matpotlib, bokeh and plotly) Extension: PLOTLY Multiple backends supported including matplotlib, bokeh, and plotly Rendering is typically slower than the BOKEH backend These plots can be generated by setting the `backend='ms_plotly'`. PLOTLY plots inferfances well with StreamLit WebApps and allow for interactive 3D plots. metabolomics/v2 https://github.com/Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website"
     },
     {
       "slug": "pmartr",
       "name": "pmartR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pmartR/PMart_ShinyApp",
       "license_spdx": "",
       "evidence_text": "uses a modified \"spans_procedure\" function from the R package pmartR [51] Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pmartr.yaml",
-      "search_text": "pmartr pmartR uses a modified \"spans_procedure\" function from the R package pmartR [51] Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package metabolomics/v2"
+      "search_text": "pmartr pmartR uses a modified \"spans_procedure\" function from the R package pmartR [51] Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package metabolomics/v2 https://github.com/pmartR/PMart_ShinyApp"
     },
     {
       "slug": "pnnl-preprocessor",
       "name": "PNNL PreProcessor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor",
       "license_spdx": "",
       "evidence_text": "we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM) IM-MS",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pnnl-preprocessor.yaml",
-      "search_text": "pnnl-preprocessor PNNL PreProcessor we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM) IM-MS metabolomics/v2"
+      "search_text": "pnnl-preprocessor PNNL PreProcessor we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files we have developed this user-friendly tool for Agilent MassHunter (.d) and UIMF mass spectrometry data files (MS-files) from drift tube (DT) and structure for lossless ion manipulations (SLIM) IM-MS metabolomics/v2 https://github.com/PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
     },
     {
       "slug": "poetry",
@@ -120858,68 +120906,68 @@
     {
       "slug": "postgresql",
       "name": "PostgreSQL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "docker run --name some-pg -d -p 5432:5432",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/postgresql.yaml",
-      "search_text": "postgresql PostgreSQL docker run --name some-pg -d -p 5432:5432 metabolomics/v2"
+      "search_text": "postgresql PostgreSQL docker run --name some-pg -d -p 5432:5432 metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "prcomp",
       "name": "prcomp",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BorchLab/CordBat",
       "license_spdx": "",
       "evidence_text": "pca_res <- prcomp(cordbat_example[, metabolite_cols], scale. = TRUE)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/prcomp.yaml",
-      "search_text": "prcomp prcomp pca_res <- prcomp(cordbat_example[, metabolite_cols], scale. = TRUE) metabolomics/v2"
+      "search_text": "prcomp prcomp pca_res <- prcomp(cordbat_example[, metabolite_cols], scale. = TRUE) metabolomics/v2 https://github.com/BorchLab/CordBat"
     },
     {
       "slug": "prepare-wikidata-lotus-prefect-py",
       "name": "prepare_wikidata_lotus_prefect.py",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/corinnabrungs/msn_tree_library",
       "license_spdx": "",
       "evidence_text": "run `prepare_wikidata_lotus_prefect.py` for updating the data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/prepare-wikidata-lotus-prefect-py.yaml",
-      "search_text": "prepare-wikidata-lotus-prefect-py prepare_wikidata_lotus_prefect.py run `prepare_wikidata_lotus_prefect.py` for updating the data metabolomics/v2"
+      "search_text": "prepare-wikidata-lotus-prefect-py prepare_wikidata_lotus_prefect.py run `prepare_wikidata_lotus_prefect.py` for updating the data metabolomics/v2 https://github.com/corinnabrungs/msn_tree_library"
     },
     {
       "slug": "prima-panel",
       "name": "PRIMA-Panel",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/funkam/PRIMA",
       "license_spdx": "",
       "evidence_text": "Pre-Analytical Investigator for NMR-based Metabolomics (PRIMA-Panel)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/prima-panel.yaml",
-      "search_text": "prima-panel PRIMA-Panel Pre-Analytical Investigator for NMR-based Metabolomics (PRIMA-Panel) metabolomics/v2"
+      "search_text": "prima-panel PRIMA-Panel Pre-Analytical Investigator for NMR-based Metabolomics (PRIMA-Panel) metabolomics/v2 https://github.com/funkam/PRIMA"
     },
     {
       "slug": "probability-product-kernel-ppk",
       "name": "Probability Product Kernel (PPK)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "we filter the input spectra to include only the peaks found in the training data, before using the Probability Product Kernel (PPK)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/probability-product-kernel-ppk.yaml",
-      "search_text": "probability-product-kernel-ppk Probability Product Kernel (PPK) we filter the input spectra to include only the peaks found in the training data, before using the Probability Product Kernel (PPK) metabolomics/v2"
+      "search_text": "probability-product-kernel-ppk Probability Product Kernel (PPK) we filter the input spectra to include only the peaks found in the training data, before using the Probability Product Kernel (PPK) metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "proc",
       "name": "pROC",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/slfan2013/SERDA",
       "license_spdx": "",
       "evidence_text": "packageVersion(\"pROC\") [1] ‘1.17.0.1’",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proc.yaml",
-      "search_text": "proc pROC packageVersion(\"pROC\") [1] ‘1.17.0.1’ metabolomics/v2"
+      "search_text": "proc pROC packageVersion(\"pROC\") [1] ‘1.17.0.1’ metabolomics/v2 https://github.com/slfan2013/SERDA"
     },
     {
       "slug": "proforma-2-0",
@@ -120946,57 +120994,57 @@
     {
       "slug": "proteowizard-library-and-tools",
       "name": "ProteoWizard Library and Tools",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ProteoWizard/pwiz",
       "license_spdx": "",
       "evidence_text": "The ProteoWizard Library and Tools are a set of modular and extensible open-source, cross-platform tools and software libraries",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proteowizard-library-and-tools.yaml",
-      "search_text": "proteowizard-library-and-tools ProteoWizard Library and Tools The ProteoWizard Library and Tools are a set of modular and extensible open-source, cross-platform tools and software libraries metabolomics/v2"
+      "search_text": "proteowizard-library-and-tools ProteoWizard Library and Tools The ProteoWizard Library and Tools are a set of modular and extensible open-source, cross-platform tools and software libraries metabolomics/v2 https://github.com/ProteoWizard/pwiz"
     },
     {
       "slug": "proteowizard-msconvert",
       "name": "ProteoWizard msconvert",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LabLaskin/MSIGen",
       "license_spdx": "",
       "evidence_text": "Conversion to mzML from several other formats can be performed using the free and open-source [ProteoWizard](https://proteowizard.sourceforge.io/) msconvert utility. transform the raw data from vendor format into __mz(X)ML__ format using __Proteowizard MSconvert__ you can convert it to the open-source .mzML format using ProteoWizard's MSConvert tool. You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proteowizard-msconvert.yaml",
-      "search_text": "proteowizard-msconvert ProteoWizard msconvert Conversion to mzML from several other formats can be performed using the free and open-source [ProteoWizard](https://proteowizard.sourceforge.io/) msconvert utility. transform the raw data from vendor format into __mz(X)ML__ format using __Proteowizard MSconvert__ you can convert it to the open-source .mzML format using ProteoWizard's MSConvert tool. You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html. metabolomics/v2"
+      "search_text": "proteowizard-msconvert ProteoWizard msconvert Conversion to mzML from several other formats can be performed using the free and open-source [ProteoWizard](https://proteowizard.sourceforge.io/) msconvert utility. transform the raw data from vendor format into __mz(X)ML__ format using __Proteowizard MSconvert__ you can convert it to the open-source .mzML format using ProteoWizard's MSConvert tool. You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html You can download ProteoWizard from https://proteowizard.sourceforge.io/download.html. metabolomics/v2 https://github.com/LabLaskin/MSIGen"
     },
     {
       "slug": "proteowizard-pwiz-skyline",
       "name": "proteowizard/pwiz-skyline",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "docker run --detach --name msconvert_docker --rm -it -e WINEDEBUG=-all -v ./chem_spectra/tmp:/data proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses bash docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proteowizard-pwiz-skyline.yaml",
-      "search_text": "proteowizard-pwiz-skyline proteowizard/pwiz-skyline docker run --detach --name msconvert_docker --rm -it -e WINEDEBUG=-all -v ./chem_spectra/tmp:/data proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses bash docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses metabolomics/v2"
+      "search_text": "proteowizard-pwiz-skyline proteowizard/pwiz-skyline docker run --detach --name msconvert_docker --rm -it -e WINEDEBUG=-all -v ./chem_spectra/tmp:/data proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses bash docker pull proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "proteowizard",
       "name": "ProteoWizard",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "pwiz_bindings_cli.dll from the ProteoWizard project based on pwiz_bindings_cli.dll from the ProteoWizard project. msconvert, distributed with the ProteoWizard Project msconvert, distributed with the ProteoWizard Project http://proteowizard.sourceforge.net/download.html Msconvert in ProteoWizard (https://proteowizard.sourceforge.io/tools.shtml) can handle the conversion of most vendor data formats. MetaMiner natively supports MGF, mzXML, mzData and uses msconvert utility from the ProteoWizard package to convert spectra in other formats to MGF",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proteowizard.yaml",
-      "search_text": "proteowizard ProteoWizard pwiz_bindings_cli.dll from the ProteoWizard project based on pwiz_bindings_cli.dll from the ProteoWizard project. msconvert, distributed with the ProteoWizard Project msconvert, distributed with the ProteoWizard Project http://proteowizard.sourceforge.net/download.html Msconvert in ProteoWizard (https://proteowizard.sourceforge.io/tools.shtml) can handle the conversion of most vendor data formats. MetaMiner natively supports MGF, mzXML, mzData and uses msconvert utility from the ProteoWizard package to convert spectra in other formats to MGF metabolomics/v2"
+      "search_text": "proteowizard ProteoWizard pwiz_bindings_cli.dll from the ProteoWizard project based on pwiz_bindings_cli.dll from the ProteoWizard project. msconvert, distributed with the ProteoWizard Project msconvert, distributed with the ProteoWizard Project http://proteowizard.sourceforge.net/download.html Msconvert in ProteoWizard (https://proteowizard.sourceforge.io/tools.shtml) can handle the conversion of most vendor data formats. MetaMiner natively supports MGF, mzXML, mzData and uses msconvert utility from the ProteoWizard package to convert spectra in other formats to MGF metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "proteoxchange-repository",
       "name": "ProteoXchange Repository",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "ProteoXchange Repository Data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/proteoxchange-repository.yaml",
-      "search_text": "proteoxchange-repository ProteoXchange Repository ProteoXchange Repository Data metabolomics/v2"
+      "search_text": "proteoxchange-repository ProteoXchange Repository ProteoXchange Repository Data metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "ps2ms",
@@ -121023,79 +121071,79 @@
     {
       "slug": "psm-utils",
       "name": "psm_utils",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/compomics/ms2rescore",
       "license_spdx": "",
       "evidence_text": "Accepted ProForma modification labels in :py:mod:`psm_utils`",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/psm-utils.yaml",
-      "search_text": "psm-utils psm_utils Accepted ProForma modification labels in :py:mod:`psm_utils` metabolomics/v2"
+      "search_text": "psm-utils psm_utils Accepted ProForma modification labels in :py:mod:`psm_utils` metabolomics/v2 https://github.com/compomics/ms2rescore"
     },
     {
       "slug": "pubchem-standardization",
       "name": "PubChem standardization",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/michaelwitting/RepoRT",
       "license_spdx": "",
       "evidence_text": "structures are standardized using the PubChem standardization",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pubchem-standardization.yaml",
-      "search_text": "pubchem-standardization PubChem standardization structures are standardized using the PubChem standardization metabolomics/v2"
+      "search_text": "pubchem-standardization PubChem standardization structures are standardized using the PubChem standardization metabolomics/v2 https://github.com/michaelwitting/RepoRT"
     },
     {
       "slug": "pubchem",
       "name": "PubChem",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RECETOX/MSMetaEnhancer",
       "license_spdx": "",
       "evidence_text": "all ids are converted to a unique one, in this case the PubChem ID By inputting the chemical formula and your experimental spectrum, the WebUI will rank it against all candidates from PubChem. the WebUI will rank it against all candidates from PubChem find structures on other chemical projects like Pubchem Final candidate selection is done in Python using RDKit and PubChemPy fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pubchem.yaml",
-      "search_text": "pubchem PubChem all ids are converted to a unique one, in this case the PubChem ID By inputting the chemical formula and your experimental spectrum, the WebUI will rank it against all candidates from PubChem. the WebUI will rank it against all candidates from PubChem find structures on other chemical projects like Pubchem Final candidate selection is done in Python using RDKit and PubChemPy fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb metabolomics/v2"
+      "search_text": "pubchem PubChem all ids are converted to a unique one, in this case the PubChem ID By inputting the chemical formula and your experimental spectrum, the WebUI will rank it against all candidates from PubChem. the WebUI will rank it against all candidates from PubChem find structures on other chemical projects like Pubchem Final candidate selection is done in Python using RDKit and PubChemPy fetched from the following services: CIR, CTS, PubChem, IDSM, and BridgeDb metabolomics/v2 https://github.com/RECETOX/MSMetaEnhancer"
     },
     {
       "slug": "pubchempy",
       "name": "PubChemPy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zmahnoor14/MAW",
       "license_spdx": "",
       "evidence_text": "Final candidate selection is done in Python using RDKit and PubChemPy We then ran an automated search against PubChem [42] using pubchempy [43] for spectra which still missed InChI or SMILES annotations.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pubchempy.yaml",
-      "search_text": "pubchempy PubChemPy Final candidate selection is done in Python using RDKit and PubChemPy We then ran an automated search against PubChem [42] using pubchempy [43] for spectra which still missed InChI or SMILES annotations. metabolomics/v2"
+      "search_text": "pubchempy PubChemPy Final candidate selection is done in Python using RDKit and PubChemPy We then ran an automated search against PubChem [42] using pubchempy [43] for spectra which still missed InChI or SMILES annotations. metabolomics/v2 https://github.com/zmahnoor14/MAW"
     },
     {
       "slug": "punc-data",
       "name": "Punc'data",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/WTVoe/puncdata",
       "license_spdx": "",
       "evidence_text": "Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results. Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/punc-data.yaml",
-      "search_text": "punc-data Punc'data Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results. Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results metabolomics/v2"
+      "search_text": "punc-data Punc'data Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results. Punc'data is an interactive attribution and vizualization tool made for high resolution mass spectrometry results metabolomics/v2 https://github.com/WTVoe/puncdata"
     },
     {
       "slug": "puncdata",
       "name": "puncdata",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/WTVoe/puncdata",
       "license_spdx": "",
       "evidence_text": "Source: github:github.com__WTVoe__puncdata",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/puncdata.yaml",
-      "search_text": "puncdata puncdata Source: github:github.com__WTVoe__puncdata metabolomics/v2"
+      "search_text": "puncdata puncdata Source: github:github.com__WTVoe__puncdata metabolomics/v2 https://github.com/WTVoe/puncdata"
     },
     {
       "slug": "purrr",
       "name": "purrr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kilgain/MassSpec",
       "license_spdx": "",
       "evidence_text": "required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\",",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/purrr.yaml",
-      "search_text": "purrr purrr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2"
+      "search_text": "purrr purrr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2 https://github.com/kilgain/MassSpec"
     },
     {
       "slug": "pwiz-bindings-cli-dll",
@@ -121111,13 +121159,13 @@
     {
       "slug": "pwiz",
       "name": "pwiz",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ProteoWizard/pwiz",
       "license_spdx": "",
       "evidence_text": "github.com__ProteoWizard__pwiz",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pwiz.yaml",
-      "search_text": "pwiz pwiz github.com__ProteoWizard__pwiz metabolomics/v2"
+      "search_text": "pwiz pwiz github.com__ProteoWizard__pwiz metabolomics/v2 https://github.com/ProteoWizard/pwiz"
     },
     {
       "slug": "py4cytoscape",
@@ -121144,24 +121192,24 @@
     {
       "slug": "pybaf2sql",
       "name": "pyBaf2Sql",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LabLaskin/MSIGen",
       "license_spdx": "",
       "evidence_text": "If you are planning on using Bruker .d data in the .baf format, you will also need to install pyBaf2Sql from GitHub",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pybaf2sql.yaml",
-      "search_text": "pybaf2sql pyBaf2Sql If you are planning on using Bruker .d data in the .baf format, you will also need to install pyBaf2Sql from GitHub metabolomics/v2"
+      "search_text": "pybaf2sql pyBaf2Sql If you are planning on using Bruker .d data in the .baf format, you will also need to install pyBaf2Sql from GitHub metabolomics/v2 https://github.com/LabLaskin/MSIGen"
     },
     {
       "slug": "pycharm",
       "name": "PyCharm",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SysMedOs/LipidLynxX",
       "license_spdx": "",
       "evidence_text": "JSON configurations are formatted by Visual Studio Code / PyCharm editor",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pycharm.yaml",
-      "search_text": "pycharm PyCharm JSON configurations are formatted by Visual Studio Code / PyCharm editor metabolomics/v2"
+      "search_text": "pycharm PyCharm JSON configurations are formatted by Visual Studio Code / PyCharm editor metabolomics/v2 https://github.com/SysMedOs/LipidLynxX"
     },
     {
       "slug": "pycombat",
@@ -121177,79 +121225,79 @@
     {
       "slug": "pyeva",
       "name": "pyEVA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab-backup/EVA",
       "license_spdx": "",
       "evidence_text": "EVA now has a python version that can be easily installed and used on Mac, PC, and Linux systems. Please check out pyEVA",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyeva.yaml",
-      "search_text": "pyeva pyEVA EVA now has a python version that can be easily installed and used on Mac, PC, and Linux systems. Please check out pyEVA metabolomics/v2"
+      "search_text": "pyeva pyEVA EVA now has a python version that can be easily installed and used on Mac, PC, and Linux systems. Please check out pyEVA metabolomics/v2 https://github.com/HuanLab-backup/EVA"
     },
     {
       "slug": "pyg",
       "name": "PyG",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RiverCCC/ABCoRT",
       "license_spdx": "",
       "evidence_text": "**PyG** [PyG](https://pytorch-geometric.readthedocs.io/en/latest/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyg.yaml",
-      "search_text": "pyg PyG **PyG** [PyG](https://pytorch-geometric.readthedocs.io/en/latest/) metabolomics/v2"
+      "search_text": "pyg PyG **PyG** [PyG](https://pytorch-geometric.readthedocs.io/en/latest/) metabolomics/v2 https://github.com/RiverCCC/ABCoRT"
     },
     {
       "slug": "pyhmmer",
       "name": "pyHMMER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/medema-group/bigslice",
       "license_spdx": "",
       "evidence_text": "Switching from HMMER to [pyHMMER](https://github.com/althonos/pyhmmer)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyhmmer.yaml",
-      "search_text": "pyhmmer pyHMMER Switching from HMMER to [pyHMMER](https://github.com/althonos/pyhmmer) metabolomics/v2"
+      "search_text": "pyhmmer pyHMMER Switching from HMMER to [pyHMMER](https://github.com/althonos/pyhmmer) metabolomics/v2 https://github.com/medema-group/bigslice"
     },
     {
       "slug": "pyineta",
       "name": "PyINETA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/edisonomics/PyINETA",
       "license_spdx": "",
       "evidence_text": "This is the documentation for the PyINETA package version 2.0.0. .. automodule:: pyineta.finding :members: .. automodule:: pyineta.matching :members:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyineta.yaml",
-      "search_text": "pyineta PyINETA This is the documentation for the PyINETA package version 2.0.0. .. automodule:: pyineta.finding :members: .. automodule:: pyineta.matching :members: metabolomics/v2"
+      "search_text": "pyineta PyINETA This is the documentation for the PyINETA package version 2.0.0. .. automodule:: pyineta.finding :members: .. automodule:: pyineta.matching :members: metabolomics/v2 https://github.com/edisonomics/PyINETA"
     },
     {
       "slug": "pymolnetenhancer",
       "name": "pyMolNetEnhancer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/madeleineernst/pyMolNetEnhancer",
       "license_spdx": "",
       "evidence_text": "pyMolNetEnhancer is a python module integrating chemical class and substructure information",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pymolnetenhancer.yaml",
-      "search_text": "pymolnetenhancer pyMolNetEnhancer pyMolNetEnhancer is a python module integrating chemical class and substructure information metabolomics/v2"
+      "search_text": "pymolnetenhancer pyMolNetEnhancer pyMolNetEnhancer is a python module integrating chemical class and substructure information metabolomics/v2 https://github.com/madeleineernst/pyMolNetEnhancer"
     },
     {
       "slug": "pymrmtransitiongrouppicker",
       "name": "pyMRMTransitionGroupPicker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "pyMRMTransitionGroupPicker",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pymrmtransitiongrouppicker.yaml",
-      "search_text": "pymrmtransitiongrouppicker pyMRMTransitionGroupPicker pyMRMTransitionGroupPicker metabolomics/v2"
+      "search_text": "pymrmtransitiongrouppicker pyMRMTransitionGroupPicker pyMRMTransitionGroupPicker metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "pymzml",
       "name": "pymzml",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "The default method uses `pymzml` to parse mzML files. pymzml==2.5.2 In order to make pymzML accept other kinds of mzML data (e.g databases), one can implement an own wrapper from pymzml import spec from pymzml.run import Reader .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pymzml.yaml",
-      "search_text": "pymzml pymzml The default method uses `pymzml` to parse mzML files. pymzml==2.5.2 In order to make pymzML accept other kinds of mzML data (e.g databases), one can implement an own wrapper from pymzml import spec from pymzml.run import Reader .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml metabolomics/v2"
+      "search_text": "pymzml pymzml The default method uses `pymzml` to parse mzML files. pymzml==2.5.2 In order to make pymzML accept other kinds of mzML data (e.g databases), one can implement an own wrapper from pymzml import spec from pymzml.run import Reader .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "pyopenms-viz",
@@ -121265,35 +121313,35 @@
     {
       "slug": "pyopenms",
       "name": "pyopenms",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AutoFlowResearch/SmartPeak",
       "license_spdx": "",
       "evidence_text": "A :class:`MSExperiment` object (supported by :mod:`pyopenms`) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml pyopenms ... pymzml ... pyteomics These files can be parsed and processed by the pyOpenMS Python package pyOpenMS](https://pyopenms.readthedocs.io/) (version 2.7.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyopenms.yaml",
-      "search_text": "pyopenms pyopenms A :class:`MSExperiment` object (supported by :mod:`pyopenms`) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml pyopenms ... pymzml ... pyteomics These files can be parsed and processed by the pyOpenMS Python package pyOpenMS](https://pyopenms.readthedocs.io/) (version 2.7.0) metabolomics/v2"
+      "search_text": "pyopenms pyopenms A :class:`MSExperiment` object (supported by :mod:`pyopenms`) pyOpenMS (Python interface to the C++ OpenMS library) is used for feature detection in MS raw data .mzML ----- .. toctree:: :maxdepth: 1 pyopenms pymzml pyopenms ... pymzml ... pyteomics These files can be parsed and processed by the pyOpenMS Python package pyOpenMS](https://pyopenms.readthedocs.io/) (version 2.7.0) metabolomics/v2 https://github.com/AutoFlowResearch/SmartPeak"
     },
     {
       "slug": "pyqt5",
       "name": "PyQt5",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Leo-Cheng-Lab/ROIAL-NMR",
       "license_spdx": "",
       "evidence_text": "PyQt5 5.15.11",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyqt5.yaml",
-      "search_text": "pyqt5 PyQt5 PyQt5 5.15.11 metabolomics/v2"
+      "search_text": "pyqt5 PyQt5 PyQt5 5.15.11 metabolomics/v2 https://github.com/Leo-Cheng-Lab/ROIAL-NMR"
     },
     {
       "slug": "pyrwr",
       "name": "pyrwr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/computational-chemical-biology/ChemWalker",
       "license_spdx": "",
       "evidence_text": "using [random walk](https://github.com/jinhongjung/pyrwr)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyrwr.yaml",
-      "search_text": "pyrwr pyrwr using [random walk](https://github.com/jinhongjung/pyrwr) metabolomics/v2"
+      "search_text": "pyrwr pyrwr using [random walk](https://github.com/jinhongjung/pyrwr) metabolomics/v2 https://github.com/computational-chemical-biology/ChemWalker"
     },
     {
       "slug": "pyteomics",
@@ -121309,134 +121357,134 @@
     {
       "slug": "pytest",
       "name": "pytest",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "pytest tests/ No discussion section present in document See our organization-level document on [CONTRIBUTING] Run the pytest test suite Tests are performed using Pytest make sure the existing tests still work by running ``pytest``",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytest.yaml",
-      "search_text": "pytest pytest pytest tests/ No discussion section present in document See our organization-level document on [CONTRIBUTING] Run the pytest test suite Tests are performed using Pytest make sure the existing tests still work by running ``pytest`` metabolomics/v2"
+      "search_text": "pytest pytest pytest tests/ No discussion section present in document See our organization-level document on [CONTRIBUTING] Run the pytest test suite Tests are performed using Pytest make sure the existing tests still work by running ``pytest`` metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "python-2-7",
       "name": "Python 2.7",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Viant-Metabolomics/Galaxy-M",
       "license_spdx": "",
       "evidence_text": "[Python (version 2.7)](https://www.python.org/download/releases/2.7/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-2-7.yaml",
-      "search_text": "python-2-7 Python 2.7 [Python (version 2.7)](https://www.python.org/download/releases/2.7/) metabolomics/v2"
+      "search_text": "python-2-7 Python 2.7 [Python (version 2.7)](https://www.python.org/download/releases/2.7/) metabolomics/v2 https://github.com/Viant-Metabolomics/Galaxy-M"
     },
     {
       "slug": "python-3-11-7",
       "name": "Python 3.11.7",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HassounLab/MVP",
       "license_spdx": "",
       "evidence_text": "python_version: 3.11.7",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-11-7.yaml",
-      "search_text": "python-3-11-7 Python 3.11.7 python_version: 3.11.7 metabolomics/v2"
+      "search_text": "python-3-11-7 Python 3.11.7 python_version: 3.11.7 metabolomics/v2 https://github.com/HassounLab/MVP"
     },
     {
       "slug": "python-3-6-12",
       "name": "Python 3.6.12",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "Python(3.6.12) 1- Python(3.6.12)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-6-12.yaml",
-      "search_text": "python-3-6-12 Python 3.6.12 Python(3.6.12) 1- Python(3.6.12) metabolomics/v2"
+      "search_text": "python-3-6-12 Python 3.6.12 Python(3.6.12) 1- Python(3.6.12) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "python-3-6",
       "name": "Python 3.6",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Dingxian666/Norm-ISWSVR",
       "license_spdx": "",
       "evidence_text": "![Python 3.6](https://img.shields.io/badge/python-3.6-green.svg)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-6.yaml",
-      "search_text": "python-3-6 Python 3.6 ![Python 3.6](https://img.shields.io/badge/python-3.6-green.svg) metabolomics/v2"
+      "search_text": "python-3-6 Python 3.6 ![Python 3.6](https://img.shields.io/badge/python-3.6-green.svg) metabolomics/v2 https://github.com/Dingxian666/Norm-ISWSVR"
     },
     {
       "slug": "python-3-7",
       "name": "Python 3.7",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/aaronma2020/MSGO",
       "license_spdx": "",
       "evidence_text": "Python: 3.7",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-7.yaml",
-      "search_text": "python-3-7 Python 3.7 Python: 3.7 metabolomics/v2"
+      "search_text": "python-3-7 Python 3.7 Python: 3.7 metabolomics/v2 https://github.com/aaronma2020/MSGO"
     },
     {
       "slug": "python-3-8-1",
       "name": "Python 3.8.1",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LinShuhaiLAB/QuanFormer",
       "license_spdx": "",
       "evidence_text": "written in Python (v3.8.1)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-8-1.yaml",
-      "search_text": "python-3-8-1 Python 3.8.1 written in Python (v3.8.1) metabolomics/v2"
+      "search_text": "python-3-8-1 Python 3.8.1 written in Python (v3.8.1) metabolomics/v2 https://github.com/LinShuhaiLAB/QuanFormer"
     },
     {
       "slug": "python-3-8-2",
       "name": "Python >= 3.8.2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zsspython/LAGF",
       "license_spdx": "",
       "evidence_text": "Python >= 3.8.2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-8-2.yaml",
-      "search_text": "python-3-8-2 Python >= 3.8.2 Python >= 3.8.2 metabolomics/v2"
+      "search_text": "python-3-8-2 Python >= 3.8.2 Python >= 3.8.2 metabolomics/v2 https://github.com/zsspython/LAGF"
     },
     {
       "slug": "python-3-8",
       "name": "Python 3.8+",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wh-xu/Hyper-Spec",
       "license_spdx": "",
       "evidence_text": "_falcon_ requires Python 3.8+ and is available on the Linux and OSX platforms. HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. HyperSpec is a Python library that supports extremely fast spectra clustering",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-8.yaml",
-      "search_text": "python-3-8 Python 3.8+ _falcon_ requires Python 3.8+ and is available on the Linux and OSX platforms. HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. HyperSpec is a Python library that supports extremely fast spectra clustering metabolomics/v2"
+      "search_text": "python-3-8 Python 3.8+ _falcon_ requires Python 3.8+ and is available on the Linux and OSX platforms. HyperSpec requires `Python 3.8+` with `CUDA` environment HyperSpec requires `Python 3.8+` with `CUDA` environment. HyperSpec is a Python library that supports extremely fast spectra clustering metabolomics/v2 https://github.com/wh-xu/Hyper-Spec"
     },
     {
       "slug": "python-3-9-0",
       "name": "Python 3.9.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RaoboXu/Lipidwizard",
       "license_spdx": "",
       "evidence_text": "python 3.9.0",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-9-0.yaml",
-      "search_text": "python-3-9-0 Python 3.9.0 python 3.9.0 metabolomics/v2"
+      "search_text": "python-3-9-0 Python 3.9.0 python 3.9.0 metabolomics/v2 https://github.com/RaoboXu/Lipidwizard"
     },
     {
       "slug": "python-3-9",
       "name": "Python >=3.9",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Leo-Cheng-Lab/ROIAL-NMR",
       "license_spdx": "",
       "evidence_text": "Python>=3.9 [Python](https://www.anaconda.com/download/)>=3.9",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3-9.yaml",
-      "search_text": "python-3-9 Python >=3.9 Python>=3.9 [Python](https://www.anaconda.com/download/)>=3.9 metabolomics/v2"
+      "search_text": "python-3-9 Python >=3.9 Python>=3.9 [Python](https://www.anaconda.com/download/)>=3.9 metabolomics/v2 https://github.com/Leo-Cheng-Lab/ROIAL-NMR"
     },
     {
       "slug": "python-3",
       "name": "Python 3",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ComPlat/chem-spectra-app",
       "license_spdx": "",
       "evidence_text": "Use the file pyproject.toml to determine the version of Python required. [python3](https://www.python.org/) Khipu is developed as an open source Python 3 package 221[[smiles.py]], 260[[3_cleaningAndEnriching/sanitizing.py]], 280[[3_cleaningAndEnriching/stereocounting.py]] R - Python 3 - Java >= 17 Python scripts for data parsing and transformation",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-3.yaml",
-      "search_text": "python-3 Python 3 Use the file pyproject.toml to determine the version of Python required. [python3](https://www.python.org/) Khipu is developed as an open source Python 3 package 221[[smiles.py]], 260[[3_cleaningAndEnriching/sanitizing.py]], 280[[3_cleaningAndEnriching/stereocounting.py]] R - Python 3 - Java >= 17 Python scripts for data parsing and transformation metabolomics/v2"
+      "search_text": "python-3 Python 3 Use the file pyproject.toml to determine the version of Python required. [python3](https://www.python.org/) Khipu is developed as an open source Python 3 package 221[[smiles.py]], 260[[3_cleaningAndEnriching/sanitizing.py]], 280[[3_cleaningAndEnriching/stereocounting.py]] R - Python 3 - Java >= 17 Python scripts for data parsing and transformation metabolomics/v2 https://github.com/ComPlat/chem-spectra-app"
     },
     {
       "slug": "python-deep-learning-framework-pytorch-or-tensorflow",
@@ -121452,13 +121500,13 @@
     {
       "slug": "python-json-module-for-parsing-json-files",
       "name": "Python (json module for parsing JSON files)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mibig-secmet/mibig-json",
       "license_spdx": "",
       "evidence_text": "MIBiG curation data in JSON format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-json-module-for-parsing-json-files.yaml",
-      "search_text": "python-json-module-for-parsing-json-files Python (json module for parsing JSON files) MIBiG curation data in JSON format metabolomics/v2"
+      "search_text": "python-json-module-for-parsing-json-files Python (json module for parsing JSON files) MIBiG curation data in JSON format metabolomics/v2 https://github.com/mibig-secmet/mibig-json"
     },
     {
       "slug": "python-numpy-pandas",
@@ -121474,24 +121522,24 @@
     {
       "slug": "python-numpy-scipy-stats-pandas-matplotlib-seaborn",
       "name": "Python (numpy, scipy.stats, pandas, matplotlib, seaborn)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/NPLinker/nplinker",
       "license_spdx": "",
       "evidence_text": "NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set, maintaining the hierarchical relationship between them",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-numpy-scipy-stats-pandas-matplotlib-seaborn.yaml",
-      "search_text": "python-numpy-scipy-stats-pandas-matplotlib-seaborn Python (numpy, scipy.stats, pandas, matplotlib, seaborn) NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set, maintaining the hierarchical relationship between them metabolomics/v2"
+      "search_text": "python-numpy-scipy-stats-pandas-matplotlib-seaborn Python (numpy, scipy.stats, pandas, matplotlib, seaborn) NPLinker creates objects for spectra, MFs, BGCs and GCFs in the data set, maintaining the hierarchical relationship between them metabolomics/v2 https://github.com/NPLinker/nplinker"
     },
     {
       "slug": "python-pandas-numpy-scipy",
       "name": "Python (pandas, NumPy, SciPy)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chopralab/CLAW",
       "license_spdx": "",
       "evidence_text": "statistical analysis MetENP",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python-pandas-numpy-scipy.yaml",
-      "search_text": "python-pandas-numpy-scipy Python (pandas, NumPy, SciPy) statistical analysis MetENP metabolomics/v2"
+      "search_text": "python-pandas-numpy-scipy Python (pandas, NumPy, SciPy) statistical analysis MetENP metabolomics/v2 https://github.com/chopralab/CLAW"
     },
     {
       "slug": "python-scikit-learn-seaborn-or-matplotlib-for-visualization",
@@ -121518,35 +121566,35 @@
     {
       "slug": "python",
       "name": "Python",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "**Python** Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing Trackable and scalable Python program for high-resolution metabolomics data processing. Requires Python 3.8+. Download and install Python 3.8 or later from `python.org` model.computeNextGradient()",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/python.yaml",
-      "search_text": "python Python **Python** Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing Trackable and scalable Python program for high-resolution metabolomics data processing. Requires Python 3.8+. Download and install Python 3.8 or later from `python.org` model.computeNextGradient() metabolomics/v2"
+      "search_text": "python Python **Python** Trackable and scalable Python program for high-resolution LC-MS metabolomics data preprocessing Trackable and scalable Python program for high-resolution metabolomics data processing. Requires Python 3.8+. Download and install Python 3.8 or later from `python.org` model.computeNextGradient() metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "pytorch-2-2",
       "name": "PyTorch 2.2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zhanghailiangcsu/MSBERT",
       "license_spdx": "",
       "evidence_text": "[Pytorch](https://pytorch.org/) 2.2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytorch-2-2.yaml",
-      "search_text": "pytorch-2-2 PyTorch 2.2 [Pytorch](https://pytorch.org/) 2.2 metabolomics/v2"
+      "search_text": "pytorch-2-2 PyTorch 2.2 [Pytorch](https://pytorch.org/) 2.2 metabolomics/v2 https://github.com/zhanghailiangcsu/MSBERT"
     },
     {
       "slug": "pytorch-cu118",
       "name": "PyTorch+cu118",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/yfWang01/FlavorFormer",
       "license_spdx": "",
       "evidence_text": "Python 3.13.2 and Pytorch (version 2.7.0+cu118)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytorch-cu118.yaml",
-      "search_text": "pytorch-cu118 PyTorch+cu118 Python 3.13.2 and Pytorch (version 2.7.0+cu118) metabolomics/v2"
+      "search_text": "pytorch-cu118 PyTorch+cu118 Python 3.13.2 and Pytorch (version 2.7.0+cu118) metabolomics/v2 https://github.com/yfWang01/FlavorFormer"
     },
     {
       "slug": "pytorch-geometric-pyg",
@@ -121562,24 +121610,24 @@
     {
       "slug": "pytorch-geometric",
       "name": "PyTorch Geometric",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/tingxiecsu/CSU-MS2",
       "license_spdx": "",
       "evidence_text": "- [PyTorch Geometric](https://pytorch-geometric.readthedocs.io/en/latest/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytorch-geometric.yaml",
-      "search_text": "pytorch-geometric PyTorch Geometric - [PyTorch Geometric](https://pytorch-geometric.readthedocs.io/en/latest/) metabolomics/v2"
+      "search_text": "pytorch-geometric PyTorch Geometric - [PyTorch Geometric](https://pytorch-geometric.readthedocs.io/en/latest/) metabolomics/v2 https://github.com/tingxiecsu/CSU-MS2"
     },
     {
       "slug": "pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context",
       "name": "PyTorch or equivalent deep learning framework (inferred from GNN/contrastive learning context)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Chen-micslab/QCCAssisted4DSterol",
       "license_spdx": "",
       "evidence_text": "Our method integrates contrastive learning with masked graph modeling",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context.yaml",
-      "search_text": "pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context PyTorch or equivalent deep learning framework (inferred from GNN/contrastive learning context) Our method integrates contrastive learning with masked graph modeling metabolomics/v2"
+      "search_text": "pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context PyTorch or equivalent deep learning framework (inferred from GNN/contrastive learning context) Our method integrates contrastive learning with masked graph modeling metabolomics/v2 https://github.com/Chen-micslab/QCCAssisted4DSterol"
     },
     {
       "slug": "pytorch-or-tensorflow",
@@ -121595,13 +121643,13 @@
     {
       "slug": "pytorch",
       "name": "PyTorch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Chen-micslab/QCCAssisted4DSterol",
       "license_spdx": "",
       "evidence_text": "PyTorch must be installed separately. Check the `official PyTorch website **Pytorch** - **Pytorch** Pytorch is installed automatically when installing Casanovo Upgraded minimum Lightning version to 2.6. Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pytorch.yaml",
-      "search_text": "pytorch PyTorch PyTorch must be installed separately. Check the `official PyTorch website **Pytorch** - **Pytorch** Pytorch is installed automatically when installing Casanovo Upgraded minimum Lightning version to 2.6. Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files. metabolomics/v2"
+      "search_text": "pytorch PyTorch PyTorch must be installed separately. Check the `official PyTorch website **Pytorch** - **Pytorch** Pytorch is installed automatically when installing Casanovo Upgraded minimum Lightning version to 2.6. Hotfix to ensure compatibility with PyTorch v2.6 when loading weights files. metabolomics/v2 https://github.com/Chen-micslab/QCCAssisted4DSterol"
     },
     {
       "slug": "pyvis",
@@ -121617,24 +121665,24 @@
     {
       "slug": "pyyaml",
       "name": "PyYAML",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ZzakB/MolNotator",
       "license_spdx": "",
       "evidence_text": "import yaml",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/pyyaml.yaml",
-      "search_text": "pyyaml PyYAML import yaml metabolomics/v2"
+      "search_text": "pyyaml PyYAML import yaml metabolomics/v2 https://github.com/ZzakB/MolNotator"
     },
     {
       "slug": "q-exactive-orbitrap",
       "name": "Q-Exactive orbitrap",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "tested and validated using Q-Exactive orbitrap UHPLC-HRMS/MS data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/q-exactive-orbitrap.yaml",
-      "search_text": "q-exactive-orbitrap Q-Exactive orbitrap tested and validated using Q-Exactive orbitrap UHPLC-HRMS/MS data metabolomics/v2"
+      "search_text": "q-exactive-orbitrap Q-Exactive orbitrap tested and validated using Q-Exactive orbitrap UHPLC-HRMS/MS data metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "q2-qemistree",
@@ -121661,68 +121709,68 @@
     {
       "slug": "qcxms2",
       "name": "QCxMS2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "Program package for the quantum mechanical calculation of EI mass spectra using automated reaction network exploration",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/qcxms2.yaml",
-      "search_text": "qcxms2 QCxMS2 Program package for the quantum mechanical calculation of EI mass spectra using automated reaction network exploration metabolomics/v2"
+      "search_text": "qcxms2 QCxMS2 Program package for the quantum mechanical calculation of EI mass spectra using automated reaction network exploration metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "qmake",
       "name": "qmake",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "qmake -r build.pro",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/qmake.yaml",
-      "search_text": "qmake qmake qmake -r build.pro metabolomics/v2"
+      "search_text": "qmake qmake qmake -r build.pro metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "qr-code-generation-library",
       "name": "QR Code Generation Library",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MetabolomicsSpectrumResolver",
       "license_spdx": "",
       "evidence_text": "3rd party embedding of QR code",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/qr-code-generation-library.yaml",
-      "search_text": "qr-code-generation-library QR Code Generation Library 3rd party embedding of QR code metabolomics/v2"
+      "search_text": "qr-code-generation-library QR Code Generation Library 3rd party embedding of QR code metabolomics/v2 https://github.com/mwang87/MetabolomicsSpectrumResolver"
     },
     {
       "slug": "qt5",
       "name": "Qt5",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eugenemel/maven",
       "license_spdx": "",
       "evidence_text": "Install the qt5 package",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/qt5.yaml",
-      "search_text": "qt5 Qt5 Install the qt5 package metabolomics/v2"
+      "search_text": "qt5 Qt5 Install the qt5 package metabolomics/v2 https://github.com/eugenemel/maven"
     },
     {
       "slug": "quick",
       "name": "QUICK",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DasSusanta/snakemake_ccs",
       "license_spdx": "",
       "evidence_text": "QUICK: For quantum calculations",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/quick.yaml",
-      "search_text": "quick QUICK QUICK: For quantum calculations metabolomics/v2"
+      "search_text": "quick QUICK QUICK: For quantum calculations metabolomics/v2 https://github.com/DasSusanta/snakemake_ccs"
     },
     {
       "slug": "r-3-0-1",
       "name": "R 3.0.1",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Viant-Metabolomics/Galaxy-M",
       "license_spdx": "",
       "evidence_text": "[R programming language (version 3.0.1, x86 64bit)](http://cran.r-project.org/bin/windows/base/)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-3-0-1.yaml",
-      "search_text": "r-3-0-1 R 3.0.1 [R programming language (version 3.0.1, x86 64bit)](http://cran.r-project.org/bin/windows/base/) metabolomics/v2"
+      "search_text": "r-3-0-1 R 3.0.1 [R programming language (version 3.0.1, x86 64bit)](http://cran.r-project.org/bin/windows/base/) metabolomics/v2 https://github.com/Viant-Metabolomics/Galaxy-M"
     },
     {
       "slug": "r-4-0-2",
@@ -121738,68 +121786,68 @@
     {
       "slug": "r-4-1-2",
       "name": "R ≥4.1.2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/plyush1993/OUKS",
       "license_spdx": "",
       "evidence_text": "[![](https://img.shields.io/badge/R≥4.1.2-5fb9ed.svg?style=flat&logo=r&logoColor=white?)](https://cran.r-project.org/index.html)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-4-1-2.yaml",
-      "search_text": "r-4-1-2 R ≥4.1.2 [![](https://img.shields.io/badge/R≥4.1.2-5fb9ed.svg?style=flat&logo=r&logoColor=white?)](https://cran.r-project.org/index.html) metabolomics/v2"
+      "search_text": "r-4-1-2 R ≥4.1.2 [![](https://img.shields.io/badge/R≥4.1.2-5fb9ed.svg?style=flat&logo=r&logoColor=white?)](https://cran.r-project.org/index.html) metabolomics/v2 https://github.com/plyush1993/OUKS"
     },
     {
       "slug": "r-base-stats-tidyverse-or-similar",
       "name": "R (base stats, tidyverse, or similar)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chopralab/CLAW",
       "license_spdx": "",
       "evidence_text": "statistical analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-base-stats-tidyverse-or-similar.yaml",
-      "search_text": "r-base-stats-tidyverse-or-similar R (base stats, tidyverse, or similar) statistical analysis metabolomics/v2"
+      "search_text": "r-base-stats-tidyverse-or-similar R (base stats, tidyverse, or similar) statistical analysis metabolomics/v2 https://github.com/chopralab/CLAW"
     },
     {
       "slug": "r-gui",
       "name": "R GUI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuJenL/SMART",
       "license_spdx": "",
       "evidence_text": "SMART written in R and R GUI has been developed as user-friendly software",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-gui.yaml",
-      "search_text": "r-gui R GUI SMART written in R and R GUI has been developed as user-friendly software metabolomics/v2"
+      "search_text": "r-gui R GUI SMART written in R and R GUI has been developed as user-friendly software metabolomics/v2 https://github.com/YuJenL/SMART"
     },
     {
       "slug": "r-or-language-used-by-pairkat-scripts",
       "name": "R (or language used by PaIRKAT scripts)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/CharlieCarpenter/PaIRKAT",
       "license_spdx": "",
       "evidence_text": "Scripts for PaIRKAT functions with example work flow",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-or-language-used-by-pairkat-scripts.yaml",
-      "search_text": "r-or-language-used-by-pairkat-scripts R (or language used by PaIRKAT scripts) Scripts for PaIRKAT functions with example work flow metabolomics/v2"
+      "search_text": "r-or-language-used-by-pairkat-scripts R (or language used by PaIRKAT scripts) Scripts for PaIRKAT functions with example work flow metabolomics/v2 https://github.com/CharlieCarpenter/PaIRKAT"
     },
     {
       "slug": "r-package-amanida",
       "name": "R package Amanida",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mariallr/easy-amanida",
       "license_spdx": "",
       "evidence_text": "implements the R package Amanida",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-package-amanida.yaml",
-      "search_text": "r-package-amanida R package Amanida implements the R package Amanida metabolomics/v2"
+      "search_text": "r-package-amanida R package Amanida implements the R package Amanida metabolomics/v2 https://github.com/mariallr/easy-amanida"
     },
     {
       "slug": "r-shiny",
       "name": "R Shiny",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Lab-XUE/EISA-EXPOSOME",
       "license_spdx": "",
       "evidence_text": "We provide a Rshiny program for EISA-EXPOSOME We provide a Rshiny program for EISA-EXPOSOME, which runs with the interface shown below GraphBio---A modular and scalable R Shiny dashboard",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r-shiny.yaml",
-      "search_text": "r-shiny R Shiny We provide a Rshiny program for EISA-EXPOSOME We provide a Rshiny program for EISA-EXPOSOME, which runs with the interface shown below GraphBio---A modular and scalable R Shiny dashboard metabolomics/v2"
+      "search_text": "r-shiny R Shiny We provide a Rshiny program for EISA-EXPOSOME We provide a Rshiny program for EISA-EXPOSOME, which runs with the interface shown below GraphBio---A modular and scalable R Shiny dashboard metabolomics/v2 https://github.com/Lab-XUE/EISA-EXPOSOME"
     },
     {
       "slug": "r-vegan-package",
@@ -121826,24 +121874,24 @@
     {
       "slug": "r",
       "name": "R (>=)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LargeMetabo/LargeMetabo",
       "license_spdx": "",
       "evidence_text": "Dependent on R (>= 3.5.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/r.yaml",
-      "search_text": "r R (>=) Dependent on R (>= 3.5.0) metabolomics/v2"
+      "search_text": "r R (>=) Dependent on R (>= 3.5.0) metabolomics/v2 https://github.com/LargeMetabo/LargeMetabo"
     },
     {
       "slug": "ramclustr",
       "name": "RamClustR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/cbroeckl/RAMClustR",
       "license_spdx": "",
       "evidence_text": "An example of feature annotation using LC-MS AIF chromatograms processed using xcms and RamClustR packages ramclustR function is built to use xcms data RC <- ramclustR(xcmsObj = xset, ExpDes=experiment) RC <- do.findmain(RC, mode = \"positive\", mzabs.error = 0.02, ppm.error = 10)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ramclustr.yaml",
-      "search_text": "ramclustr RamClustR An example of feature annotation using LC-MS AIF chromatograms processed using xcms and RamClustR packages ramclustR function is built to use xcms data RC <- ramclustR(xcmsObj = xset, ExpDes=experiment) RC <- do.findmain(RC, mode = \"positive\", mzabs.error = 0.02, ppm.error = 10) metabolomics/v2"
+      "search_text": "ramclustr RamClustR An example of feature annotation using LC-MS AIF chromatograms processed using xcms and RamClustR packages ramclustR function is built to use xcms data RC <- ramclustR(xcmsObj = xset, ExpDes=experiment) RC <- do.findmain(RC, mode = \"positive\", mzabs.error = 0.02, ppm.error = 10) metabolomics/v2 https://github.com/cbroeckl/RAMClustR"
     },
     {
       "slug": "random-forest-regression",
@@ -121881,101 +121929,101 @@
     {
       "slug": "randomforest",
       "name": "randomForest",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/connor-reid-tiffany/Omu",
       "license_spdx": "",
       "evidence_text": "Omu has a function, ```random_forest```, which is a wrapper built around the function ```randomForest``` from the R package randomForest",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/randomforest.yaml",
-      "search_text": "randomforest randomForest Omu has a function, ```random_forest```, which is a wrapper built around the function ```randomForest``` from the R package randomForest metabolomics/v2"
+      "search_text": "randomforest randomForest Omu has a function, ```random_forest```, which is a wrapper built around the function ```randomForest``` from the R package randomForest metabolomics/v2 https://github.com/connor-reid-tiffany/Omu"
     },
     {
       "slug": "rankprod",
       "name": "RankProd",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Differential expression analyss | R packages: DESeq2, edger, RankProd",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rankprod.yaml",
-      "search_text": "rankprod RankProd Differential expression analyss | R packages: DESeq2, edger, RankProd metabolomics/v2"
+      "search_text": "rankprod RankProd Differential expression analyss | R packages: DESeq2, edger, RankProd metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "rapidmass",
       "name": "RapidMass",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Katherine00689/RapidMass",
       "license_spdx": "",
       "evidence_text": "We have developed a versatile software platform, RapidMass. We have developed a versatile software platform, RapidMass",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rapidmass.yaml",
-      "search_text": "rapidmass RapidMass We have developed a versatile software platform, RapidMass. We have developed a versatile software platform, RapidMass metabolomics/v2"
+      "search_text": "rapidmass RapidMass We have developed a versatile software platform, RapidMass. We have developed a versatile software platform, RapidMass metabolomics/v2 https://github.com/Katherine00689/RapidMass"
     },
     {
       "slug": "raw-file-uploader-rtklab-byu-raw-file-uploader",
       "name": "Raw File Uploader (RTKlab-BYU/Raw_File_Uploader)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "works with [Raw file uploader]",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/raw-file-uploader-rtklab-byu-raw-file-uploader.yaml",
-      "search_text": "raw-file-uploader-rtklab-byu-raw-file-uploader Raw File Uploader (RTKlab-BYU/Raw_File_Uploader) works with [Raw file uploader] metabolomics/v2"
+      "search_text": "raw-file-uploader-rtklab-byu-raw-file-uploader Raw File Uploader (RTKlab-BYU/Raw_File_Uploader) works with [Raw file uploader] metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "rawfilereader",
       "name": "RawFileReader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fgcz/rawrr",
       "license_spdx": "",
       "evidence_text": "The extracted information is written to a temporary location on the harddrive, read back into memory and parsed into `R` objects using RawFileReader API ThermoFisher.CommonCore dlls can be obtained through: https://github.com/thermofisherlsms/RawFileReader Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific. invoke compiled `C#` wrapper methods using a system call. Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo RawFileReader dynamic link library provided by Thermo Fisher Scientific",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rawfilereader.yaml",
-      "search_text": "rawfilereader RawFileReader The extracted information is written to a temporary location on the harddrive, read back into memory and parsed into `R` objects using RawFileReader API ThermoFisher.CommonCore dlls can be obtained through: https://github.com/thermofisherlsms/RawFileReader Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific. invoke compiled `C#` wrapper methods using a system call. Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo RawFileReader dynamic link library provided by Thermo Fisher Scientific metabolomics/v2"
+      "search_text": "rawfilereader RawFileReader The extracted information is written to a temporary location on the harddrive, read back into memory and parsed into `R` objects using RawFileReader API ThermoFisher.CommonCore dlls can be obtained through: https://github.com/thermofisherlsms/RawFileReader Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo Fisher Scientific. invoke compiled `C#` wrapper methods using a system call. Calling a wrapper method typically results in the execution of methods defined in the `RawFileReader` dynamic link library provided by Thermo RawFileReader dynamic link library provided by Thermo Fisher Scientific metabolomics/v2 https://github.com/fgcz/rawrr"
     },
     {
       "slug": "rawrr",
       "name": "rawrr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fgcz/rawrr",
       "license_spdx": "",
       "evidence_text": "rawrr::readSpectrum Our .NET 8.0 [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file Specifically, `R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods using a system call Our `.NET 8.0` [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file and shipped with the released `R` package. R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods The `rawrr` executable will run out of the box",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rawrr.yaml",
-      "search_text": "rawrr rawrr rawrr::readSpectrum Our .NET 8.0 [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file Specifically, `R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods using a system call Our `.NET 8.0` [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file and shipped with the released `R` package. R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods The `rawrr` executable will run out of the box metabolomics/v2"
+      "search_text": "rawrr rawrr rawrr::readSpectrum Our .NET 8.0 [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file Specifically, `R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods using a system call Our `.NET 8.0` [@dotnet] precompiled wrapper methods are bundled, including the runtime, in the `r BiocStyle::Biocpkg('rawrr')` executable file and shipped with the released `R` package. R` functions requesting access to data stored in binary raw files (reader family functions listed in Table 1) invoke compiled `C#` wrapper methods The `rawrr` executable will run out of the box metabolomics/v2 https://github.com/fgcz/rawrr"
     },
     {
       "slug": "raxport",
       "name": "Raxport",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/thepanlab/Aerith",
       "license_spdx": "",
       "evidence_text": "Extract visualization information from `.FT2` files",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/raxport.yaml",
-      "search_text": "raxport Raxport Extract visualization information from `.FT2` files metabolomics/v2"
+      "search_text": "raxport Raxport Extract visualization information from `.FT2` files metabolomics/v2 https://github.com/thepanlab/Aerith"
     },
     {
       "slug": "rcdk",
       "name": "rcdk",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/michaelwitting/RepoRT",
       "license_spdx": "",
       "evidence_text": "molecular fingerprints and chemical descriptors are calculated using rcdk",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rcdk.yaml",
-      "search_text": "rcdk rcdk molecular fingerprints and chemical descriptors are calculated using rcdk metabolomics/v2"
+      "search_text": "rcdk rcdk molecular fingerprints and chemical descriptors are calculated using rcdk metabolomics/v2 https://github.com/michaelwitting/RepoRT"
     },
     {
       "slug": "rdkit-2020-03-4",
       "name": "RDKit 2020.03.4",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chensaian/TransG-Net",
       "license_spdx": "",
       "evidence_text": "RDKit == 2020.03.4",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rdkit-2020-03-4.yaml",
-      "search_text": "rdkit-2020-03-4 RDKit 2020.03.4 RDKit == 2020.03.4 metabolomics/v2"
+      "search_text": "rdkit-2020-03-4 RDKit 2020.03.4 RDKit == 2020.03.4 metabolomics/v2 https://github.com/chensaian/TransG-Net"
     },
     {
       "slug": "rdkit-or-similar-cheminformatics-library-for-molecular-fingerprint-computation",
@@ -121991,90 +122039,90 @@
     {
       "slug": "rdkit-pypi",
       "name": "rdkit-pypi",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "rdkit-pypi - rdkit-pypi",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rdkit-pypi.yaml",
-      "search_text": "rdkit-pypi rdkit-pypi rdkit-pypi - rdkit-pypi metabolomics/v2"
+      "search_text": "rdkit-pypi rdkit-pypi rdkit-pypi - rdkit-pypi metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "rdkit",
       "name": "RDKit",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DasSusanta/snakemake_ccs",
       "license_spdx": "",
       "evidence_text": "Tanimoto similarity (Jaccard index) based on daylight-like molecular fingerprints, version 2020.03.2, 2048 bits, derived using rdkit 3DMolMS has the following dependencies: * Python 3.8+ * PyTorch * RDKit **RDKit** - **RDKit** standard library for parsing and manipulating SMILES and chemical structures No usage/docs found.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rdkit.yaml",
-      "search_text": "rdkit RDKit Tanimoto similarity (Jaccard index) based on daylight-like molecular fingerprints, version 2020.03.2, 2048 bits, derived using rdkit 3DMolMS has the following dependencies: * Python 3.8+ * PyTorch * RDKit **RDKit** - **RDKit** standard library for parsing and manipulating SMILES and chemical structures No usage/docs found. metabolomics/v2"
+      "search_text": "rdkit RDKit Tanimoto similarity (Jaccard index) based on daylight-like molecular fingerprints, version 2020.03.2, 2048 bits, derived using rdkit 3DMolMS has the following dependencies: * Python 3.8+ * PyTorch * RDKit **RDKit** - **RDKit** standard library for parsing and manipulating SMILES and chemical structures No usage/docs found. metabolomics/v2 https://github.com/DasSusanta/snakemake_ccs"
     },
     {
       "slug": "reactiveextensions",
       "name": "ReactiveExtensions",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "utilizing packages such as ReactiveExtensions and ReactiveProperty",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/reactiveextensions.yaml",
-      "search_text": "reactiveextensions ReactiveExtensions utilizing packages such as ReactiveExtensions and ReactiveProperty metabolomics/v2"
+      "search_text": "reactiveextensions ReactiveExtensions utilizing packages such as ReactiveExtensions and ReactiveProperty metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "reactiveproperty",
       "name": "ReactiveProperty",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "utilizing packages such as ReactiveExtensions and ReactiveProperty",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/reactiveproperty.yaml",
-      "search_text": "reactiveproperty ReactiveProperty utilizing packages such as ReactiveExtensions and ReactiveProperty metabolomics/v2"
+      "search_text": "reactiveproperty ReactiveProperty utilizing packages such as ReactiveExtensions and ReactiveProperty metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "readr",
       "name": "readr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" library(readr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\",",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/readr.yaml",
-      "search_text": "readr readr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" library(readr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2"
+      "search_text": "readr readr invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" library(readr) required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "readxl",
       "name": "readxl",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "readxl library(readxl)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/readxl.yaml",
-      "search_text": "readxl readxl readxl library(readxl) metabolomics/v2"
+      "search_text": "readxl readxl readxl library(readxl) metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "redis",
       "name": "Redis",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "Redis queue is purely additive and only activates in online Docker deployments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/redis.yaml",
-      "search_text": "redis Redis Redis queue is purely additive and only activates in online Docker deployments metabolomics/v2"
+      "search_text": "redis Redis Redis queue is purely additive and only activates in online Docker deployments metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "redu",
       "name": "ReDU",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/ReDU-MS2-Documentation",
       "license_spdx": "",
       "evidence_text": "Validation of the ReDU sample information template using the drag-and-drop validator ReDU only interacts with MassIVE",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/redu.yaml",
-      "search_text": "redu ReDU Validation of the ReDU sample information template using the drag-and-drop validator ReDU only interacts with MassIVE metabolomics/v2"
+      "search_text": "redu ReDU Validation of the ReDU sample information template using the drag-and-drop validator ReDU only interacts with MassIVE metabolomics/v2 https://github.com/mwang87/ReDU-MS2-Documentation"
     },
     {
       "slug": "relu-activation",
@@ -122090,13 +122138,13 @@
     {
       "slug": "reshape2",
       "name": "reshape2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "reshape2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/reshape2.yaml",
-      "search_text": "reshape2 reshape2 reshape2 metabolomics/v2"
+      "search_text": "reshape2 reshape2 reshape2 metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "resnet18",
@@ -122112,90 +122160,90 @@
     {
       "slug": "rest-client-gem",
       "name": "rest-client gem",
-      "canonical_url": "",
+      "canonical_url": "https://bitbucket.org/wishartlab/classyfire_api.git",
       "license_spdx": "",
       "evidence_text": "gem 'rest-client', '=1.8.0'",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rest-client-gem.yaml",
-      "search_text": "rest-client-gem rest-client gem gem 'rest-client', '=1.8.0' metabolomics/v2"
+      "search_text": "rest-client-gem rest-client gem gem 'rest-client', '=1.8.0' metabolomics/v2 https://bitbucket.org/wishartlab/classyfire_api.git"
     },
     {
       "slug": "rest-client",
       "name": "rest-client",
-      "canonical_url": "",
+      "canonical_url": "https://bitbucket.org/wishartlab/classyfire_api.git",
       "license_spdx": "",
       "evidence_text": "gem 'rest-client', '=1.8.0'",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rest-client.yaml",
-      "search_text": "rest-client rest-client gem 'rest-client', '=1.8.0' metabolomics/v2"
+      "search_text": "rest-client rest-client gem 'rest-client', '=1.8.0' metabolomics/v2 https://bitbucket.org/wishartlab/classyfire_api.git"
     },
     {
       "slug": "resultsloader",
       "name": "ResultsLoader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "ResultsLoader",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/resultsloader.yaml",
-      "search_text": "resultsloader ResultsLoader ResultsLoader metabolomics/v2"
+      "search_text": "resultsloader ResultsLoader ResultsLoader metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "reticulate",
       "name": "reticulate",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/slfan2013/SERDA",
       "license_spdx": "",
       "evidence_text": "packageVersion(\"reticulate\") [1] ‘1.19’",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/reticulate.yaml",
-      "search_text": "reticulate reticulate packageVersion(\"reticulate\") [1] ‘1.19’ metabolomics/v2"
+      "search_text": "reticulate reticulate packageVersion(\"reticulate\") [1] ‘1.19’ metabolomics/v2 https://github.com/slfan2013/SERDA"
     },
     {
       "slug": "retip",
       "name": "Retip",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/oloBion/Retip",
       "license_spdx": "",
       "evidence_text": "github.com__oloBion__Retip",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/retip.yaml",
-      "search_text": "retip Retip github.com__oloBion__Retip metabolomics/v2"
+      "search_text": "retip Retip github.com__oloBion__Retip metabolomics/v2 https://github.com/oloBion/Retip"
     },
     {
       "slug": "reverse-search",
       "name": "reverse_search",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Philipbear/reverse_search",
       "license_spdx": "",
       "evidence_text": "github.com/Philipbear/reverse_search",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/reverse-search.yaml",
-      "search_text": "reverse-search reverse_search github.com/Philipbear/reverse_search metabolomics/v2"
+      "search_text": "reverse-search reverse_search github.com/Philipbear/reverse_search metabolomics/v2 https://github.com/Philipbear/reverse_search"
     },
     {
       "slug": "rgcxgc",
       "name": "RGCxGC",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DanielQuiroz97/RGCxGC",
       "license_spdx": "",
       "evidence_text": "The goal of RGCxGC is to provide an easy-to-use platform to analyze two-dimensional gas chromatography data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rgcxgc.yaml",
-      "search_text": "rgcxgc RGCxGC The goal of RGCxGC is to provide an easy-to-use platform to analyze two-dimensional gas chromatography data. metabolomics/v2"
+      "search_text": "rgcxgc RGCxGC The goal of RGCxGC is to provide an easy-to-use platform to analyze two-dimensional gas chromatography data. metabolomics/v2 https://github.com/DanielQuiroz97/RGCxGC"
     },
     {
       "slug": "rhdf5",
       "name": "rhdf5",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/PNNL-m-q/mza",
       "license_spdx": "",
       "evidence_text": "using generic HDF5 libraries available (e.g., h5py and rhdf5)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rhdf5.yaml",
-      "search_text": "rhdf5 rhdf5 using generic HDF5 libraries available (e.g., h5py and rhdf5) metabolomics/v2"
+      "search_text": "rhdf5 rhdf5 using generic HDF5 libraries available (e.g., h5py and rhdf5) metabolomics/v2 https://github.com/PNNL-m-q/mza"
     },
     {
       "slug": "ricoderks-qcomics",
@@ -122222,24 +122270,24 @@
     {
       "slug": "rjson",
       "name": "rjson",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/fgcz/rawrr",
       "license_spdx": "",
       "evidence_text": "rjson::toJSON",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rjson.yaml",
-      "search_text": "rjson rjson rjson::toJSON metabolomics/v2"
+      "search_text": "rjson rjson rjson::toJSON metabolomics/v2 https://github.com/fgcz/rawrr"
     },
     {
       "slug": "rmarkdown",
       "name": "rmarkdown",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/MRCIEU/metaboprep",
       "license_spdx": "",
       "evidence_text": "%\\VignetteEngine{knitr::rmarkdown}",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rmarkdown.yaml",
-      "search_text": "rmarkdown rmarkdown %\\VignetteEngine{knitr::rmarkdown} metabolomics/v2"
+      "search_text": "rmarkdown rmarkdown %\\VignetteEngine{knitr::rmarkdown} metabolomics/v2 https://github.com/MRCIEU/metaboprep"
     },
     {
       "slug": "rmsi",
@@ -122277,90 +122325,90 @@
     {
       "slug": "roasmi",
       "name": "ROASMI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FangYuan717/ROASMI",
       "license_spdx": "",
       "evidence_text": "ROASMI is a Retention Order model to Assist Small Molecule Identification",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/roasmi.yaml",
-      "search_text": "roasmi ROASMI ROASMI is a Retention Order model to Assist Small Molecule Identification metabolomics/v2"
+      "search_text": "roasmi ROASMI ROASMI is a Retention Order model to Assist Small Molecule Identification metabolomics/v2 https://github.com/FangYuan717/ROASMI"
     },
     {
       "slug": "roipeaks",
       "name": "ROIpeaks",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/roipeaks.yaml",
-      "search_text": "roipeaks ROIpeaks functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot metabolomics/v2"
+      "search_text": "roipeaks ROIpeaks functions (ROIpeaks, MSroiaug) developed by Romà Tauler, Eva Gorrochategui and Joaquim Jaumot metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "rpref",
       "name": "rPref",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rpref.yaml",
-      "search_text": "rpref rPref invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2"
+      "search_text": "rpref rPref invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "rq-redis-queue",
       "name": "RQ (Redis Queue)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "Task Queue | **RQ (Redis Queue)** | Lightweight, Python-native, simpler than Celery",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rq-redis-queue.yaml",
-      "search_text": "rq-redis-queue RQ (Redis Queue) Task Queue | **RQ (Redis Queue)** | Lightweight, Python-native, simpler than Celery metabolomics/v2"
+      "search_text": "rq-redis-queue RQ (Redis Queue) Task Queue | **RQ (Redis Queue)** | Lightweight, Python-native, simpler than Celery metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "rstudio",
       "name": "RStudio",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Fraunhofer-ITMP/alister",
       "license_spdx": "",
       "evidence_text": "[![](https://img.shields.io/badge/Shiny-shinyapps.io-blue?style=flat&labelColor=white&logo=RStudio&logoColor=blue)] we recommend using RStudio to complete the installation and usage of ISFrag The use of RStudio is also recommended. RStudio is an integrated development environment (IDE)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rstudio.yaml",
-      "search_text": "rstudio RStudio [![](https://img.shields.io/badge/Shiny-shinyapps.io-blue?style=flat&labelColor=white&logo=RStudio&logoColor=blue)] we recommend using RStudio to complete the installation and usage of ISFrag The use of RStudio is also recommended. RStudio is an integrated development environment (IDE) metabolomics/v2"
+      "search_text": "rstudio RStudio [![](https://img.shields.io/badge/Shiny-shinyapps.io-blue?style=flat&labelColor=white&logo=RStudio&logoColor=blue)] we recommend using RStudio to complete the installation and usage of ISFrag The use of RStudio is also recommended. RStudio is an integrated development environment (IDE) metabolomics/v2 https://github.com/Fraunhofer-ITMP/alister"
     },
     {
       "slug": "rtklab-byu-proteomics-data-processor",
       "name": "RTKlab-BYU/Proteomics_Data_Processor",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "works with [Processor](https://github.com/RTKlab-BYU/Proteomics_Data_Processor)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rtklab-byu-proteomics-data-processor.yaml",
-      "search_text": "rtklab-byu-proteomics-data-processor RTKlab-BYU/Proteomics_Data_Processor works with [Processor](https://github.com/RTKlab-BYU/Proteomics_Data_Processor) metabolomics/v2"
+      "search_text": "rtklab-byu-proteomics-data-processor RTKlab-BYU/Proteomics_Data_Processor works with [Processor](https://github.com/RTKlab-BYU/Proteomics_Data_Processor) metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "rtklab-byu-raw-file-uploader",
       "name": "RTKlab-BYU/Raw_File_Uploader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RTKlab-BYU/MSConnect",
       "license_spdx": "",
       "evidence_text": "works with [Raw file uploader](https://github.com/RTKlab-BYU/Raw_File_Uploader)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/rtklab-byu-raw-file-uploader.yaml",
-      "search_text": "rtklab-byu-raw-file-uploader RTKlab-BYU/Raw_File_Uploader works with [Raw file uploader](https://github.com/RTKlab-BYU/Raw_File_Uploader) metabolomics/v2"
+      "search_text": "rtklab-byu-raw-file-uploader RTKlab-BYU/Raw_File_Uploader works with [Raw file uploader](https://github.com/RTKlab-BYU/Raw_File_Uploader) metabolomics/v2 https://github.com/RTKlab-BYU/MSConnect"
     },
     {
       "slug": "ruby",
       "name": "Ruby",
-      "canonical_url": "",
+      "canonical_url": "https://bitbucket.org/wishartlab/classyfire_api.git",
       "license_spdx": "",
       "evidence_text": "in order to use the commands below in a Ruby console",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ruby.yaml",
-      "search_text": "ruby Ruby in order to use the commands below in a Ruby console metabolomics/v2"
+      "search_text": "ruby Ruby in order to use the commands below in a Ruby console metabolomics/v2 https://bitbucket.org/wishartlab/classyfire_api.git"
     },
     {
       "slug": "rust",
@@ -122376,79 +122424,79 @@
     {
       "slug": "ruv-iii",
       "name": "RUV-III",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SydneyBioX/hRUV",
       "license_spdx": "",
       "evidence_text": "utilises 2 types of replicates: intra-batch and inter-batch replicates to estimate the unwanted variation within and between batches with RUV-III",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ruv-iii.yaml",
-      "search_text": "ruv-iii RUV-III utilises 2 types of replicates: intra-batch and inter-batch replicates to estimate the unwanted variation within and between batches with RUV-III metabolomics/v2"
+      "search_text": "ruv-iii RUV-III utilises 2 types of replicates: intra-batch and inter-batch replicates to estimate the unwanted variation within and between batches with RUV-III metabolomics/v2 https://github.com/SydneyBioX/hRUV"
     },
     {
       "slug": "s4vectors",
       "name": "S4Vectors",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), return the **full** spectra data within a backend as a `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package) DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/s4vectors.yaml",
-      "search_text": "s4vectors S4Vectors invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), return the **full** spectra data within a backend as a `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package) DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package) metabolomics/v2"
+      "search_text": "s4vectors S4Vectors invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), return the **full** spectra data within a backend as a `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` `DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package) DataFrame` object (defined in the `r Biocpkg(\"S4Vectors\")` package) metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "safari",
       "name": "Safari",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lidawei1975/colmarvista",
       "license_spdx": "",
       "evidence_text": "For Safari: 1. Open Safari settings and go to the \"Advanced\" tab.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/safari.yaml",
-      "search_text": "safari Safari For Safari: 1. Open Safari settings and go to the \"Advanced\" tab. metabolomics/v2"
+      "search_text": "safari Safari For Safari: 1. Open Safari settings and go to the \"Advanced\" tab. metabolomics/v2 https://github.com/lidawei1975/colmarvista"
     },
     {
       "slug": "salmon",
       "name": "Salmon",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Genes, miRNA, isoforms | Align and Assembly | Salmon, samtools, STAR, Hisat2, StringTie2 It then employs [salmon](../modules/nf-core/salmon) in order to obtain quantification files",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/salmon.yaml",
-      "search_text": "salmon Salmon Genes, miRNA, isoforms | Align and Assembly | Salmon, samtools, STAR, Hisat2, StringTie2 It then employs [salmon](../modules/nf-core/salmon) in order to obtain quantification files metabolomics/v2"
+      "search_text": "salmon Salmon Genes, miRNA, isoforms | Align and Assembly | Salmon, samtools, STAR, Hisat2, StringTie2 It then employs [salmon](../modules/nf-core/salmon) in order to obtain quantification files metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "sand",
       "name": "SAND",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/edisonomics/SAND",
       "license_spdx": "",
       "evidence_text": "Any user is welcome to make new modificaitons on the SAND code, particularly its version for NMRBox",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sand.yaml",
-      "search_text": "sand SAND Any user is welcome to make new modificaitons on the SAND code, particularly its version for NMRBox metabolomics/v2"
+      "search_text": "sand SAND Any user is welcome to make new modificaitons on the SAND code, particularly its version for NMRBox metabolomics/v2 https://github.com/edisonomics/SAND"
     },
     {
       "slug": "scannotation",
       "name": "Scannotation",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/scannotation/Scannotation_software",
       "license_spdx": "",
       "evidence_text": "Scannotation is an automated and user-friendly suspect screening tool for the rapid pre-annotation of LC-HRMS datasets.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scannotation.yaml",
-      "search_text": "scannotation Scannotation Scannotation is an automated and user-friendly suspect screening tool for the rapid pre-annotation of LC-HRMS datasets. metabolomics/v2"
+      "search_text": "scannotation Scannotation Scannotation is an automated and user-friendly suspect screening tool for the rapid pre-annotation of LC-HRMS datasets. metabolomics/v2 https://github.com/scannotation/Scannotation_software"
     },
     {
       "slug": "scanpy",
       "name": "scanpy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bioinfo-ibms-pumc/SMART",
       "license_spdx": "",
       "evidence_text": "scanpy",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scanpy.yaml",
-      "search_text": "scanpy scanpy scanpy metabolomics/v2"
+      "search_text": "scanpy scanpy scanpy metabolomics/v2 https://github.com/bioinfo-ibms-pumc/SMART"
     },
     {
       "slug": "scarf",
@@ -122497,13 +122545,13 @@
     {
       "slug": "sciex-q-tof-uhplc-hrms-ms",
       "name": "SCIEX Q-TOF UHPLC-HRMS/MS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GarrettLab-UF/LipidMatch",
       "license_spdx": "",
       "evidence_text": "Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sciex-q-tof-uhplc-hrms-ms.yaml",
-      "search_text": "sciex-q-tof-uhplc-hrms-ms SCIEX Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2"
+      "search_text": "sciex-q-tof-uhplc-hrms-ms SCIEX Q-TOF UHPLC-HRMS/MS Agilent, Bruker and SCIEX Q-TOF UHPLC-HRMS/MS experiments metabolomics/v2 https://github.com/GarrettLab-UF/LipidMatch"
     },
     {
       "slug": "scikit-bio",
@@ -122519,13 +122567,13 @@
     {
       "slug": "scikit-learn-0-23-2",
       "name": "scikit-learn 0.23.2",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "sklearn(0.23.2)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scikit-learn-0-23-2.yaml",
-      "search_text": "scikit-learn-0-23-2 scikit-learn 0.23.2 sklearn(0.23.2) metabolomics/v2"
+      "search_text": "scikit-learn-0-23-2 scikit-learn 0.23.2 sklearn(0.23.2) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "scikit-learn-mlpregressor",
@@ -122541,13 +122589,13 @@
     {
       "slug": "scikit-learn-nearestneighbors-for-knn-index-construction",
       "name": "scikit-learn (NearestNeighbors for KNN index construction)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/WanluLiuLab/SpatialMETA",
       "license_spdx": "",
       "evidence_text": ".. autofunction:: spatialmeta.pp.spot_align_byknn",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scikit-learn-nearestneighbors-for-knn-index-construction.yaml",
-      "search_text": "scikit-learn-nearestneighbors-for-knn-index-construction scikit-learn (NearestNeighbors for KNN index construction) .. autofunction:: spatialmeta.pp.spot_align_byknn metabolomics/v2"
+      "search_text": "scikit-learn-nearestneighbors-for-knn-index-construction scikit-learn (NearestNeighbors for KNN index construction) .. autofunction:: spatialmeta.pp.spot_align_byknn metabolomics/v2 https://github.com/WanluLiuLab/SpatialMETA"
     },
     {
       "slug": "scikit-learn-python",
@@ -122563,57 +122611,57 @@
     {
       "slug": "scikit-learn",
       "name": "scikit-learn",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "a :class:`sklearn.preprocessing.StandardScaler` object used to scale the data a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object * :attr:`gpr`: a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object. from sklearn.model_selection import train_test_split A scikit-learn ``RandomForestClassifier`` wrapper. ## Dependencies - mbpls==1.0.4 - pandas - numpy - matplotlib - scipy - scikit-learn",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scikit-learn.yaml",
-      "search_text": "scikit-learn scikit-learn a :class:`sklearn.preprocessing.StandardScaler` object used to scale the data a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object * :attr:`gpr`: a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object. from sklearn.model_selection import train_test_split A scikit-learn ``RandomForestClassifier`` wrapper. ## Dependencies - mbpls==1.0.4 - pandas - numpy - matplotlib - scipy - scikit-learn metabolomics/v2"
+      "search_text": "scikit-learn scikit-learn a :class:`sklearn.preprocessing.StandardScaler` object used to scale the data a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object * :attr:`gpr`: a :class:`sklearn.gaussian_process.GaussianProcessRegressor` object. from sklearn.model_selection import train_test_split A scikit-learn ``RandomForestClassifier`` wrapper. ## Dependencies - mbpls==1.0.4 - pandas - numpy - matplotlib - scipy - scikit-learn metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "scipy-1-0-0",
       "name": "scipy 1.0.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "scipy(1.0.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scipy-1-0-0.yaml",
-      "search_text": "scipy-1-0-0 scipy 1.0.0 scipy(1.0.0) metabolomics/v2"
+      "search_text": "scipy-1-0-0 scipy 1.0.0 scipy(1.0.0) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport",
       "name": "SciPy (scipy.stats.wasserstein_distance or scipy.optimize.linprog for optimal transport)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GeoMetabolomics-ICBM/mcfNMR",
       "license_spdx": "",
       "evidence_text": "github.com__GeoMetabolomics-ICBM__mcfNMR",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport.yaml",
-      "search_text": "scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport SciPy (scipy.stats.wasserstein_distance or scipy.optimize.linprog for optimal transport) github.com__GeoMetabolomics-ICBM__mcfNMR metabolomics/v2"
+      "search_text": "scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport SciPy (scipy.stats.wasserstein_distance or scipy.optimize.linprog for optimal transport) github.com__GeoMetabolomics-ICBM__mcfNMR metabolomics/v2 https://github.com/GeoMetabolomics-ICBM/mcfNMR"
     },
     {
       "slug": "scipy-signal-detrend",
       "name": "scipy.signal.detrend",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "detrend (scipy.signal.detrend) is performed on the mass track. detrend (scipy.signal.detrend) is performed on the mass track detrend (scipy.signal.detrend) is performed on the mass track. Detrend is a regression method to ensure the baseline is not significantly rising or decreasing over the chromatography.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scipy-signal-detrend.yaml",
-      "search_text": "scipy-signal-detrend scipy.signal.detrend detrend (scipy.signal.detrend) is performed on the mass track. detrend (scipy.signal.detrend) is performed on the mass track detrend (scipy.signal.detrend) is performed on the mass track. Detrend is a regression method to ensure the baseline is not significantly rising or decreasing over the chromatography. metabolomics/v2"
+      "search_text": "scipy-signal-detrend scipy.signal.detrend detrend (scipy.signal.detrend) is performed on the mass track. detrend (scipy.signal.detrend) is performed on the mass track detrend (scipy.signal.detrend) is performed on the mass track. Detrend is a regression method to ensure the baseline is not significantly rising or decreasing over the chromatography. metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "scipy-signal-find-peaks",
       "name": "scipy.signal.find_peaks",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/asari",
       "license_spdx": "",
       "evidence_text": "Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control that is dynamically determined on each mass track then each segment.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scipy-signal-find-peaks.yaml",
-      "search_text": "scipy-signal-find-peaks scipy.signal.find_peaks Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control that is dynamically determined on each mass track then each segment. metabolomics/v2"
+      "search_text": "scipy-signal-find-peaks scipy.signal.find_peaks Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control Asari uses a simple local maxima method (scipy.signal.find_peaks), with prominence control that is dynamically determined on each mass track then each segment. metabolomics/v2 https://github.com/shuzhao-li-lab/asari"
     },
     {
       "slug": "scipy-spearman-correlation",
@@ -122629,35 +122677,35 @@
     {
       "slug": "scipy",
       "name": "scipy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FanzhouKong/spectral_denoising",
       "license_spdx": "",
       "evidence_text": "An additional cosine score implementation [in S3 Text] relies on scipy [41] An additional cosine score implementation (Fig C in S3 Text) relies on scipy [41] scipy.signal module for LOWESS fitting via the regression function scipy==1.4.1 scipy Dependencies: scipy",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/scipy.yaml",
-      "search_text": "scipy scipy An additional cosine score implementation [in S3 Text] relies on scipy [41] An additional cosine score implementation (Fig C in S3 Text) relies on scipy [41] scipy.signal module for LOWESS fitting via the regression function scipy==1.4.1 scipy Dependencies: scipy metabolomics/v2"
+      "search_text": "scipy scipy An additional cosine score implementation [in S3 Text] relies on scipy [41] An additional cosine score implementation (Fig C in S3 Text) relies on scipy [41] scipy.signal module for LOWESS fitting via the regression function scipy==1.4.1 scipy Dependencies: scipy metabolomics/v2 https://github.com/FanzhouKong/spectral_denoising"
     },
     {
       "slug": "sdf-file-parser-molecular-structure-library",
       "name": "SDF file parser / molecular structure library",
-      "canonical_url": "",
+      "canonical_url": "https://gitlab.com/nexs-metabolomics/projects/dna_adductomics_database.git",
       "license_spdx": "",
       "evidence_text": "SDF format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sdf-file-parser-molecular-structure-library.yaml",
-      "search_text": "sdf-file-parser-molecular-structure-library SDF file parser / molecular structure library SDF format metabolomics/v2"
+      "search_text": "sdf-file-parser-molecular-structure-library SDF file parser / molecular structure library SDF format metabolomics/v2 https://gitlab.com/nexs-metabolomics/projects/dna_adductomics_database.git"
     },
     {
       "slug": "seaborn-0-9-0",
       "name": "seaborn 0.9.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "seaborn (0.9.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/seaborn-0-9-0.yaml",
-      "search_text": "seaborn-0-9-0 seaborn 0.9.0 seaborn (0.9.0) metabolomics/v2"
+      "search_text": "seaborn-0-9-0 seaborn 0.9.0 seaborn (0.9.0) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "seaborn-clustermap",
@@ -122673,13 +122721,13 @@
     {
       "slug": "seaborn",
       "name": "seaborn",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/chopralab/CLAW",
       "license_spdx": "",
       "evidence_text": "streamline various tasks such as data parsing, matching, statistical analysis, and visualization It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn [43] We recalculated S so that each element in S* is also between -1 and 1. The normalized S was then used to cluster microbes (rows) and metabolites (columns) separately based on the Euclidean distance import seaborn as sns",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/seaborn.yaml",
-      "search_text": "seaborn seaborn streamline various tasks such as data parsing, matching, statistical analysis, and visualization It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn [43] We recalculated S so that each element in S* is also between -1 and 1. The normalized S was then used to cluster microbes (rows) and metabolites (columns) separately based on the Euclidean distance import seaborn as sns metabolomics/v2"
+      "search_text": "seaborn seaborn streamline various tasks such as data parsing, matching, statistical analysis, and visualization It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn It requires the Python dependencies NumPy [40], pandas [41, 42], seaborn [43] We recalculated S so that each element in S* is also between -1 and 1. The normalized S was then used to cluster microbes (rows) and metabolites (columns) separately based on the Euclidean distance import seaborn as sns metabolomics/v2 https://github.com/chopralab/CLAW"
     },
     {
       "slug": "semantic-release",
@@ -122695,123 +122743,123 @@
     {
       "slug": "seurat",
       "name": "Seurat",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GenomicsMachineLearning/SpaMTP",
       "license_spdx": "",
       "evidence_text": "library(Seurat)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/seurat.yaml",
-      "search_text": "seurat Seurat library(Seurat) metabolomics/v2"
+      "search_text": "seurat Seurat library(Seurat) metabolomics/v2 https://github.com/GenomicsMachineLearning/SpaMTP"
     },
     {
       "slug": "shiny",
       "name": "Shiny",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Fraunhofer-ITMP/alister",
       "license_spdx": "",
       "evidence_text": "ALISTER is a web-app containing scientific information on pre-analytical blood sample stability in metabolomics and lipidomics developed with Shiny The process is implemented in a Shiny app, which can be launched using a function exported by this package Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package QuantyFey is a Shiny application for the visualization, analysis, and quantification of mass spectrometry (MS) data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/shiny.yaml",
-      "search_text": "shiny Shiny ALISTER is a web-app containing scientific information on pre-analytical blood sample stability in metabolomics and lipidomics developed with Shiny The process is implemented in a Shiny app, which can be launched using a function exported by this package Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package QuantyFey is a Shiny application for the visualization, analysis, and quantification of mass spectrometry (MS) data metabolomics/v2"
+      "search_text": "shiny Shiny ALISTER is a web-app containing scientific information on pre-analytical blood sample stability in metabolomics and lipidomics developed with Shiny The process is implemented in a Shiny app, which can be launched using a function exported by this package Shiny GUI implementation of the pmartR R package. Shiny GUI implementation of the pmartR R package QuantyFey is a Shiny application for the visualization, analysis, and quantification of mass spectrometry (MS) data metabolomics/v2 https://github.com/Fraunhofer-ITMP/alister"
     },
     {
       "slug": "shinyscreen",
       "name": "shinyscreen",
-      "canonical_url": "",
+      "canonical_url": "https://gitlab.com/uniluxembourg/lcsb/eci/shinyscreen.git",
       "license_spdx": "",
       "evidence_text": "Shinyscreen is a Shiny application for visualizing and analyzing high resolution mass spectrometry data.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/shinyscreen.yaml",
-      "search_text": "shinyscreen shinyscreen Shinyscreen is a Shiny application for visualizing and analyzing high resolution mass spectrometry data. metabolomics/v2"
+      "search_text": "shinyscreen shinyscreen Shinyscreen is a Shiny application for visualizing and analyzing high resolution mass spectrometry data. metabolomics/v2 https://gitlab.com/uniluxembourg/lcsb/eci/shinyscreen.git"
     },
     {
       "slug": "signal-processing-toolbox",
       "name": "Signal Processing Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/signal-processing-toolbox.yaml",
-      "search_text": "signal-processing-toolbox Signal Processing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "signal-processing-toolbox Signal Processing Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "signalp",
       "name": "signalP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Functional annotation | CPAT, signalP, pfam",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/signalp.yaml",
-      "search_text": "signalp signalP Functional annotation | CPAT, signalP, pfam metabolomics/v2"
+      "search_text": "signalp signalP Functional annotation | CPAT, signalP, pfam metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "simile",
       "name": "SIMILE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/biorack/simile",
       "license_spdx": "",
       "evidence_text": "SIMILE (Significant Interrelation of MS/MS Ions via Laplacian Embedding) is a Python library",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/simile.yaml",
-      "search_text": "simile SIMILE SIMILE (Significant Interrelation of MS/MS Ions via Laplacian Embedding) is a Python library metabolomics/v2"
+      "search_text": "simile SIMILE SIMILE (Significant Interrelation of MS/MS Ions via Laplacian Embedding) is a Python library metabolomics/v2 https://github.com/biorack/simile"
     },
     {
       "slug": "singularity",
       "name": "Singularity",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Build singularity image on job node. Freaks out on login node: ``` SCRATCH_PATH=/cluster/scratch/$(id Build singularity image on job node Build singularity image on job node. It uses Docker/Singularity containers making installation trivial and results highly reproducible. Both Docker and Singularity (for high-performance computing) are supported Both Docker and Singularity (for high-performance computing) are supported.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/singularity.yaml",
-      "search_text": "singularity Singularity Build singularity image on job node. Freaks out on login node: ``` SCRATCH_PATH=/cluster/scratch/$(id Build singularity image on job node Build singularity image on job node. It uses Docker/Singularity containers making installation trivial and results highly reproducible. Both Docker and Singularity (for high-performance computing) are supported Both Docker and Singularity (for high-performance computing) are supported. metabolomics/v2"
+      "search_text": "singularity Singularity Build singularity image on job node. Freaks out on login node: ``` SCRATCH_PATH=/cluster/scratch/$(id Build singularity image on job node Build singularity image on job node. It uses Docker/Singularity containers making installation trivial and results highly reproducible. Both Docker and Singularity (for high-performance computing) are supported Both Docker and Singularity (for high-performance computing) are supported. metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "sirius",
       "name": "SIRIUS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/boecker-lab/sirius",
       "license_spdx": "",
       "evidence_text": "ConCISE utlizes the structural annotations provided by in silico tools such as [SIRIUS] SIRIUS is a java-based software framework for the analysis of LC-MS/MS data install Sirius and run it in your set. install Sirius and run it in your set install [Sirius](https://bio.informatik.uni-jena.de/software/sirius/) and run it in your set. compound database dereplication using SIRIUS OR MetFrag",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sirius.yaml",
-      "search_text": "sirius SIRIUS ConCISE utlizes the structural annotations provided by in silico tools such as [SIRIUS] SIRIUS is a java-based software framework for the analysis of LC-MS/MS data install Sirius and run it in your set. install Sirius and run it in your set install [Sirius](https://bio.informatik.uni-jena.de/software/sirius/) and run it in your set. compound database dereplication using SIRIUS OR MetFrag metabolomics/v2"
+      "search_text": "sirius SIRIUS ConCISE utlizes the structural annotations provided by in silico tools such as [SIRIUS] SIRIUS is a java-based software framework for the analysis of LC-MS/MS data install Sirius and run it in your set. install Sirius and run it in your set install [Sirius](https://bio.informatik.uni-jena.de/software/sirius/) and run it in your set. compound database dereplication using SIRIUS OR MetFrag metabolomics/v2 https://github.com/boecker-lab/sirius"
     },
     {
       "slug": "sklearn",
       "name": "Sklearn",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/facundof2016/CCSP2.0",
       "license_spdx": "",
       "evidence_text": "The current version of CCSP 2.0 requires Sklearn V1.0.2 or later",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sklearn.yaml",
-      "search_text": "sklearn Sklearn The current version of CCSP 2.0 requires Sklearn V1.0.2 or later metabolomics/v2"
+      "search_text": "sklearn Sklearn The current version of CCSP 2.0 requires Sklearn V1.0.2 or later metabolomics/v2 https://github.com/facundof2016/CCSP2.0"
     },
     {
       "slug": "skyline",
       "name": "Skyline",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/13479776/statTarget",
       "license_spdx": "",
       "evidence_text": "LipidCreator is a plugin for Skyline supporting targeted workflow development in lipidomics LipidCreator is a plugin for [Skyline](https://skyline.ms/project/home/software/Skyline/begin.view) supporting targeted workflow development in lipidomics. `lipidr` takes exported Skyline CSV as input, allowing for multiple methods to be analyzed together. You can inspect the Benchmark in greater detail by exporting it to Skyline, which you can download from [here] In the academic environment, MaxQuant and Skyline are by far the most popular ones. [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline](https://skyline.ms/project/home/begin.view?)[@MacLean2010] are by far the most popular ones.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/skyline.yaml",
-      "search_text": "skyline Skyline LipidCreator is a plugin for Skyline supporting targeted workflow development in lipidomics LipidCreator is a plugin for [Skyline](https://skyline.ms/project/home/software/Skyline/begin.view) supporting targeted workflow development in lipidomics. `lipidr` takes exported Skyline CSV as input, allowing for multiple methods to be analyzed together. You can inspect the Benchmark in greater detail by exporting it to Skyline, which you can download from [here] In the academic environment, MaxQuant and Skyline are by far the most popular ones. [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline](https://skyline.ms/project/home/begin.view?)[@MacLean2010] are by far the most popular ones. metabolomics/v2"
+      "search_text": "skyline Skyline LipidCreator is a plugin for Skyline supporting targeted workflow development in lipidomics LipidCreator is a plugin for [Skyline](https://skyline.ms/project/home/software/Skyline/begin.view) supporting targeted workflow development in lipidomics. `lipidr` takes exported Skyline CSV as input, allowing for multiple methods to be analyzed together. You can inspect the Benchmark in greater detail by exporting it to Skyline, which you can download from [here] In the academic environment, MaxQuant and Skyline are by far the most popular ones. [MaxQuant](https://maxquant.org/)[@Cox2008] and [Skyline](https://skyline.ms/project/home/begin.view?)[@MacLean2010] are by far the most popular ones. metabolomics/v2 https://github.com/13479776/statTarget"
     },
     {
       "slug": "slack-api",
       "name": "Slack API",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/czbiohub-sf/Rapid-QC-MS",
       "license_spdx": "",
       "evidence_text": "**Realtime updates on QC fails** in the form of Slack or email notifications",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/slack-api.yaml",
-      "search_text": "slack-api Slack API **Realtime updates on QC fails** in the form of Slack or email notifications metabolomics/v2"
+      "search_text": "slack-api Slack API **Realtime updates on QC fails** in the form of Slack or email notifications metabolomics/v2 https://github.com/czbiohub-sf/Rapid-QC-MS"
     },
     {
       "slug": "slaw-grouping-module",
@@ -122838,178 +122886,178 @@
     {
       "slug": "slurm",
       "name": "SLURM",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/meowcat/MSNovelist",
       "license_spdx": "",
       "evidence_text": "For usage with SLURM, sets up one GPU. Use with `sbatch --array=0-9` For usage with SLURM, sets up one GPU",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/slurm.yaml",
-      "search_text": "slurm SLURM For usage with SLURM, sets up one GPU. Use with `sbatch --array=0-9` For usage with SLURM, sets up one GPU metabolomics/v2"
+      "search_text": "slurm SLURM For usage with SLURM, sets up one GPU. Use with `sbatch --array=0-9` For usage with SLURM, sets up one GPU metabolomics/v2 https://github.com/meowcat/MSNovelist"
     },
     {
       "slug": "smart",
       "name": "SMART",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bioinfo-ibms-pumc/SMART",
       "license_spdx": "",
       "evidence_text": "we present SMART, an open-source platform designed for precise formula assignment in mass spectrometry imaging",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/smart.yaml",
-      "search_text": "smart SMART we present SMART, an open-source platform designed for precise formula assignment in mass spectrometry imaging metabolomics/v2"
+      "search_text": "smart SMART we present SMART, an open-source platform designed for precise formula assignment in mass spectrometry imaging metabolomics/v2 https://github.com/bioinfo-ibms-pumc/SMART"
     },
     {
       "slug": "smartpeak",
       "name": "SmartPeak",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AutoFlowResearch/SmartPeak",
       "license_spdx": "",
       "evidence_text": "SmartPeak automates targeted and quantitative metabolomics data processing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/smartpeak.yaml",
-      "search_text": "smartpeak SmartPeak SmartPeak automates targeted and quantitative metabolomics data processing metabolomics/v2"
+      "search_text": "smartpeak SmartPeak SmartPeak automates targeted and quantitative metabolomics data processing metabolomics/v2 https://github.com/AutoFlowResearch/SmartPeak"
     },
     {
       "slug": "smartpeakcli",
       "name": "SmartPeakCLI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AutoFlowResearch/SmartPeak",
       "license_spdx": "",
       "evidence_text": "SmartPeak CLI provides an equivalent of SmartPeak GUI application, however with a possibility to run in headless mode SmartPeak CLI provides an equivalent of SmartPeak GUI application",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/smartpeakcli.yaml",
-      "search_text": "smartpeakcli SmartPeakCLI SmartPeak CLI provides an equivalent of SmartPeak GUI application, however with a possibility to run in headless mode SmartPeak CLI provides an equivalent of SmartPeak GUI application metabolomics/v2"
+      "search_text": "smartpeakcli SmartPeakCLI SmartPeak CLI provides an equivalent of SmartPeak GUI application, however with a possibility to run in headless mode SmartPeak CLI provides an equivalent of SmartPeak GUI application metabolomics/v2 https://github.com/AutoFlowResearch/SmartPeak"
     },
     {
       "slug": "smartpeakgui",
       "name": "SmartPeakGUI",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AutoFlowResearch/SmartPeak",
       "license_spdx": "",
       "evidence_text": "SmartPeak GUI provides functionality to facilitate users to get up and running as quickly as possible",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/smartpeakgui.yaml",
-      "search_text": "smartpeakgui SmartPeakGUI SmartPeak GUI provides functionality to facilitate users to get up and running as quickly as possible metabolomics/v2"
+      "search_text": "smartpeakgui SmartPeakGUI SmartPeak GUI provides functionality to facilitate users to get up and running as quickly as possible metabolomics/v2 https://github.com/AutoFlowResearch/SmartPeak"
     },
     {
       "slug": "smiter",
       "name": "SMITER",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeidelLab/SMITER",
       "license_spdx": "",
       "evidence_text": "SMITER (Synthetic mzML writer) is a python-based command-line tool designed to simulate LC-MS/MS runs.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/smiter.yaml",
-      "search_text": "smiter SMITER SMITER (Synthetic mzML writer) is a python-based command-line tool designed to simulate LC-MS/MS runs. metabolomics/v2"
+      "search_text": "smiter SMITER SMITER (Synthetic mzML writer) is a python-based command-line tool designed to simulate LC-MS/MS runs. metabolomics/v2 https://github.com/LeidelLab/SMITER"
     },
     {
       "slug": "snakemake",
       "name": "Snakemake",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/DasSusanta/snakemake_ccs",
       "license_spdx": "",
       "evidence_text": "snakemake --configfile config/config_fast.yaml --jobs 1 --dry-run -p A Snakemake configuration file in YAML format is required. A Snakemake configuration file in `YAML <http://yaml.org/>`_ format is required. Snakemake workflow manager for predicting collisional cross sections This repository contains a Snakemake workflow manager for predicting collisional cross sections (CCS)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/snakemake.yaml",
-      "search_text": "snakemake Snakemake snakemake --configfile config/config_fast.yaml --jobs 1 --dry-run -p A Snakemake configuration file in YAML format is required. A Snakemake configuration file in `YAML <http://yaml.org/>`_ format is required. Snakemake workflow manager for predicting collisional cross sections This repository contains a Snakemake workflow manager for predicting collisional cross sections (CCS) metabolomics/v2"
+      "search_text": "snakemake Snakemake snakemake --configfile config/config_fast.yaml --jobs 1 --dry-run -p A Snakemake configuration file in YAML format is required. A Snakemake configuration file in `YAML <http://yaml.org/>`_ format is required. Snakemake workflow manager for predicting collisional cross sections This repository contains a Snakemake workflow manager for predicting collisional cross sections (CCS) metabolomics/v2 https://github.com/DasSusanta/snakemake_ccs"
     },
     {
       "slug": "spamtp",
       "name": "SpaMTP",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GenomicsMachineLearning/SpaMTP",
       "license_spdx": "",
       "evidence_text": "Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\") Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\")",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spamtp.yaml",
-      "search_text": "spamtp SpaMTP Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\") Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\") metabolomics/v2"
+      "search_text": "spamtp SpaMTP Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\") Install SpaMTP if not previously installed devtools::install_github(\"GenomicsMachineLearning/SpaMTP\") metabolomics/v2 https://github.com/GenomicsMachineLearning/SpaMTP"
     },
     {
       "slug": "spatialmeta",
       "name": "spatialMETA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/WanluLiuLab/SpatialMETA",
       "license_spdx": "",
       "evidence_text": "spatialMETA is a method for integrating spatial multi-omics data spatialmeta.pp.calculate_qc_metrics_sm spatialmeta.model.ConditionalVAESTSM",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spatialmeta.yaml",
-      "search_text": "spatialmeta spatialMETA spatialMETA is a method for integrating spatial multi-omics data spatialmeta.pp.calculate_qc_metrics_sm spatialmeta.model.ConditionalVAESTSM metabolomics/v2"
+      "search_text": "spatialmeta spatialMETA spatialMETA is a method for integrating spatial multi-omics data spatialmeta.pp.calculate_qc_metrics_sm spatialmeta.model.ConditionalVAESTSM metabolomics/v2 https://github.com/WanluLiuLab/SpatialMETA"
     },
     {
       "slug": "spec2vec",
       "name": "Spec2Vec",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/vdhooftcompmet/MS2LDA",
       "license_spdx": "",
       "evidence_text": "we introduce Spec2Vec, a novel spectral similarity score spec2vec (https://github.com/iomega/spec2vec). Both packages are freely available and can be installed via conda The underlying code was developed into two Python packages to handle and compare mass spectra, matchms (https://github.com/matchms/matchms) and spec2vec (https://github.com/iomega/spec2vec) MEMO is mainly built on `matchms`_ and `spec2vec`_ packages for handling the MS2 spectra recently introduced unsupervised Spec2V Automated Mass2Motif Annotation Guidance (MAG) with Spec2Vec",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spec2vec.yaml",
-      "search_text": "spec2vec Spec2Vec we introduce Spec2Vec, a novel spectral similarity score spec2vec (https://github.com/iomega/spec2vec). Both packages are freely available and can be installed via conda The underlying code was developed into two Python packages to handle and compare mass spectra, matchms (https://github.com/matchms/matchms) and spec2vec (https://github.com/iomega/spec2vec) MEMO is mainly built on `matchms`_ and `spec2vec`_ packages for handling the MS2 spectra recently introduced unsupervised Spec2V Automated Mass2Motif Annotation Guidance (MAG) with Spec2Vec metabolomics/v2"
+      "search_text": "spec2vec Spec2Vec we introduce Spec2Vec, a novel spectral similarity score spec2vec (https://github.com/iomega/spec2vec). Both packages are freely available and can be installed via conda The underlying code was developed into two Python packages to handle and compare mass spectra, matchms (https://github.com/matchms/matchms) and spec2vec (https://github.com/iomega/spec2vec) MEMO is mainly built on `matchms`_ and `spec2vec`_ packages for handling the MS2 spectra recently introduced unsupervised Spec2V Automated Mass2Motif Annotation Guidance (MAG) with Spec2Vec metabolomics/v2 https://github.com/vdhooftcompmet/MS2LDA"
     },
     {
       "slug": "spectra-hash",
       "name": "spectra-hash",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/eMetaboHUB/FragHub",
       "license_spdx": "",
       "evidence_text": "direct integration of spectra-hash (https://github.com/berlinguyinca/spectra-hash) into fraghub",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectra-hash.yaml",
-      "search_text": "spectra-hash spectra-hash direct integration of spectra-hash (https://github.com/berlinguyinca/spectra-hash) into fraghub metabolomics/v2"
+      "search_text": "spectra-hash spectra-hash direct integration of spectra-hash (https://github.com/berlinguyinca/spectra-hash) into fraghub metabolomics/v2 https://github.com/eMetaboHUB/FragHub"
     },
     {
       "slug": "spectra",
       "name": "Spectra",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), performs spectral database dereplication using R Package spectral database dereplication using R Package Spectra The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"Spectra\")` The *Spectra* package defines an efficient infrastructure for storing and handling mass spectrometry spectra",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectra.yaml",
-      "search_text": "spectra Spectra invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), performs spectral database dereplication using R Package spectral database dereplication using R Package Spectra The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"Spectra\")` The *Spectra* package defines an efficient infrastructure for storing and handling mass spectrometry spectra metabolomics/v2"
+      "search_text": "spectra Spectra invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\" invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\", \"patchwork\", \"S4Vectors\", \"Spectra\", \"BiocManager\", \"knitr\", \"markdown\"), performs spectral database dereplication using R Package spectral database dereplication using R Package Spectra The transformation is performed using functionality from the packages `r BiocStyle::Biocpkg(\"Spectra\")` The *Spectra* package defines an efficient infrastructure for storing and handling mass spectrometry spectra metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "spectral-denoising",
       "name": "spectral_denoising",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/FanzhouKong/spectral_denoising",
       "license_spdx": "",
       "evidence_text": "import spectral_denoising as sd",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectral-denoising.yaml",
-      "search_text": "spectral-denoising spectral_denoising import spectral_denoising as sd metabolomics/v2"
+      "search_text": "spectral-denoising spectral_denoising import spectral_denoising as sd metabolomics/v2 https://github.com/FanzhouKong/spectral_denoising"
     },
     {
       "slug": "spectral-similarity",
       "name": "spectral_similarity",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuanyueLi/SpectralEntropy",
       "license_spdx": "",
       "evidence_text": ".. automodule:: spectral_similarity :members:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectral-similarity.yaml",
-      "search_text": "spectral-similarity spectral_similarity .. automodule:: spectral_similarity :members: metabolomics/v2"
+      "search_text": "spectral-similarity spectral_similarity .. automodule:: spectral_similarity :members: metabolomics/v2 https://github.com/YuanyueLi/SpectralEntropy"
     },
     {
       "slug": "spectralentropy",
       "name": "SpectralEntropy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/YuanyueLi/SpectralEntropy",
       "license_spdx": "",
       "evidence_text": "This repository contains the original source code for the paper",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectralentropy.yaml",
-      "search_text": "spectralentropy SpectralEntropy This repository contains the original source code for the paper metabolomics/v2"
+      "search_text": "spectralentropy SpectralEntropy This repository contains the original source code for the paper metabolomics/v2 https://github.com/YuanyueLi/SpectralEntropy"
     },
     {
       "slug": "spectraverse-analysis-repository",
       "name": "spectraverse-analysis repository",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/skinniderlab/spectraverse-analysis",
       "license_spdx": "",
       "evidence_text": "github.com/skinniderlab/spectraverse-analysis",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/spectraverse-analysis-repository.yaml",
-      "search_text": "spectraverse-analysis-repository spectraverse-analysis repository github.com/skinniderlab/spectraverse-analysis metabolomics/v2"
+      "search_text": "spectraverse-analysis-repository spectraverse-analysis repository github.com/skinniderlab/spectraverse-analysis metabolomics/v2 https://github.com/skinniderlab/spectraverse-analysis"
     },
     {
       "slug": "spectripy",
@@ -123047,13 +123095,13 @@
     {
       "slug": "sphinx",
       "name": "Sphinx",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pluskal-lab/DreaMS",
       "license_spdx": "",
       "evidence_text": "sphinx-apidoc -o . ../dreams && make html Build docs with sphinx-build",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sphinx.yaml",
-      "search_text": "sphinx Sphinx sphinx-apidoc -o . ../dreams && make html Build docs with sphinx-build metabolomics/v2"
+      "search_text": "sphinx Sphinx sphinx-apidoc -o . ../dreams && make html Build docs with sphinx-build metabolomics/v2 https://github.com/pluskal-lab/DreaMS"
     },
     {
       "slug": "spreadout",
@@ -123069,13 +123117,13 @@
     {
       "slug": "sql",
       "name": "SQL",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MassQueryLanguage",
       "license_spdx": "",
       "evidence_text": "It is inspired by SQL, but it attempts to bake in assumptions of mass spectrometry",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sql.yaml",
-      "search_text": "sql SQL It is inspired by SQL, but it attempts to bake in assumptions of mass spectrometry metabolomics/v2"
+      "search_text": "sql SQL It is inspired by SQL, but it attempts to bake in assumptions of mass spectrometry metabolomics/v2 https://github.com/mwang87/MassQueryLanguage"
     },
     {
       "slug": "sqlalchemy",
@@ -123113,35 +123161,35 @@
     {
       "slug": "sqmassloader",
       "name": "SqMassLoader",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "Chromatogram Loaders: Raw data stores chromatograms, this allows for faster loading however since extraction has already been performed by the upstream analysis tool. This includes SqMassLoader",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sqmassloader.yaml",
-      "search_text": "sqmassloader SqMassLoader Chromatogram Loaders: Raw data stores chromatograms, this allows for faster loading however since extraction has already been performed by the upstream analysis tool. This includes SqMassLoader metabolomics/v2"
+      "search_text": "sqmassloader SqMassLoader Chromatogram Loaders: Raw data stores chromatograms, this allows for faster loading however since extraction has already been performed by the upstream analysis tool. This includes SqMassLoader metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "sra-toolkit",
       "name": "SRA toolkit",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Genes, miRNA, isoforms | SRA download | SRA toolkit",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sra-toolkit.yaml",
-      "search_text": "sra-toolkit SRA toolkit Genes, miRNA, isoforms | SRA download | SRA toolkit metabolomics/v2"
+      "search_text": "sra-toolkit SRA toolkit Genes, miRNA, isoforms | SRA download | SRA toolkit metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "stagate",
       "name": "STAGATE",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/bioinfo-ibms-pumc/SMART",
       "license_spdx": "",
       "evidence_text": "STAGATE",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/stagate.yaml",
-      "search_text": "stagate STAGATE STAGATE metabolomics/v2"
+      "search_text": "stagate STAGATE STAGATE metabolomics/v2 https://github.com/bioinfo-ibms-pumc/SMART"
     },
     {
       "slug": "star-aligner-v-2-6-1d",
@@ -123157,46 +123205,46 @@
     {
       "slug": "statistical-analysis-libraries-scipy-stats-for-enrichment-tests",
       "name": "Statistical analysis libraries (scipy.stats for enrichment tests)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/metabolomicsworkbench/MetENP",
       "license_spdx": "",
       "evidence_text": "enrichment statistics",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/statistical-analysis-libraries-scipy-stats-for-enrichment-tests.yaml",
-      "search_text": "statistical-analysis-libraries-scipy-stats-for-enrichment-tests Statistical analysis libraries (scipy.stats for enrichment tests) enrichment statistics metabolomics/v2"
+      "search_text": "statistical-analysis-libraries-scipy-stats-for-enrichment-tests Statistical analysis libraries (scipy.stats for enrichment tests) enrichment statistics metabolomics/v2 https://github.com/metabolomicsworkbench/MetENP"
     },
     {
       "slug": "statistical-total-correlation-spectroscopy-stocsy",
       "name": "Statistical Total Correlation Spectroscopy (STOCSY)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AndreaRMICL/MWASTools",
       "license_spdx": "",
       "evidence_text": "metabolite assignment using Statistical Total Correlation Spectroscopy (STOCSY)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/statistical-total-correlation-spectroscopy-stocsy.yaml",
-      "search_text": "statistical-total-correlation-spectroscopy-stocsy Statistical Total Correlation Spectroscopy (STOCSY) metabolite assignment using Statistical Total Correlation Spectroscopy (STOCSY) metabolomics/v2"
+      "search_text": "statistical-total-correlation-spectroscopy-stocsy Statistical Total Correlation Spectroscopy (STOCSY) metabolite assignment using Statistical Total Correlation Spectroscopy (STOCSY) metabolomics/v2 https://github.com/AndreaRMICL/MWASTools"
     },
     {
       "slug": "statistics-and-machine-learning-toolbox",
       "name": "Statistics And Machine Learning Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/statistics-and-machine-learning-toolbox.yaml",
-      "search_text": "statistics-and-machine-learning-toolbox Statistics And Machine Learning Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "statistics-and-machine-learning-toolbox Statistics And Machine Learning Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "stats",
       "name": "stats",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/BiosystemEngineeringLab-IITB/dures",
       "license_spdx": "",
       "evidence_text": "invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\"",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/stats.yaml",
-      "search_text": "stats stats invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2"
+      "search_text": "stats stats invisible(lapply(c(\"dplyr\", \"readr\", \"data.table\", \"pbapply\", \"magrittr\", \"utils\", \"stats\", \"rPref\", \"ggplot2\", \"DEoptim\" metabolomics/v2 https://github.com/BiosystemEngineeringLab-IITB/dures"
     },
     {
       "slug": "stattarget",
@@ -123212,57 +123260,57 @@
     {
       "slug": "streamlit",
       "name": "Streamlit",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/OpenMS/OpenMS",
       "license_spdx": "",
       "evidence_text": "streamlit graphical user interface (GUI) OpenMS Streamlit Template's **online mode only**",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/streamlit.yaml",
-      "search_text": "streamlit Streamlit streamlit graphical user interface (GUI) OpenMS Streamlit Template's **online mode only** metabolomics/v2"
+      "search_text": "streamlit Streamlit streamlit graphical user interface (GUI) OpenMS Streamlit Template's **online mode only** metabolomics/v2 https://github.com/OpenMS/OpenMS"
     },
     {
       "slug": "stringr",
       "name": "stringr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kilgain/MassSpec",
       "license_spdx": "",
       "evidence_text": "required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\",",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/stringr.yaml",
-      "search_text": "stringr stringr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2"
+      "search_text": "stringr stringr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2 https://github.com/kilgain/MassSpec"
     },
     {
       "slug": "summarizedexperiment",
       "name": "SummarizedExperiment",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SydneyBioX/hRUV",
       "license_spdx": "",
       "evidence_text": "library(SummarizedExperiment)... The data is already formatted in to a `SummarizedExperiment` object The toolbox builds upon the bioconductor package SummarizedExperiment (SE) The `buildExperiment` function will then take the data and create an experiment object that can be used for analysis. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data The `buildExperiment` function will then take the data and create an experiment object",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/summarizedexperiment.yaml",
-      "search_text": "summarizedexperiment SummarizedExperiment library(SummarizedExperiment)... The data is already formatted in to a `SummarizedExperiment` object The toolbox builds upon the bioconductor package SummarizedExperiment (SE) The `buildExperiment` function will then take the data and create an experiment object that can be used for analysis. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data The `buildExperiment` function will then take the data and create an experiment object metabolomics/v2"
+      "search_text": "summarizedexperiment SummarizedExperiment library(SummarizedExperiment)... The data is already formatted in to a `SummarizedExperiment` object The toolbox builds upon the bioconductor package SummarizedExperiment (SE) The `buildExperiment` function will then take the data and create an experiment object that can be used for analysis. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data. Internally, mzQuality uses Bioconductors' *SummarizedExperiment* object to store the data The `buildExperiment` function will then take the data and create an experiment object metabolomics/v2 https://github.com/SydneyBioX/hRUV"
     },
     {
       "slug": "sva",
       "name": "sva",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "ComBat(parametric and non-parametric)-model [PMID:16632515] from sva package [PMID:22257669] Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/sva.yaml",
-      "search_text": "sva sva ComBat(parametric and non-parametric)-model [PMID:16632515] from sva package [PMID:22257669] Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva metabolomics/v2"
+      "search_text": "sva sva ComBat(parametric and non-parametric)-model [PMID:16632515] from sva package [PMID:22257669] Genes, miRNA, isoforms, proteins, lipids | Data preprocessing | R packages: edger, limma, sva metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "symfony",
       "name": "Symfony",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/privrja/MassSpecBlocks",
       "license_spdx": "",
       "evidence_text": "Backend is written in PHP with Symfony framework",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/symfony.yaml",
-      "search_text": "symfony Symfony Backend is written in PHP with Symfony framework metabolomics/v2"
+      "search_text": "symfony Symfony Backend is written in PHP with Symfony framework metabolomics/v2 https://github.com/privrja/MassSpecBlocks"
     },
     {
       "slug": "syncsa",
@@ -123278,13 +123326,13 @@
     {
       "slug": "syrupy",
       "name": "Syrupy",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Roestlab/massdash",
       "license_spdx": "",
       "evidence_text": "Syrupy is used to compare output to previous expected output states",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/syrupy.yaml",
-      "search_text": "syrupy Syrupy Syrupy is used to compare output to previous expected output states metabolomics/v2"
+      "search_text": "syrupy Syrupy Syrupy is used to compare output to previous expected output states metabolomics/v2 https://github.com/Roestlab/massdash"
     },
     {
       "slug": "t-sne-t-distributed-stochastic-neighbor-embedding",
@@ -123311,13 +123359,13 @@
     {
       "slug": "tandemmatch",
       "name": "TandemMatch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pnnl/IonToolPack",
       "license_spdx": "",
       "evidence_text": "TandemMatch: MS/MS spectral library matching with support for MSP and CSV library formats.",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tandemmatch.yaml",
-      "search_text": "tandemmatch TandemMatch TandemMatch: MS/MS spectral library matching with support for MSP and CSV library formats. metabolomics/v2"
+      "search_text": "tandemmatch TandemMatch TandemMatch: MS/MS spectral library matching with support for MSP and CSV library formats. metabolomics/v2 https://github.com/pnnl/IonToolPack"
     },
     {
       "slug": "tardis",
@@ -123333,13 +123381,13 @@
     {
       "slug": "tensorflow-1-8-0",
       "name": "Tensorflow 1.8.0",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/wabdelmoula/massNet",
       "license_spdx": "",
       "evidence_text": "Tensorflow(1.8.0)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tensorflow-1-8-0.yaml",
-      "search_text": "tensorflow-1-8-0 Tensorflow 1.8.0 Tensorflow(1.8.0) metabolomics/v2"
+      "search_text": "tensorflow-1-8-0 Tensorflow 1.8.0 Tensorflow(1.8.0) metabolomics/v2 https://github.com/wabdelmoula/massNet"
     },
     {
       "slug": "tensorflow-2-3-0",
@@ -123366,24 +123414,24 @@
     {
       "slug": "tensorflow-serving",
       "name": "TensorFlow Serving",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/NP-Classifier",
       "license_spdx": "",
       "evidence_text": "We pass through tensorflow serving at this url We pass through tensorflow serving at this url:",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tensorflow-serving.yaml",
-      "search_text": "tensorflow-serving TensorFlow Serving We pass through tensorflow serving at this url We pass through tensorflow serving at this url: metabolomics/v2"
+      "search_text": "tensorflow-serving TensorFlow Serving We pass through tensorflow serving at this url We pass through tensorflow serving at this url: metabolomics/v2 https://github.com/mwang87/NP-Classifier"
     },
     {
       "slug": "tensorflow",
       "name": "TensorFlow",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/JainLab/Manuscript-DNNs-for-Classification-of-LCMS-Peaks",
       "license_spdx": "",
       "evidence_text": "tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models We pass through tensorflow serving at this url: ```/model/metadata``` Make sure you have python installed and tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models. Deep Neural Networks for Classification of LC-MS Spectral Peaks _No usage/docs found._ cddd does not seem to work on newer cuda drivers, therefore it is build using tensorflow cpu",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tensorflow.yaml",
-      "search_text": "tensorflow TensorFlow tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models We pass through tensorflow serving at this url: ```/model/metadata``` Make sure you have python installed and tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models. Deep Neural Networks for Classification of LC-MS Spectral Peaks _No usage/docs found._ cddd does not seem to work on newer cuda drivers, therefore it is build using tensorflow cpu metabolomics/v2"
+      "search_text": "tensorflow TensorFlow tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models We pass through tensorflow serving at this url: ```/model/metadata``` Make sure you have python installed and tensorflow version 2.3.0 installed to convert the keras models into HDF5 TF2 models. Deep Neural Networks for Classification of LC-MS Spectral Peaks _No usage/docs found._ cddd does not seem to work on newer cuda drivers, therefore it is build using tensorflow cpu metabolomics/v2 https://github.com/JainLab/Manuscript-DNNs-for-Classification-of-LCMS-Peaks"
     },
     {
       "slug": "thermorawfileparser",
@@ -123399,57 +123447,57 @@
     {
       "slug": "tibble",
       "name": "tibble",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/kilgain/MassSpec",
       "license_spdx": "",
       "evidence_text": "required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\",",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tibble.yaml",
-      "search_text": "tibble tibble required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2"
+      "search_text": "tibble tibble required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", metabolomics/v2 https://github.com/kilgain/MassSpec"
     },
     {
       "slug": "tidyr",
       "name": "tidyr",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/GenomicsMachineLearning/SpaMTP",
       "license_spdx": "",
       "evidence_text": "required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(tidyr)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tidyr.yaml",
-      "search_text": "tidyr tidyr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(tidyr) metabolomics/v2"
+      "search_text": "tidyr tidyr required_pkgs <- c(\"dplyr\",\"tidyr\",\"readr\", \"stringr\", \"tibble\", \"purrr\", library(tidyr) metabolomics/v2 https://github.com/GenomicsMachineLearning/SpaMTP"
     },
     {
       "slug": "tidyverse",
       "name": "tidyverse",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LeaveMeNotTonight/CMDN",
       "license_spdx": "",
       "evidence_text": "tidyverse library(tidyverse)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tidyverse.yaml",
-      "search_text": "tidyverse tidyverse tidyverse library(tidyverse) metabolomics/v2"
+      "search_text": "tidyverse tidyverse tidyverse library(tidyverse) metabolomics/v2 https://github.com/LeaveMeNotTonight/CMDN"
     },
     {
       "slug": "timar",
       "name": "timaR",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/luigiquiros/inventa",
       "license_spdx": "",
       "evidence_text": "tima_results_filename: timaR reponderated output format. - for performing in silico annotations and taxonomically informed reponderation. tima_results_filename: timaR reponderated output format",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/timar.yaml",
-      "search_text": "timar timaR tima_results_filename: timaR reponderated output format. - for performing in silico annotations and taxonomically informed reponderation. tima_results_filename: timaR reponderated output format metabolomics/v2"
+      "search_text": "timar timaR tima_results_filename: timaR reponderated output format. - for performing in silico annotations and taxonomically informed reponderation. tima_results_filename: timaR reponderated output format metabolomics/v2 https://github.com/luigiquiros/inventa"
     },
     {
       "slug": "tissuemasst",
       "name": "tissueMASST",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mwang87/MASST",
       "license_spdx": "",
       "evidence_text": "microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tissuemasst.yaml",
-      "search_text": "tissuemasst tissueMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2"
+      "search_text": "tissuemasst tissueMASST microbeMASST, plantMASST, tissueMASST, microbiomeMASST, and foodMASST metabolomics/v2 https://github.com/mwang87/MASST"
     },
     {
       "slug": "tomcat",
@@ -123476,101 +123524,101 @@
     {
       "slug": "torch-1-7-1",
       "name": "Torch 1.7.1",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/aaronma2020/MSGO",
       "license_spdx": "",
       "evidence_text": "Torch: 1.7.1",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch-1-7-1.yaml",
-      "search_text": "torch-1-7-1 Torch 1.7.1 Torch: 1.7.1 metabolomics/v2"
+      "search_text": "torch-1-7-1 Torch 1.7.1 Torch: 1.7.1 metabolomics/v2 https://github.com/aaronma2020/MSGO"
     },
     {
       "slug": "torch-cluster",
       "name": "torch-cluster",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "**torch-cluster** torch-cluster",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch-cluster.yaml",
-      "search_text": "torch-cluster torch-cluster **torch-cluster** torch-cluster metabolomics/v2"
+      "search_text": "torch-cluster torch-cluster **torch-cluster** torch-cluster metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "torch-geometric",
       "name": "torch_geometric",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "torch_geometric",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch-geometric.yaml",
-      "search_text": "torch-geometric torch_geometric torch_geometric metabolomics/v2"
+      "search_text": "torch-geometric torch_geometric torch_geometric metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "torch-scatter",
       "name": "torch-scatter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "**torch-scatter** torch-scatter",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch-scatter.yaml",
-      "search_text": "torch-scatter torch-scatter **torch-scatter** torch-scatter metabolomics/v2"
+      "search_text": "torch-scatter torch-scatter **torch-scatter** torch-scatter metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "torch-sparse",
       "name": "torch-sparse",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "**torch-sparse** torch-sparse",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch-sparse.yaml",
-      "search_text": "torch-sparse torch-sparse **torch-sparse** torch-sparse metabolomics/v2"
+      "search_text": "torch-sparse torch-sparse **torch-sparse** torch-sparse metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "torch",
       "name": "torch",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "torch >= 1.4.0 Torch: 1.7.1 torch",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torch.yaml",
-      "search_text": "torch torch torch >= 1.4.0 Torch: 1.7.1 torch metabolomics/v2"
+      "search_text": "torch torch torch >= 1.4.0 Torch: 1.7.1 torch metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "torchmetrics",
       "name": "TorchMetrics",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/RiverCCC/ABCoRT",
       "license_spdx": "",
       "evidence_text": "**TorchMetrics**",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/torchmetrics.yaml",
-      "search_text": "torchmetrics TorchMetrics **TorchMetrics** metabolomics/v2"
+      "search_text": "torchmetrics TorchMetrics **TorchMetrics** metabolomics/v2 https://github.com/RiverCCC/ABCoRT"
     },
     {
       "slug": "tqdm-joblib",
       "name": "tqdm_joblib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/zsspython/LAGF",
       "license_spdx": "",
       "evidence_text": "tqdm_joblib==0.0.3",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tqdm-joblib.yaml",
-      "search_text": "tqdm-joblib tqdm_joblib tqdm_joblib==0.0.3 metabolomics/v2"
+      "search_text": "tqdm-joblib tqdm_joblib tqdm_joblib==0.0.3 metabolomics/v2 https://github.com/zsspython/LAGF"
     },
     {
       "slug": "tqdm",
       "name": "tqdm",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/01dadada/RT-Transformer",
       "license_spdx": "",
       "evidence_text": "tqdm==4.45.0 tqdm",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/tqdm.yaml",
-      "search_text": "tqdm tqdm tqdm==4.45.0 tqdm metabolomics/v2"
+      "search_text": "tqdm tqdm tqdm==4.45.0 tqdm metabolomics/v2 https://github.com/01dadada/RT-Transformer"
     },
     {
       "slug": "transformer-architecture",
@@ -123586,35 +123634,35 @@
     {
       "slug": "transformer",
       "name": "transformer",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HaldamirS/CLERMS",
       "license_spdx": "",
       "evidence_text": "based on transformer architecture utilizes a transformer-based architecture with molecular structure information MIST applies a transformer architecture to directly encode and learn to represent collections of chemical formula a transformer architecture can be constructed to efficiently solve the task, traditionally performed by chemists, of assembling large numbers of molecular fragments into molecular",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/transformer.yaml",
-      "search_text": "transformer transformer based on transformer architecture utilizes a transformer-based architecture with molecular structure information MIST applies a transformer architecture to directly encode and learn to represent collections of chemical formula a transformer architecture can be constructed to efficiently solve the task, traditionally performed by chemists, of assembling large numbers of molecular fragments into molecular metabolomics/v2"
+      "search_text": "transformer transformer based on transformer architecture utilizes a transformer-based architecture with molecular structure information MIST applies a transformer architecture to directly encode and learn to represent collections of chemical formula a transformer architecture can be constructed to efficiently solve the task, traditionally performed by chemists, of assembling large numbers of molecular fragments into molecular metabolomics/v2 https://github.com/HaldamirS/CLERMS"
     },
     {
       "slug": "treelib",
       "name": "treelib",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/shuzhao-li-lab/khipu",
       "license_spdx": "",
       "evidence_text": "tree visualization aided by the treelib library",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/treelib.yaml",
-      "search_text": "treelib treelib tree visualization aided by the treelib library metabolomics/v2"
+      "search_text": "treelib treelib tree visualization aided by the treelib library metabolomics/v2 https://github.com/shuzhao-li-lab/khipu"
     },
     {
       "slug": "trelliscope",
       "name": "trelliscope",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pmartR/MODE_ShinyApp",
       "license_spdx": "",
       "evidence_text": "Create shareable and interactive trelliscope displays for visualizing omics data",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/trelliscope.yaml",
-      "search_text": "trelliscope trelliscope Create shareable and interactive trelliscope displays for visualizing omics data metabolomics/v2"
+      "search_text": "trelliscope trelliscope Create shareable and interactive trelliscope displays for visualizing omics data metabolomics/v2 https://github.com/pmartR/MODE_ShinyApp"
     },
     {
       "slug": "trfba",
@@ -123630,35 +123678,35 @@
     {
       "slug": "trimgalore",
       "name": "trimgalore",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
       "license_spdx": "",
       "evidence_text": "Genes, miRNA, isoforms | Quality control | FastQC, trimgalore",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/trimgalore.yaml",
-      "search_text": "trimgalore trimgalore Genes, miRNA, isoforms | Quality control | FastQC, trimgalore metabolomics/v2"
+      "search_text": "trimgalore trimgalore Genes, miRNA, isoforms | Quality control | FastQC, trimgalore metabolomics/v2 https://github.com/ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
     },
     {
       "slug": "trove4j",
       "name": "trove4j",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/rformassspectrometry/Spectra",
       "license_spdx": "",
       "evidence_text": "trove4j-3.0.3",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/trove4j.yaml",
-      "search_text": "trove4j trove4j trove4j-3.0.3 metabolomics/v2"
+      "search_text": "trove4j trove4j trove4j-3.0.3 metabolomics/v2 https://github.com/rformassspectrometry/Spectra"
     },
     {
       "slug": "ubuntu",
       "name": "Ubuntu",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LQZ0123/MSThunder",
       "license_spdx": "",
       "evidence_text": "available through our experiments conducted on an Ubuntu 20.04 environment",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/ubuntu.yaml",
-      "search_text": "ubuntu Ubuntu available through our experiments conducted on an Ubuntu 20.04 environment metabolomics/v2"
+      "search_text": "ubuntu Ubuntu available through our experiments conducted on an Ubuntu 20.04 environment metabolomics/v2 https://github.com/LQZ0123/MSThunder"
     },
     {
       "slug": "ultramassexplorer",
@@ -123707,13 +123755,13 @@
     {
       "slug": "vim",
       "name": "VIM",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/scibiome/meteor",
       "license_spdx": "",
       "evidence_text": "library(VIM)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/vim.yaml",
-      "search_text": "vim VIM library(VIM) metabolomics/v2"
+      "search_text": "vim VIM library(VIM) metabolomics/v2 https://github.com/scibiome/meteor"
     },
     {
       "slug": "vimms",
@@ -123729,90 +123777,90 @@
     {
       "slug": "visual-studio-code",
       "name": "Visual Studio Code",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/SysMedOs/LipidLynxX",
       "license_spdx": "",
       "evidence_text": "This project can be coded in Visual Studio Code (VSCode) JSON configurations are formatted by Visual Studio Code / PyCharm editor",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/visual-studio-code.yaml",
-      "search_text": "visual-studio-code Visual Studio Code This project can be coded in Visual Studio Code (VSCode) JSON configurations are formatted by Visual Studio Code / PyCharm editor metabolomics/v2"
+      "search_text": "visual-studio-code Visual Studio Code This project can be coded in Visual Studio Code (VSCode) JSON configurations are formatted by Visual Studio Code / PyCharm editor metabolomics/v2 https://github.com/SysMedOs/LipidLynxX"
     },
     {
       "slug": "visual-studio",
       "name": "Visual Studio",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "If you intend to contribute to the GUI part of the code and would like to have access to a preview, we recommend using Visual Studio we recommend using Visual Studio",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/visual-studio.yaml",
-      "search_text": "visual-studio Visual Studio If you intend to contribute to the GUI part of the code and would like to have access to a preview, we recommend using Visual Studio we recommend using Visual Studio metabolomics/v2"
+      "search_text": "visual-studio Visual Studio If you intend to contribute to the GUI part of the code and would like to have access to a preview, we recommend using Visual Studio we recommend using Visual Studio metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "wavelet-toolbox",
       "name": "Wavelet Toolbox",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/AdrianHaun/AriumMS",
       "license_spdx": "",
       "evidence_text": "Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/wavelet-toolbox.yaml",
-      "search_text": "wavelet-toolbox Wavelet Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2"
+      "search_text": "wavelet-toolbox Wavelet Toolbox Required toolboxes for the app version: Bioinformatic Toolbox, Statistics And Machine Learning Toolbox, Wavelet Toolbox, Image Processing Toolbox, Signal Processing Toolbox, Parallel Computing metabolomics/v2 https://github.com/AdrianHaun/AriumMS"
     },
     {
       "slug": "webassembly",
       "name": "WebAssembly",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lidawei1975/colmarvista",
       "license_spdx": "",
       "evidence_text": "This program uses WebWorker and WebAssembly, which cannot be loaded automatically",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/webassembly.yaml",
-      "search_text": "webassembly WebAssembly This program uses WebWorker and WebAssembly, which cannot be loaded automatically metabolomics/v2"
+      "search_text": "webassembly WebAssembly This program uses WebWorker and WebAssembly, which cannot be loaded automatically metabolomics/v2 https://github.com/lidawei1975/colmarvista"
     },
     {
       "slug": "webchem",
       "name": "webchem",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/mariallr/amanida",
       "license_spdx": "",
       "evidence_text": "the package will retrieve the PubChem ID from the ID using `webchem` uafR taps into an amazing set of cheminformatics packages -- ChemmineR, fmcsR, webchem uafR taps into an amazing set of cheminformatics packages -- [ChemmineR](https://www.bioconductor.org/packages/release/bioc/html/ChemmineR.html), [fmcsR](https://bioconductor.org/packages/release/bioc [fmcsR](https://bioconductor.org/packages/release/bioc/html/fmcsR.html), [webchem](https://cran.r-project.org/web/packages/webchem/index.html)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/webchem.yaml",
-      "search_text": "webchem webchem the package will retrieve the PubChem ID from the ID using `webchem` uafR taps into an amazing set of cheminformatics packages -- ChemmineR, fmcsR, webchem uafR taps into an amazing set of cheminformatics packages -- [ChemmineR](https://www.bioconductor.org/packages/release/bioc/html/ChemmineR.html), [fmcsR](https://bioconductor.org/packages/release/bioc [fmcsR](https://bioconductor.org/packages/release/bioc/html/fmcsR.html), [webchem](https://cran.r-project.org/web/packages/webchem/index.html) metabolomics/v2"
+      "search_text": "webchem webchem the package will retrieve the PubChem ID from the ID using `webchem` uafR taps into an amazing set of cheminformatics packages -- ChemmineR, fmcsR, webchem uafR taps into an amazing set of cheminformatics packages -- [ChemmineR](https://www.bioconductor.org/packages/release/bioc/html/ChemmineR.html), [fmcsR](https://bioconductor.org/packages/release/bioc [fmcsR](https://bioconductor.org/packages/release/bioc/html/fmcsR.html), [webchem](https://cran.r-project.org/web/packages/webchem/index.html) metabolomics/v2 https://github.com/mariallr/amanida"
     },
     {
       "slug": "webworker",
       "name": "WebWorker",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/lidawei1975/colmarvista",
       "license_spdx": "",
       "evidence_text": "This program uses WebWorker and WebAssembly, which cannot be loaded automatically",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/webworker.yaml",
-      "search_text": "webworker WebWorker This program uses WebWorker and WebAssembly, which cannot be loaded automatically metabolomics/v2"
+      "search_text": "webworker WebWorker This program uses WebWorker and WebAssembly, which cannot be loaded automatically metabolomics/v2 https://github.com/lidawei1975/colmarvista"
     },
     {
       "slug": "wgcna",
       "name": "WGCNA",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/andreasmock/MetaboDiff",
       "license_spdx": "",
       "evidence_text": "install.packages(\"WGCNA\") The core concept of the so called \"weighted\" correlation analysis by Langfelder and Horvarth Weighted correlation network analysis (WGCNA) of microbial features was performed using the WGCNA library in R compared the microbial modules in the IBD (PRISM) dataset identified by MiMeNet to those identified by the Weighted Correlation Network Analysis (WGCNA)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/wgcna.yaml",
-      "search_text": "wgcna WGCNA install.packages(\"WGCNA\") The core concept of the so called \"weighted\" correlation analysis by Langfelder and Horvarth Weighted correlation network analysis (WGCNA) of microbial features was performed using the WGCNA library in R compared the microbial modules in the IBD (PRISM) dataset identified by MiMeNet to those identified by the Weighted Correlation Network Analysis (WGCNA) metabolomics/v2"
+      "search_text": "wgcna WGCNA install.packages(\"WGCNA\") The core concept of the so called \"weighted\" correlation analysis by Langfelder and Horvarth Weighted correlation network analysis (WGCNA) of microbial features was performed using the WGCNA library in R compared the microbial modules in the IBD (PRISM) dataset identified by MiMeNet to those identified by the Weighted Correlation Network Analysis (WGCNA) metabolomics/v2 https://github.com/andreasmock/MetaboDiff"
     },
     {
       "slug": "windows",
       "name": "Windows",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/LQZ0123/MSThunder",
       "license_spdx": "",
       "evidence_text": "A case file named “Pesticides” can be run in the Windows environment",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/windows.yaml",
-      "search_text": "windows Windows A case file named “Pesticides” can be run in the Windows environment metabolomics/v2"
+      "search_text": "windows Windows A case file named “Pesticides” can be run in the Windows environment metabolomics/v2 https://github.com/LQZ0123/MSThunder"
     },
     {
       "slug": "wine",
@@ -123839,46 +123887,46 @@
     {
       "slug": "wpf-windows-presentation-foundation",
       "name": "WPF (Windows Presentation Foundation)",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/systemsomicslab/MsdialWorkbench",
       "license_spdx": "",
       "evidence_text": "we are using the WPF (Windows Presentation Foundation) UI framework for GUI implementation",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/wpf-windows-presentation-foundation.yaml",
-      "search_text": "wpf-windows-presentation-foundation WPF (Windows Presentation Foundation) we are using the WPF (Windows Presentation Foundation) UI framework for GUI implementation metabolomics/v2"
+      "search_text": "wpf-windows-presentation-foundation WPF (Windows Presentation Foundation) we are using the WPF (Windows Presentation Foundation) UI framework for GUI implementation metabolomics/v2 https://github.com/systemsomicslab/MsdialWorkbench"
     },
     {
       "slug": "xcms-centwave",
       "name": "XCMS CentWave",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/HuanLab/Paramounter",
       "license_spdx": "",
       "evidence_text": "mzdiff is used as the mass tolerance to dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/xcms-centwave.yaml",
-      "search_text": "xcms-centwave XCMS CentWave mzdiff is used as the mass tolerance to dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave metabolomics/v2"
+      "search_text": "xcms-centwave XCMS CentWave mzdiff is used as the mass tolerance to dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave dereplicate the features (similar m/z values and retention times) extracted by XCMS CentWave metabolomics/v2 https://github.com/HuanLab/Paramounter"
     },
     {
       "slug": "xcms",
       "name": "XCMS",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/13479776/statTarget",
       "license_spdx": "",
       "evidence_text": "AutoTuner is a parameter tuning algorithm for XCMS, MZmine2, and other metabolomics data processing softwares. the estimates may be entered directly into XCMS to processes raw untargeted metabolomics data. Other metabolomics data processing tools can also be used for customized evaluation: `XCMS XCMS Development Version 3.11.4 or above Use XCMS package (https://bioconductor.org/packages/release/bioc/html/xcms.html) for peak picking, alignment and grouping open source tools such as XCMS and MS-Dial",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/xcms.yaml",
-      "search_text": "xcms XCMS AutoTuner is a parameter tuning algorithm for XCMS, MZmine2, and other metabolomics data processing softwares. the estimates may be entered directly into XCMS to processes raw untargeted metabolomics data. Other metabolomics data processing tools can also be used for customized evaluation: `XCMS XCMS Development Version 3.11.4 or above Use XCMS package (https://bioconductor.org/packages/release/bioc/html/xcms.html) for peak picking, alignment and grouping open source tools such as XCMS and MS-Dial metabolomics/v2"
+      "search_text": "xcms XCMS AutoTuner is a parameter tuning algorithm for XCMS, MZmine2, and other metabolomics data processing softwares. the estimates may be entered directly into XCMS to processes raw untargeted metabolomics data. Other metabolomics data processing tools can also be used for customized evaluation: `XCMS XCMS Development Version 3.11.4 or above Use XCMS package (https://bioconductor.org/packages/release/bioc/html/xcms.html) for peak picking, alignment and grouping open source tools such as XCMS and MS-Dial metabolomics/v2 https://github.com/13479776/statTarget"
     },
     {
       "slug": "xlsxwriter",
       "name": "XlsxWriter",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Leo-Cheng-Lab/ROIAL-NMR",
       "license_spdx": "",
       "evidence_text": "XlsxWriter 3.2.2",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/xlsxwriter.yaml",
-      "search_text": "xlsxwriter XlsxWriter XlsxWriter 3.2.2 metabolomics/v2"
+      "search_text": "xlsxwriter XlsxWriter XlsxWriter 3.2.2 metabolomics/v2 https://github.com/Leo-Cheng-Lab/ROIAL-NMR"
     },
     {
       "slug": "xml-etree-elementtree",
@@ -123905,13 +123953,13 @@
     {
       "slug": "xtb",
       "name": "xtb",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/grimme-lab/QCxMS2",
       "license_spdx": "",
       "evidence_text": "**xtb** (version > 6.7.1 - bleeding edge version)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/xtb.yaml",
-      "search_text": "xtb xtb **xtb** (version > 6.7.1 - bleeding edge version) metabolomics/v2"
+      "search_text": "xtb xtb **xtb** (version > 6.7.1 - bleeding edge version) metabolomics/v2 https://github.com/grimme-lab/QCxMS2"
     },
     {
       "slug": "ysi2950-bioanalyzer",
@@ -123927,24 +123975,24 @@
     {
       "slug": "zenodo-org-records-10997887",
       "name": "zenodo.org/records/10997887",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/pluskal-lab/DreaMS",
       "license_spdx": "",
       "evidence_text": "https://zenodo.org/records/10997887 https://zenodo.org/records/13843034",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/zenodo-org-records-10997887.yaml",
-      "search_text": "zenodo-org-records-10997887 zenodo.org/records/10997887 https://zenodo.org/records/10997887 https://zenodo.org/records/13843034 metabolomics/v2"
+      "search_text": "zenodo-org-records-10997887 zenodo.org/records/10997887 https://zenodo.org/records/10997887 https://zenodo.org/records/13843034 metabolomics/v2 https://github.com/pluskal-lab/DreaMS"
     },
     {
       "slug": "zenodo",
       "name": "Zenodo",
-      "canonical_url": "",
+      "canonical_url": "https://github.com/Chen-micslab/QCCAssisted4DSterol",
       "license_spdx": "",
       "evidence_text": "Zenodo release [![DOI](https://zenodo.org/badge/125496536.svg)](https://zenodo.org/badge/latestdoi/125496536) Also a Zenodo entry will be made for the release with its own DOI. Pre-trained weights available on Zenodo [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5797920.svg)](https://doi.org/10.5281/zenodo.5797920)",
       "collection": "metabolomics/v2",
       "source_doi": "",
       "yaml_path": "collections/metabolomics/v2/tools/zenodo.yaml",
-      "search_text": "zenodo Zenodo Zenodo release [![DOI](https://zenodo.org/badge/125496536.svg)](https://zenodo.org/badge/latestdoi/125496536) Also a Zenodo entry will be made for the release with its own DOI. Pre-trained weights available on Zenodo [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5797920.svg)](https://doi.org/10.5281/zenodo.5797920) metabolomics/v2"
+      "search_text": "zenodo Zenodo Zenodo release [![DOI](https://zenodo.org/badge/125496536.svg)](https://zenodo.org/badge/latestdoi/125496536) Also a Zenodo entry will be made for the release with its own DOI. Pre-trained weights available on Zenodo [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5797920.svg)](https://doi.org/10.5281/zenodo.5797920) metabolomics/v2 https://github.com/Chen-micslab/QCCAssisted4DSterol"
     },
     {
       "slug": "anndata",

--- a/governance/LICENSE_TIERS.md
+++ b/governance/LICENSE_TIERS.md
@@ -24,3 +24,28 @@ bundles (referenced, never embedded). Beyond that, they differ:
 - **`restricted`** instead carries a **non-blocking soft note**: "no clear license
   detected — verify before commercial use or redistribution." Absence of a license
   is an unknown, not an explicit prohibition, so no blocking gate is required.
+
+## The source-reuse axis
+
+`license_tier` answers *"what may I do with the tool?"*. It does **not** answer
+*"what may we do with the source text?"* — and the two disagree. CC-BY-ND permits
+commercial use of a tool (so it is not `noncommercial`) while forbidding derivative
+text (so it is not `open`). Reading a paper's licence through the tool tier would
+call such a source open, which is the mistake the blanket "pre-prints are always
+CC-BY" rule made.
+
+The second canonical table, `source_reuse` in `license_tiers.yaml`, answers the
+source question. Reach it via `scripts/license_tier.py::source_reuse_for_license`.
+
+| Value | Meaning | Examples |
+|---|---|---|
+| `full` | Redistribute, quote at length, derive — the open-access bar | CC-BY, CC-BY-SA, CC0 |
+| `limited` | Some grant, but not full reuse; link-only | CC-BY-NC-*, CC-BY-ND-* |
+| `none` | No reuse rights granted | arXiv `nonexclusive-distrib` |
+| *(absent)* | **Unknown** — blocks admission, reported loudly | any unlisted licence |
+
+An unlisted licence returns `None`, never a default. `None` (unknown) and `none`
+(a known refusal) are different answers and must not be collapsed: one means we
+failed to establish the rights, the other means the rights were withheld. Only
+`full` admits a source at an open `access.type`. See
+`scripts/preprint_license.py` and `governance/OPEN_ACCESS_POLICY.md` § Pre-prints.

--- a/governance/OPEN_ACCESS_POLICY.md
+++ b/governance/OPEN_ACCESS_POLICY.md
@@ -148,15 +148,28 @@ The static page at <https://holobiomicslab.github.io/asb-skill-collections/paper
 
 Pre-prints (bioRxiv, medRxiv, ChemRxiv, arXiv) may be included, but **their posting licence must be verified per pre-print — it is not always CC-BY.** bioRxiv and medRxiv let the author choose CC-BY, CC-BY-NC, CC-BY-ND, CC-BY-NC-ND, CC0 or "no reuse allowed"; arXiv's default licence-to-distribute grants no reuse rights at all. Treating every pre-print as CC-BY would admit text this project has no right to redistribute.
 
-Resolve the actual licence before admitting an entry, and record how it was resolved:
+Resolve the actual licence before admitting an entry, with `scripts/preprint_license.py`:
 
-| Server | Where the licence lives | Record as |
-|---|---|---|
-| bioRxiv / medRxiv | `https://api.biorxiv.org/details/<server>/<doi>` → `license` (`cc_by`, `cc_by_nc_nd`, `cc_no`, …) | `verified_via: biorxiv_api_license` |
-| arXiv | Atom API entry → `<license>` | `verified_via: arxiv_api_license` |
-| ChemRxiv | item metadata → `license` | `verified_via: chemrxiv_api_license` |
+```bash
+python -m scripts.preprint_license --doi 10.1101/2020.04.09.033894
+python -m scripts.preprint_license --corpus 'collections/*/v*/corpus.yaml'
+```
 
-Only a licence permitting the intended reuse admits the pre-print at an open `access.type`. A non-reuse licence makes the entry link-only, exactly as for a closed paper. Note that bioRxiv/medRxiv DOIs now carry the **openRxiv prefix `10.64898`** alongside the legacy Cold Spring Harbor prefix `10.1101`; both are genuine.
+**Read pre-print-ness from the DOI registry, never from a DOI prefix.** A prefix identifies a *registrant*, not a work type — `10.1101` is Cold Spring Harbor, covering bioRxiv, medRxiv **and** CSHL journals, and bioRxiv/medRxiv now also register under the **openRxiv prefix `10.64898`**. Both registries declare the work type directly, so any server they cover resolves with no code change:
+
+| Registry | Declares a pre-print by | Licence field | Record as |
+|---|---|---|---|
+| Crossref (bioRxiv, medRxiv, ChemRxiv, most servers) | `type: posted-content` | `license[].URL` | `verified_via: crossref_license` |
+| DataCite (arXiv) | `types.resourceTypeGeneral: Preprint` | `rightsList[].rightsUri` | `verified_via: datacite_license` |
+
+Two corrections to earlier guidance, both established by testing the live APIs:
+
+- **arXiv's Atom API returns no licence at all.** Use DataCite (or OAI-PMH `arXivRaw`). arXiv's default `nonexclusive-distrib` licence grants **no reuse rights**, so an arXiv pre-print is not open by default.
+- **ChemRxiv's public API is behind Cloudflare and answers `403` to scripted requests.** Resolve ChemRxiv through Crossref, which carries its licence.
+
+`api.biorxiv.org/details/<server>/<doi>` remains an authoritative cross-check for bioRxiv/medRxiv (returning tokens such as `cc_by`, `cc_by_nc_nd`, `cc_no`), but it is server-specific and so is not the primary path.
+
+Only a **full-reuse** licence — one mapped to `source_reuse: full` in [`license_tiers.yaml`](license_tiers.yaml), i.e. CC-BY, CC-BY-SA or CC0 — admits a pre-print at an open `access.type`. NC and ND licences grant `limited` reuse and make the entry link-only, exactly as for a closed paper. A licence the table does not know resolves to **unknown**, which blocks admission and must be reported; it is never silently treated as either permissive or restrictive.
 
 Per [`CONTENT_POLICY.md`](CONTENT_POLICY.md) §3, `preprint` is a **provenance** value and must never be used as an `access.type`. When the peer-reviewed version is later published with a different DOI, the corpus entry is updated to point at the canonical DOI (linking back to the pre-print as `source_history`).
 

--- a/governance/license_tiers.yaml
+++ b/governance/license_tiers.yaml
@@ -42,7 +42,44 @@ spdx:
   CC-BY-NC-4.0: noncommercial
   CC-BY-NC-3.0: noncommercial
   CC-BY-NC-SA-4.0: noncommercial
+  CC-BY-NC-ND-4.0: noncommercial
   PolyForm-Noncommercial-1.0.0: noncommercial
+  # NoDerivatives permits commercial *use* of the tool but forbids derivative
+  # distribution. It carries no explicit commercial prohibition, so it is not
+  # `noncommercial`; it grants no derivative rights, so it is not `open`.
+  CC-BY-ND-4.0: restricted
 fallback:
   noncommercial_keywords: [noncommercial, "non-commercial", "cc-by-nc", polyform-noncommercial]
   default: restricted
+
+# ---------------------------------------------------------------------------
+# SOURCE-REUSE axis. Distinct from the `spdx` tier map above.
+#
+#   spdx:         "what may a consumer do with the TOOL?"      -> license_tier
+#   source_reuse: "what may WE do with the SOURCE TEXT?"       -> access.type
+#
+# These are different questions and must not be conflated (LICENSE_TIERS.md).
+# CC-BY-ND allows commercial use of a tool but forbids derivative text, so it is
+# `restricted` on the tool axis and `limited` on the source axis.
+#
+#   full    - redistribute, quote at length, and derive (the OA-first bar)
+#   limited - some grant, but not full reuse (NC and/or ND); link-only
+#   none    - no reuse rights granted at all
+#
+# An SPDX id absent from this table resolves to UNKNOWN, never to a default.
+# Unknown must block admission and be reported loudly; see scripts/preprint_license.py.
+source_reuse:
+  CC-BY-4.0: full
+  CC-BY-3.0: full
+  CC-BY-SA-4.0: full
+  CC0-1.0: full
+  CC-BY-NC-4.0: limited
+  CC-BY-NC-3.0: limited
+  CC-BY-NC-SA-4.0: limited
+  CC-BY-ND-4.0: limited
+  CC-BY-NC-ND-4.0: limited
+  # arXiv's default: a non-exclusive licence to distribute, granting no reuse rights.
+  arXiv-1.0: none
+  # A pre-print server displays the work but the author reserved all rights
+  # (bioRxiv/medRxiv token `cc_no`). A known refusal, not an unknown.
+  NoReuse-1.0: none

--- a/governance/license_tiers.yaml
+++ b/governance/license_tiers.yaml
@@ -69,14 +69,21 @@ fallback:
 # An SPDX id absent from this table resolves to UNKNOWN, never to a default.
 # Unknown must block admission and be reported loudly; see scripts/preprint_license.py.
 source_reuse:
-  CC-BY-4.0: full
+  CC-BY-1.0: full
+  CC-BY-2.0: full
+  CC-BY-2.5: full
   CC-BY-3.0: full
+  CC-BY-4.0: full
+  CC-BY-SA-3.0: full
   CC-BY-SA-4.0: full
   CC0-1.0: full
-  CC-BY-NC-4.0: limited
   CC-BY-NC-3.0: limited
+  CC-BY-NC-4.0: limited
+  CC-BY-NC-SA-3.0: limited
   CC-BY-NC-SA-4.0: limited
+  CC-BY-ND-3.0: limited
   CC-BY-ND-4.0: limited
+  CC-BY-NC-ND-3.0: limited
   CC-BY-NC-ND-4.0: limited
   # arXiv's default: a non-exclusive licence to distribute, granting no reuse rights.
   arXiv-1.0: none

--- a/governance/preprint_servers.yaml
+++ b/governance/preprint_servers.yaml
@@ -1,0 +1,29 @@
+# Server-specific licence APIs, consulted only when the DOI registry itself
+# declares no usable licence URL. Crossref names the server in `institution[].name`;
+# that name (lowercased) selects an entry here. Nothing dispatches on a DOI prefix,
+# so adding a server is a change to this file, never to scripts/preprint_license.py.
+#
+# Human doc: governance/OPEN_ACCESS_POLICY.md, section "Pre-prints".
+version: 1
+
+servers:
+  biorxiv:
+    detail_url: https://api.biorxiv.org/details/biorxiv/{doi}
+  medrxiv:
+    detail_url: https://api.biorxiv.org/details/medrxiv/{doi}
+
+# The token these servers return in `collection[].license` -> an SPDX id.
+# Resolve the id's reuse rights through `source_reuse` in license_tiers.yaml.
+# A token absent from this table is UNKNOWN and blocks admission; it is never
+# assumed to be permissive.
+license_tokens:
+  cc_by: CC-BY-4.0
+  cc_by_sa: CC-BY-SA-4.0
+  cc_by_nc: CC-BY-NC-4.0
+  cc_by_nd: CC-BY-ND-4.0
+  cc_by_nc_sa: CC-BY-NC-SA-4.0
+  cc_by_nc_nd: CC-BY-NC-ND-4.0
+  cc0: CC0-1.0
+  # The author reserved all rights: bioRxiv displays the preprint but grants no
+  # reuse. Distinct from an unknown licence -- this is a known refusal.
+  cc_no: NoReuse-1.0

--- a/scripts/check_license_tiers.py
+++ b/scripts/check_license_tiers.py
@@ -9,9 +9,11 @@ import sys
 
 import yaml
 
-from scripts.license_tier import ack_required
+from scripts.license_tier import ack_required, load_map
 
-_VALID = {"open", "noncommercial", "restricted"}
+# The tier vocabulary has one home: governance/license_tiers.yaml. A hand-copied
+# set here silently rejects any tier added there.
+_VALID = set(load_map()["tiers"])
 
 
 def check_collection(collection_dir) -> list[str]:

--- a/scripts/license_tier.py
+++ b/scripts/license_tier.py
@@ -51,3 +51,29 @@ def ack_required(tier: str) -> bool:
     """Only the noncommercial tier triggers a blocking runtime use acknowledgment.
     'restricted' is labeled + link-only with a soft note, but does not block."""
     return tier == "noncommercial"
+
+
+def source_reuse_for_license(spdx: str, _map: dict | None = None) -> str | None:
+    """What may we do with a SOURCE's text under this licence?
+
+    Returns 'full', 'limited', 'none', or None when the licence is not in the
+    canonical table. None means UNKNOWN and must block admission -- it is never
+    the same as 'none', which is a known refusal. See governance/license_tiers.yaml.
+    """
+    if not spdx or not spdx.strip():
+        return None
+    table = (_map or load_map()).get("source_reuse") or {}
+    key = spdx.strip().lower()
+    for known, reuse in table.items():
+        if known.lower() == key:
+            return reuse
+    return None
+
+
+def permits_full_reuse(spdx: str, _map: dict | None = None) -> bool:
+    """True only for licences that grant redistribution and derivation.
+
+    An unknown licence is not full reuse, but callers must still distinguish the
+    two: use source_reuse_for_license() when the difference matters.
+    """
+    return source_reuse_for_license(spdx, _map) == "full"

--- a/scripts/preprint_license.py
+++ b/scripts/preprint_license.py
@@ -1,0 +1,304 @@
+"""Resolve a pre-print's posting licence from DOI registries.
+
+Pre-print servers let the author choose the posting licence, so a pre-print is NOT
+automatically CC-BY: bioRxiv/medRxiv offer CC-BY, CC-BY-NC, CC-BY-ND, CC-BY-NC-ND,
+CC0 and "no reuse allowed", and arXiv's default grants no reuse rights at all.
+Assuming CC-BY would admit source text this project has no right to redistribute.
+See governance/OPEN_ACCESS_POLICY.md, section "Pre-prints".
+
+Pre-print-ness is read from the registry's own declaration -- Crossref's
+`type: posted-content` and DataCite's `resourceTypeGeneral: Preprint` -- never from
+a DOI prefix. A prefix identifies a registrant, not a work type (10.1101 is Cold
+Spring Harbor, covering bioRxiv, medRxiv *and* CSHL journals), and prefix lists go
+stale the moment a server re-registers. Any server registered with either registry
+therefore resolves with no change to this module.
+
+An unrecognised or absent licence resolves to an explicit loud status, never to a
+permissive or restrictive default. Callers must treat every status other than
+`resolved` as blocking.
+"""
+from __future__ import annotations
+
+import argparse
+import glob as globlib
+import json
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+import yaml
+
+from scripts.license_tier import load_map, source_reuse_for_license, tier_for_license
+
+CROSSREF_WORK_URL = "https://api.crossref.org/works/{doi}"
+DATACITE_DOI_URL = "https://api.datacite.org/dois/{doi}"
+SERVERS_MAP = pathlib.Path(__file__).resolve().parent.parent / "governance" / "preprint_servers.yaml"
+USER_AGENT = "asb-skill-collections/1.0 (https://github.com/HolobiomicsLab/asb-skill-collections)"
+REQUEST_TIMEOUT_S = 20
+
+STATUS_RESOLVED = "resolved"
+STATUS_UNKNOWN_LICENCE = "unknown_licence"
+STATUS_NO_LICENCE_DECLARED = "no_licence_declared"
+STATUS_NOT_A_PREPRINT = "not_a_preprint"
+STATUS_UNRESOLVED = "unresolved"
+
+_CC_LICENSE_RE = re.compile(r"creativecommons\.org/licenses/(?P<code>[a-z][a-z-]*)/(?P<version>\d+(?:\.\d+)?)", re.I)
+_CC_ZERO_RE = re.compile(r"creativecommons\.org/publicdomain/zero/(?P<version>\d+(?:\.\d+)?)", re.I)
+_ARXIV_DEFAULT_RE = re.compile(r"arxiv\.org/licenses/nonexclusive-distrib/(?P<version>\d+(?:\.\d+)?)", re.I)
+
+# A trailing server-side version marker, e.g. `...433248v2` or `...530140v1.abstract`.
+# Requires a digit before the `v` so a real DOI segment like `.v2` (figshare) is kept.
+_VERSION_SUFFIX_RE = re.compile(r"(?<=\d)v\d+(?:\.[A-Za-z][\w-]*)?$")
+
+
+@dataclass(frozen=True)
+class PreprintLicense:
+    """The outcome of resolving one DOI. `status` is authoritative."""
+
+    doi: str
+    status: str
+    doi_used: str | None = None
+    registry: str | None = None
+    license_url: str | None = None
+    spdx: str | None = None
+    source_reuse: str | None = None
+    license_tier: str | None = None
+
+    @property
+    def admissible_as_open_access(self) -> bool:
+        """Only a resolved, full-reuse licence may carry an open `access.type`."""
+        return self.status == STATUS_RESOLVED and self.source_reuse == "full"
+
+
+def spdx_from_license_url(url: str) -> str | None:
+    """Map a licence URL to an SPDX id; None when the URL is not recognised."""
+    if not url:
+        return None
+    zero = _CC_ZERO_RE.search(url)
+    if zero:
+        return f"CC0-{zero['version']}"
+    arxiv = _ARXIV_DEFAULT_RE.search(url)
+    if arxiv:
+        return f"arXiv-{arxiv['version']}"
+    creative = _CC_LICENSE_RE.search(url)
+    if creative:
+        return f"CC-{creative['code'].upper()}-{creative['version']}"
+    return None
+
+
+def strip_version_suffix(doi: str) -> str:
+    """Drop a trailing `vN` / `vN.fragment` marker scraped from a landing-page URL."""
+    return _VERSION_SUFFIX_RE.sub("", (doi or "").strip())
+
+
+def fetch_json(url: str) -> dict | None:
+    """GET a JSON document. None when the record does not exist (404/403/410)."""
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code in (403, 404, 410):
+            return None
+        raise
+
+
+def _first_recognised_spdx(urls: list[str]) -> tuple[str | None, str | None]:
+    """Return the first (url, spdx) pair whose URL maps to a known SPDX id."""
+    for url in urls:
+        spdx = spdx_from_license_url(url)
+        if spdx:
+            return url, spdx
+    return (urls[0] if urls else None), None
+
+
+def _classify(doi: str, doi_used: str, registry: str, urls: list[str]) -> PreprintLicense:
+    """Turn a registry's declared licence URLs into a typed outcome."""
+    if not urls:
+        return PreprintLicense(doi, STATUS_NO_LICENCE_DECLARED, doi_used, registry)
+    url, spdx = _first_recognised_spdx(urls)
+    if not spdx:
+        return PreprintLicense(doi, STATUS_UNKNOWN_LICENCE, doi_used, registry, url)
+    reuse = source_reuse_for_license(spdx)
+    if reuse is None:
+        return PreprintLicense(doi, STATUS_UNKNOWN_LICENCE, doi_used, registry, url, spdx)
+    return PreprintLicense(doi, STATUS_RESOLVED, doi_used, registry, url, spdx, reuse, tier_for_license(spdx))
+
+
+def load_servers(path: pathlib.Path | None = None) -> dict:
+    """Load the server-API + licence-token map (governance/preprint_servers.yaml)."""
+    return yaml.safe_load((path or SERVERS_MAP).read_text(encoding="utf-8")) or {}
+
+
+def _declared_servers(message: dict, servers: dict) -> list[str]:
+    """Server slugs the registry itself names for this work, restricted to known ones."""
+    names = [str(i.get("name", "")).strip().lower() for i in (message.get("institution") or [])]
+    return [name for name in names if name in servers]
+
+
+def _probe_server_api(server: str, doi: str, original: str, fetch) -> PreprintLicense | None:
+    """Ask a pre-print server for its own licence token when the registry has none."""
+    config = load_servers()
+    payload = fetch(config["servers"][server]["detail_url"].format(doi=doi))
+    records = (payload or {}).get("collection") or []
+    if not records:
+        return None
+    token = str(records[-1].get("license") or "").strip().lower()
+    spdx = (config.get("license_tokens") or {}).get(token)
+    if not spdx:
+        return PreprintLicense(original, STATUS_UNKNOWN_LICENCE, doi, f"{server}_api", token or None)
+    reuse = source_reuse_for_license(spdx)
+    if reuse is None:
+        return PreprintLicense(original, STATUS_UNKNOWN_LICENCE, doi, f"{server}_api", token, spdx)
+    return PreprintLicense(original, STATUS_RESOLVED, doi, f"{server}_api", token, spdx, reuse, tier_for_license(spdx))
+
+
+def _probe_crossref(doi: str, original: str, fetch) -> PreprintLicense | None:
+    """Crossref declares a pre-print as type `posted-content`.
+
+    Crossref's `license` array is sometimes absent, or points at a server FAQ page
+    rather than a licence deed. When it yields nothing usable, fall back to the
+    server the registry itself names in `institution[]` -- never to a DOI prefix.
+    """
+    payload = fetch(CROSSREF_WORK_URL.format(doi=urllib.parse.quote(doi, safe="/")))
+    if not payload:
+        return None
+    message = payload.get("message") or {}
+    if message.get("type") != "posted-content":
+        return PreprintLicense(original, STATUS_NOT_A_PREPRINT, doi, "crossref")
+    urls = [entry.get("URL") for entry in (message.get("license") or []) if entry.get("URL")]
+    outcome = _classify(original, doi, "crossref", urls)
+    if outcome.status == STATUS_RESOLVED:
+        return outcome
+    for server in _declared_servers(message, load_servers().get("servers") or {}):
+        recovered = _probe_server_api(server, doi, original, fetch)
+        if recovered is not None:
+            return recovered
+    return outcome
+
+
+def _probe_datacite(doi: str, original: str, fetch) -> PreprintLicense | None:
+    """DataCite declares a pre-print as resourceTypeGeneral `Preprint` (arXiv lives here)."""
+    payload = fetch(DATACITE_DOI_URL.format(doi=urllib.parse.quote(doi, safe="/")))
+    if not payload:
+        return None
+    attributes = (payload.get("data") or {}).get("attributes") or {}
+    if (attributes.get("types") or {}).get("resourceTypeGeneral") != "Preprint":
+        return PreprintLicense(original, STATUS_NOT_A_PREPRINT, doi, "datacite")
+    urls = [r.get("rightsUri") for r in (attributes.get("rightsList") or []) if r.get("rightsUri")]
+    return _classify(original, doi, "datacite", urls)
+
+
+def _doi_candidates(doi: str) -> list[str]:
+    """The DOI as recorded, then a version-stripped retry if that differs."""
+    exact = (doi or "").strip()
+    stripped = strip_version_suffix(exact)
+    return [exact] if stripped == exact else [exact, stripped]
+
+
+def resolve_preprint_license(doi: str, fetch=fetch_json) -> PreprintLicense:
+    """Resolve one DOI's posting licence. Never guesses; see module docstring."""
+    if not (doi or "").strip():
+        return PreprintLicense(doi, STATUS_UNRESOLVED)
+    try:
+        for candidate in _doi_candidates(doi):
+            for probe in (_probe_crossref, _probe_datacite):
+                outcome = probe(candidate, doi, fetch)
+                if outcome is not None:
+                    return outcome
+    except (urllib.error.URLError, OSError, ValueError):
+        return PreprintLicense(doi, STATUS_UNRESOLVED)
+    return PreprintLicense(doi, STATUS_UNRESOLVED)
+
+
+def _corpus_entries(patterns: list[str]):
+    """Yield (path, paper) for every entry in every matching corpus file."""
+    for pattern in patterns:
+        for path in sorted(globlib.glob(pattern)):
+            document = yaml.safe_load(pathlib.Path(path).read_text(encoding="utf-8")) or {}
+            for paper in document.get("papers") or []:
+                yield path, paper
+
+
+def _load_cache(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+def audit(patterns: list[str], cache_path: pathlib.Path, fetch=fetch_json) -> list[dict]:
+    """Resolve every corpus DOI and report the pre-prints among them."""
+    cache = _load_cache(cache_path)
+    findings = []
+    for path, paper in _corpus_entries(patterns):
+        doi = str(paper.get("doi") or "").strip()
+        if not doi:
+            continue
+        if doi not in cache:
+            cache[doi] = resolve_preprint_license(doi, fetch).__dict__
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+        record = cache[doi]
+        if record["status"] == STATUS_NOT_A_PREPRINT:
+            continue
+        access = paper.get("access") or {}
+        findings.append({
+            "corpus": path, "doi": doi, "entry_status": paper.get("status"),
+            "access_type": access.get("type"), "recorded_license": access.get("license"),
+            "preprint_status": record["status"], "preprint_spdx": record["spdx"],
+            "source_reuse": record["source_reuse"],
+        })
+    return findings
+
+
+def _print_audit(findings: list[dict]) -> int:
+    """Print the audit table; return the count of entries needing a decision."""
+    unresolved = [f for f in findings if f["preprint_status"] == STATUS_UNRESOLVED]
+    preprints = [f for f in findings if f["preprint_status"] != STATUS_UNRESOLVED]
+    not_full = [f for f in preprints if f["source_reuse"] != "full"]
+    for finding in preprints:
+        print(f"  {finding['doi']:44} {str(finding['preprint_spdx']):18} reuse={str(finding['source_reuse']):8} "
+              f"access.type={finding['access_type']} status={finding['entry_status']}")
+    print(f"\npre-prints: {len(preprints)}   not-full-reuse: {len(not_full)}   unresolved: {len(unresolved)}")
+    for finding in unresolved:
+        print(f"  UNRESOLVED (blocking): {finding['doi']} in {finding['corpus']}")
+    return len(not_full) + len(unresolved)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--doi", help="resolve a single DOI and print the outcome")
+    parser.add_argument("--corpus", nargs="*", default=["collections/*/v*/corpus.yaml"],
+                        help="glob(s) of corpus.yaml files to audit")
+    parser.add_argument("--cache", default=".cache/preprint_licenses.json")
+    parser.add_argument("--strict", action="store_true", help="exit 1 if any pre-print is not full-reuse or unresolved")
+    parser.add_argument("--smoke", action="store_true", help="run the module's self-check and exit")
+    args = parser.parse_args(argv)
+
+    if args.smoke:
+        return _smoke()
+    if args.doi:
+        print(json.dumps(resolve_preprint_license(args.doi).__dict__, indent=2))
+        return 0
+    needing_decision = _print_audit(audit(args.corpus, pathlib.Path(args.cache)))
+    return 1 if (args.strict and needing_decision) else 0
+
+
+def _smoke() -> int:
+    assert spdx_from_license_url("https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode") == "CC-BY-NC-ND-4.0"
+    assert spdx_from_license_url("http://creativecommons.org/publicdomain/zero/1.0/") == "CC0-1.0"
+    assert spdx_from_license_url("http://arxiv.org/licenses/nonexclusive-distrib/1.0/") == "arXiv-1.0"
+    assert spdx_from_license_url("https://example.org/my-licence") is None
+    assert strip_version_suffix("registrant/2021.02.28.433248v2").endswith("433248")
+    assert strip_version_suffix("registrant/figshare.28876751.v2").endswith(".v2")
+    assert source_reuse_for_license("CC-BY-4.0", load_map()) == "full"
+    assert source_reuse_for_license("CC-BY-NC-ND-4.0", load_map()) == "limited"
+    assert source_reuse_for_license("Some-Unknown-1.0", load_map()) is None
+    print("PASS: preprint_license smoke check")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preprint_license.py
+++ b/scripts/preprint_license.py
@@ -51,9 +51,22 @@ STATUS_NO_LICENCE_DECLARED = "no_licence_declared"
 STATUS_NOT_A_PREPRINT = "not_a_preprint"
 STATUS_UNRESOLVED = "unresolved"
 
-_CC_LICENSE_RE = re.compile(r"creativecommons\.org/licenses/(?P<code>[a-z][a-z-]*)/(?P<version>\d+(?:\.\d+)?)", re.I)
-_CC_ZERO_RE = re.compile(r"creativecommons\.org/publicdomain/zero/(?P<version>\d+(?:\.\d+)?)", re.I)
-_ARXIV_DEFAULT_RE = re.compile(r"arxiv\.org/licenses/nonexclusive-distrib/(?P<version>\d+(?:\.\d+)?)", re.I)
+# Matched against the URL's PATH, after its host has been checked. An unanchored
+# search would accept a deed pasted into any unrelated URL, e.g.
+# `https://example.org/redirect?to=creativecommons.org/licenses/by/4.0`.
+_CC_LICENSE_RE = re.compile(r"^/licenses/(?P<code>[a-z][a-z-]*)/(?P<version>\d+(?:\.\d+)?)", re.I)
+_CC_ZERO_RE = re.compile(r"^/publicdomain/zero/(?P<version>\d+(?:\.\d+)?)", re.I)
+_ARXIV_DEFAULT_RE = re.compile(r"^/licenses/nonexclusive-distrib/(?P<version>\d+(?:\.\d+)?)", re.I)
+_CC_HOST = "creativecommons.org"
+_ARXIV_HOST = "arxiv.org"
+
+# A `tdm` grant permits text and data mining, not redistribution. It must never
+# stand in for a licence to reuse the source.
+TDM_CONTENT_VERSION = "tdm"
+
+# Least permissive first. Where a work declares several licences, the most
+# restrictive governs -- admission must not depend on registry array order.
+_REUSE_RANK = {"none": 0, "limited": 1, "full": 2}
 
 # A trailing server-side version marker, e.g. `...433248v2` or `...530140v1.abstract`.
 # Requires a digit before the `v` so a real DOI segment like `.v2` (figshare) is kept.
@@ -79,19 +92,33 @@ class PreprintLicense:
         return self.status == STATUS_RESOLVED and self.source_reuse == "full"
 
 
+def _host_and_path(url: str) -> tuple[str, str]:
+    """The URL's lowercased host (without `www.`) and its path."""
+    parsed = urllib.parse.urlparse(url if "//" in url else f"//{url}")
+    host = parsed.netloc.lower()
+    return (host[4:] if host.startswith("www.") else host), parsed.path
+
+
 def spdx_from_license_url(url: str) -> str | None:
-    """Map a licence URL to an SPDX id; None when the URL is not recognised."""
-    if not url:
+    """Map a licence URL to an SPDX id; None when the URL is not recognised.
+
+    The host is checked before the path, so a deed quoted inside an unrelated URL
+    is not mistaken for a licence grant.
+    """
+    if not isinstance(url, str) or not url:
         return None
-    zero = _CC_ZERO_RE.search(url)
-    if zero:
-        return f"CC0-{zero['version']}"
-    arxiv = _ARXIV_DEFAULT_RE.search(url)
-    if arxiv:
-        return f"arXiv-{arxiv['version']}"
-    creative = _CC_LICENSE_RE.search(url)
-    if creative:
-        return f"CC-{creative['code'].upper()}-{creative['version']}"
+    host, path = _host_and_path(url)
+    if host == _CC_HOST:
+        zero = _CC_ZERO_RE.search(path)
+        if zero:
+            return f"CC0-{zero['version']}"
+        creative = _CC_LICENSE_RE.search(path)
+        if creative:
+            return f"CC-{creative['code'].upper()}-{creative['version']}"
+    if host == _ARXIV_HOST:
+        arxiv = _ARXIV_DEFAULT_RE.search(path)
+        if arxiv:
+            return f"arXiv-{arxiv['version']}"
     return None
 
 
@@ -141,24 +168,38 @@ def fetch_json(url: str) -> dict | None:
     return None
 
 
-def _first_recognised_spdx(urls: list[str]) -> tuple[str | None, str | None]:
-    """Return the first (url, spdx) pair whose URL maps to a known SPDX id."""
+def most_restrictive_license(urls: list[str]) -> tuple[str | None, str | None, str | None]:
+    """The least permissive recognised licence among `urls`, as (url, spdx, reuse).
+
+    A work may declare several licences -- Crossref lists the accepted manuscript
+    and the version of record separately -- and their order is not guaranteed.
+    Picking the first would make admission depend on array position. The most
+    restrictive grant governs what we may actually do with the text.
+
+    A recognised SPDX with no `source_reuse` row yields reuse=None: unknown, and
+    the caller must treat it as blocking rather than fall back to another licence.
+    """
+    candidates = []
     for url in urls:
         spdx = spdx_from_license_url(url)
-        if spdx:
-            return url, spdx
-    return (urls[0] if urls else None), None
+        if not spdx:
+            continue
+        reuse = source_reuse_for_license(spdx)
+        if reuse is None:
+            return url, spdx, None
+        candidates.append((_REUSE_RANK[reuse], url, spdx, reuse))
+    if not candidates:
+        return (urls[0] if urls else None), None, None
+    _, url, spdx, reuse = min(candidates)
+    return url, spdx, reuse
 
 
 def _classify(doi: str, doi_used: str, registry: str, urls: list[str]) -> PreprintLicense:
     """Turn a registry's declared licence URLs into a typed outcome."""
     if not urls:
         return PreprintLicense(doi, STATUS_NO_LICENCE_DECLARED, doi_used, registry)
-    url, spdx = _first_recognised_spdx(urls)
-    if not spdx:
-        return PreprintLicense(doi, STATUS_UNKNOWN_LICENCE, doi_used, registry, url)
-    reuse = source_reuse_for_license(spdx)
-    if reuse is None:
+    url, spdx, reuse = most_restrictive_license(urls)
+    if not spdx or reuse is None:
         return PreprintLicense(doi, STATUS_UNKNOWN_LICENCE, doi_used, registry, url, spdx)
     return PreprintLicense(doi, STATUS_RESOLVED, doi_used, registry, url, spdx, reuse, tier_for_license(spdx))
 
@@ -174,10 +215,21 @@ def _declared_servers(message: dict, servers: dict) -> list[str]:
     return [name for name in names if name in servers]
 
 
+def _redistribution_urls(message: dict) -> list[str]:
+    """Crossref licence URLs that could ground redistribution; TDM grants excluded."""
+    urls = []
+    for entry in message.get("license") or []:
+        url = entry.get("URL")
+        if url and str(entry.get("content-version") or "").lower() != TDM_CONTENT_VERSION:
+            urls.append(url)
+    return urls
+
+
 def _probe_server_api(server: str, doi: str, original: str, fetch) -> PreprintLicense | None:
     """Ask a pre-print server for its own licence token when the registry has none."""
     config = load_servers()
-    payload = fetch(config["servers"][server]["detail_url"].format(doi=doi))
+    quoted = urllib.parse.quote(doi, safe="/")
+    payload = fetch(config["servers"][server]["detail_url"].format(doi=quoted))
     records = (payload or {}).get("collection") or []
     if not records:
         return None
@@ -204,8 +256,7 @@ def _probe_crossref(doi: str, original: str, fetch) -> PreprintLicense | None:
     message = payload.get("message") or {}
     if message.get("type") != "posted-content":
         return PreprintLicense(original, STATUS_NOT_A_PREPRINT, doi, "crossref")
-    urls = [entry.get("URL") for entry in (message.get("license") or []) if entry.get("URL")]
-    outcome = _classify(original, doi, "crossref", urls)
+    outcome = _classify(original, doi, "crossref", _redistribution_urls(message))
     if outcome.status == STATUS_RESOLVED:
         return outcome
     for server in _declared_servers(message, load_servers().get("servers") or {}):
@@ -244,7 +295,8 @@ def resolve_preprint_license(doi: str, fetch=fetch_json) -> PreprintLicense:
                 outcome = probe(candidate, doi, fetch)
                 if outcome is not None:
                     return outcome
-    except (urllib.error.URLError, OSError, ValueError):
+    except (urllib.error.URLError, OSError, ValueError, TypeError, KeyError):
+        # One malformed registry payload must fail its own DOI, never the batch.
         return PreprintLicense(doi, STATUS_UNRESOLVED)
     return PreprintLicense(doi, STATUS_UNRESOLVED)
 
@@ -270,11 +322,15 @@ def audit(patterns: list[str], cache_path: pathlib.Path, fetch=fetch_json) -> li
         doi = str(paper.get("doi") or "").strip()
         if not doi:
             continue
-        if doi not in cache:
-            cache[doi] = resolve_preprint_license(doi, fetch).__dict__
-            cache_path.parent.mkdir(parents=True, exist_ok=True)
-            cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
-        record = cache[doi]
+        record = cache.get(doi)
+        if record is None:
+            record = resolve_preprint_license(doi, fetch).__dict__
+            # `unresolved` is not a terminal answer -- a rate limit or an outage
+            # would otherwise freeze into a permanent verdict on the next run.
+            if record["status"] != STATUS_UNRESOLVED:
+                cache[doi] = record
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
         if record["status"] == STATUS_NOT_A_PREPRINT:
             continue
         access = paper.get("access") or {}

--- a/scripts/preprint_license.py
+++ b/scripts/preprint_license.py
@@ -25,6 +25,7 @@ import json
 import pathlib
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -39,6 +40,10 @@ DATACITE_DOI_URL = "https://api.datacite.org/dois/{doi}"
 SERVERS_MAP = pathlib.Path(__file__).resolve().parent.parent / "governance" / "preprint_servers.yaml"
 USER_AGENT = "asb-skill-collections/1.0 (https://github.com/HolobiomicsLab/asb-skill-collections)"
 REQUEST_TIMEOUT_S = 20
+ABSENT_STATUS = (403, 404, 410)
+RETRYABLE_STATUS = (429, 500, 502, 503, 504)
+MAX_ATTEMPTS = 4
+BACKOFF_BASE_S = 2.0
 
 STATUS_RESOLVED = "resolved"
 STATUS_UNKNOWN_LICENCE = "unknown_licence"
@@ -95,16 +100,45 @@ def strip_version_suffix(doi: str) -> str:
     return _VERSION_SUFFIX_RE.sub("", (doi or "").strip())
 
 
-def fetch_json(url: str) -> dict | None:
-    """GET a JSON document. None when the record does not exist (404/403/410)."""
+def retry_delay(attempt: int, retry_after: str | None) -> float:
+    """Seconds to wait before the next attempt, honouring a server's Retry-After."""
+    if retry_after and retry_after.strip().isdigit():
+        return float(retry_after.strip())
+    return BACKOFF_BASE_S * (2 ** (attempt - 1))
+
+
+def _get_json(url: str) -> dict | None:
+    """One attempt. None when the record is absent; raises on anything else."""
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
     try:
         with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
-        if exc.code in (403, 404, 410):
+        if exc.code in ABSENT_STATUS:
             return None
         raise
+
+
+def fetch_json(url: str) -> dict | None:
+    """GET a JSON document, retrying transient failures.
+
+    A rate-limited or briefly unavailable registry must not be mistaken for a DOI
+    that does not exist: the first would silently mark a resolvable pre-print
+    `unresolved`, and a bulk audit would report absence where there was only 429.
+    Only ABSENT_STATUS means "no record".
+    """
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            return _get_json(url)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in RETRYABLE_STATUS or attempt == MAX_ATTEMPTS:
+                raise
+            time.sleep(retry_delay(attempt, exc.headers.get("Retry-After")))
+        except (urllib.error.URLError, TimeoutError):
+            if attempt == MAX_ATTEMPTS:
+                raise
+            time.sleep(retry_delay(attempt, None))
+    return None
 
 
 def _first_recognised_spdx(urls: list[str]) -> tuple[str | None, str | None]:

--- a/scripts/skill_index.py
+++ b/scripts/skill_index.py
@@ -22,15 +22,25 @@ import argparse
 import glob as globlib
 import json
 import pathlib
-import sys
+import re
 
 import yaml
 
+from scripts.license_tier import load_map
 from scripts.propagate_license_tiers import detect_indent
 
 META_ROLE = "meta"
 INFRASTRUCTURE_PREFIX = "_"
-DEFAULT_COLLECTION_GLOB = "collections/*/v*"
+# Both trees ship skills to users. `packs/` publishes only a kb_bundle.json; a
+# directory is checked against whichever indexes it actually publishes.
+DEFAULT_COLLECTION_GLOBS = ("collections/*/v*", "packs/*/*")
+DEFAULT_KB_PREFIX = "asb-paper-"
+_NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def valid_tiers() -> set[str]:
+    """The licence-tier vocabulary, read from its one canonical home."""
+    return set(load_map()["tiers"])
 
 
 def _rewrite_json(path: pathlib.Path, payload) -> None:
@@ -80,7 +90,7 @@ def untiered(slug: str, frontmatter: dict) -> bool:
     Indexing a skill without one makes it searchable while stripping the very
     label that governs whether it may be used -- a silent downgrade, not a gap.
     """
-    return (frontmatter.get("metadata") or {}).get("license_tier") not in ("open", "noncommercial", "restricted")
+    return (frontmatter.get("metadata") or {}).get("license_tier") not in valid_tiers()
 
 
 def entry_from_frontmatter(slug: str, frontmatter: dict) -> dict:
@@ -99,13 +109,19 @@ def entry_from_frontmatter(slug: str, frontmatter: dict) -> dict:
     }
 
 
-def kb_entry_from_frontmatter(frontmatter: dict) -> dict:
+def kb_slug_for_doi(doi: str, prefix: str = DEFAULT_KB_PREFIX) -> str:
+    """The per-paper KB slug a DOI grounds against, e.g. `asb-paper-10-1093-...`."""
+    return prefix + _NON_SLUG_RE.sub("-", doi.strip().lower()).strip("-")
+
+
+def kb_entry_from_frontmatter(frontmatter: dict, kb_prefix: str = DEFAULT_KB_PREFIX) -> dict:
     """Build a kb_bundle skills entry from a skill's own frontmatter."""
     metadata = frontmatter.get("metadata") or {}
     repo_url = metadata.get("repo_url")
+    dois = _dois(frontmatter)
     return {
-        "dois": _dois(frontmatter),
-        "kb_slugs": [],
+        "dois": dois,
+        "kb_slugs": [kb_slug_for_doi(doi, kb_prefix) for doi in dois],
         "license_tier": metadata.get("license_tier"),
         "repo_urls": [repo_url] if repo_url else [],
         "tools": metadata.get("tools") or [],
@@ -163,20 +179,33 @@ def add_missing(version_dir: pathlib.Path) -> dict[str, list[str]]:
     if gaps.get("kb_bundle.json"):
         path = version_dir / "kb_bundle.json"
         bundle = json.loads(path.read_text(encoding="utf-8"))
+        prefix = bundle.get("kb_prefix") or DEFAULT_KB_PREFIX
         for slug in gaps["kb_bundle.json"]:
-            bundle.setdefault("skills", {})[slug] = kb_entry_from_frontmatter(skills[slug])
+            bundle.setdefault("skills", {})[slug] = kb_entry_from_frontmatter(skills[slug], prefix)
         bundle["skills"] = dict(sorted(bundle["skills"].items()))
         _rewrite_json(path, bundle)
     return gaps
 
 
-def _version_dirs(pattern: str) -> list[pathlib.Path]:
-    return [pathlib.Path(p) for p in sorted(globlib.glob(pattern)) if (pathlib.Path(p) / "skills").is_dir()]
+def _version_dirs(patterns: tuple[str, ...]) -> list[pathlib.Path]:
+    """Every directory that ships skills, across all configured trees."""
+    found = []
+    for pattern in patterns:
+        found += [pathlib.Path(p) for p in sorted(globlib.glob(pattern)) if (pathlib.Path(p) / "skills").is_dir()]
+    return found
+
+
+def _report(version_dir: pathlib.Path, gaps: dict[str, list[str]], fixing: bool) -> set[str]:
+    """Print one directory's gaps; return the distinct slugs involved."""
+    for index_name, slugs in gaps.items():
+        verb = "added to" if fixing else "MISSING from"
+        print(f"  {version_dir}/{index_name}: {len(slugs)} {verb} index -> {', '.join(slugs)}")
+    return {slug for slugs in gaps.values() for slug in slugs}
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("--collections", default=DEFAULT_COLLECTION_GLOB)
+    parser.add_argument("--collections", nargs="*", default=list(DEFAULT_COLLECTION_GLOBS))
     parser.add_argument("--fix", action="store_true", help="insert the missing entries instead of failing")
     parser.add_argument("--smoke", action="store_true", help="run the module's self-check and exit")
     args = parser.parse_args(argv)
@@ -184,24 +213,31 @@ def main(argv: list[str] | None = None) -> int:
     if args.smoke:
         return _smoke()
 
-    violations = 0
-    for version_dir in _version_dirs(args.collections):
+    version_dirs = _version_dirs(tuple(args.collections))
+    if not version_dirs:
+        # A gate that inspects nothing must never report success.
+        print(f"FAIL: no skill directories matched {args.collections}. Run from the repository root.")
+        return 1
+
+    orphans, needing_a_tier = set(), []
+    for version_dir in version_dirs:
         try:
             gaps = add_missing(version_dir) if args.fix else missing_from_indexes(version_dir)
         except ValueError as exc:
             print(f"  {version_dir}: {exc}")
-            violations += 1
+            needing_a_tier.append(version_dir)
             continue
-        for index_name, slugs in gaps.items():
-            verb = "added to" if args.fix else "MISSING from"
-            print(f"  {version_dir}/{index_name}: {len(slugs)} {verb} index -> {', '.join(slugs)}")
-            violations += 0 if args.fix else len(slugs)
-    if violations:
-        print(f"\nFAIL: {violations} skill(s) exist on disk but appear in no index.")
+        orphans |= _report(version_dir, gaps, args.fix) if not args.fix else set()
+    if needing_a_tier:
+        print("\nFAIL: a skill declares no metadata.license_tier, so it cannot be indexed.")
+        print("Add the tier to its SKILL.md by hand; --fix cannot invent one.")
+        return 1
+    if orphans:
+        print(f"\nFAIL: {len(orphans)} skill(s) exist on disk but appear in no index.")
         print("A skill absent from the index cannot be found by search, the MCP server, or the docs site.")
         print("Run: python -m scripts.skill_index --fix")
         return 1
-    print("PASS: every indexable skill is present in every index its collection publishes.")
+    print(f"PASS: every indexable skill across {len(version_dirs)} directories is present in every index published.")
     return 0
 
 

--- a/scripts/skill_index.py
+++ b/scripts/skill_index.py
@@ -1,0 +1,222 @@
+"""Keep a collection's indexes complete: every indexable skill has an entry.
+
+`skills_index.json` and `kb_bundle.json` are what `asbb search`, the MCP skill-server
+and the documentation site read. Nothing derives them from the skills directory --
+`propagate_license_tiers.py` only joins tiers onto entries that already exist, keyed
+by DOI. So a skill grounded on a tool with no paper DOI (a tool admitted on its
+licence tier rather than on an open-access paper) can ship on disk while appearing in
+no index at all, invisible to every consumer. `check_license_tiers.py` then skips it,
+because it only cross-checks skills the index already knows, and CI stays green.
+
+This module closes that hole. It derives an index entry from the skill's own
+frontmatter, so the skills directory is the source of truth for what exists, and it
+fails when an index is missing a skill that belongs in it.
+
+Two kinds of skill are deliberately not indexed, identified by declarative properties
+rather than by name: infrastructure skills in `_`-prefixed directories (the same
+convention `release_gate.py` uses) and meta skills declaring `metadata.role: meta`.
+"""
+from __future__ import annotations
+
+import argparse
+import glob as globlib
+import json
+import pathlib
+import sys
+
+import yaml
+
+from scripts.propagate_license_tiers import detect_indent
+
+META_ROLE = "meta"
+INFRASTRUCTURE_PREFIX = "_"
+DEFAULT_COLLECTION_GLOB = "collections/*/v*"
+
+
+def _rewrite_json(path: pathlib.Path, payload) -> None:
+    """Write JSON back in the file's own indent, byte-compatible with the generator."""
+    raw = path.read_text(encoding="utf-8")
+    path.write_text(json.dumps(payload, indent=detect_indent(raw), ensure_ascii=False), encoding="utf-8")
+
+
+def split_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Split a SKILL.md into (frontmatter, body).
+
+    The delimiter is a line that is exactly `---`. Splitting on the *substring*
+    `---` truncates any frontmatter containing a rule or a `-----` run inside a
+    quoted value, so YAML then fails and the skill is silently dropped from
+    whatever index is being built. This is the one parser; do not copy it.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, text
+    for end, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            try:
+                frontmatter = yaml.safe_load("\n".join(lines[1:end]))
+            except yaml.YAMLError:
+                return None, text
+            return frontmatter or {}, "\n".join(lines[end + 1:])
+    return None, text
+
+
+def parse_frontmatter(skill_md: pathlib.Path) -> dict:
+    """Parse a SKILL.md YAML frontmatter, tolerating `---` inside the body."""
+    frontmatter, _ = split_frontmatter(skill_md.read_text(encoding="utf-8"))
+    return frontmatter or {}
+
+
+def is_indexable(slug: str, frontmatter: dict) -> bool:
+    """Content skills are indexed; infrastructure and meta skills are not."""
+    if slug.startswith(INFRASTRUCTURE_PREFIX):
+        return False
+    return (frontmatter.get("metadata") or {}).get("role") != META_ROLE
+
+
+def untiered(slug: str, frontmatter: dict) -> bool:
+    """A skill with no licence tier must never be indexed.
+
+    The tier is what tells a consumer that a tool is noncommercial or restricted.
+    Indexing a skill without one makes it searchable while stripping the very
+    label that governs whether it may be used -- a silent downgrade, not a gap.
+    """
+    return (frontmatter.get("metadata") or {}).get("license_tier") not in ("open", "noncommercial", "restricted")
+
+
+def entry_from_frontmatter(slug: str, frontmatter: dict) -> dict:
+    """Build a skills_index entry from a skill's own frontmatter."""
+    metadata = frontmatter.get("metadata") or {}
+    return {
+        "slug": slug,
+        "name": frontmatter.get("name") or slug,
+        "description": frontmatter.get("description") or "",
+        "edam_operation": metadata.get("edam_operation"),
+        "edam_topics": metadata.get("edam_topics") or [],
+        "tools": metadata.get("tools") or [],
+        "dois": _dois(frontmatter),
+        "techniques": metadata.get("techniques") or [],
+        "license_tier": metadata.get("license_tier"),
+    }
+
+
+def kb_entry_from_frontmatter(frontmatter: dict) -> dict:
+    """Build a kb_bundle skills entry from a skill's own frontmatter."""
+    metadata = frontmatter.get("metadata") or {}
+    repo_url = metadata.get("repo_url")
+    return {
+        "dois": _dois(frontmatter),
+        "kb_slugs": [],
+        "license_tier": metadata.get("license_tier"),
+        "repo_urls": [repo_url] if repo_url else [],
+        "tools": metadata.get("tools") or [],
+    }
+
+
+def _dois(frontmatter: dict) -> list[str]:
+    entries = frontmatter.get("derived_from") or []
+    return [str(e.get("doi")) for e in entries if isinstance(e, dict) and e.get("doi")]
+
+
+def indexable_skills(version_dir: pathlib.Path) -> dict[str, dict]:
+    """Map slug -> frontmatter for every skill that belongs in an index."""
+    found = {}
+    for skill_md in sorted((version_dir / "skills").glob("*/SKILL.md")):
+        slug = skill_md.parent.name
+        frontmatter = parse_frontmatter(skill_md)
+        if is_indexable(slug, frontmatter):
+            found[slug] = frontmatter
+    return found
+
+
+def missing_from_indexes(version_dir: pathlib.Path) -> dict[str, list[str]]:
+    """Slugs absent from each index this collection publishes."""
+    expected = set(indexable_skills(version_dir))
+    gaps: dict[str, list[str]] = {}
+    skills_index = version_dir / "skills_index.json"
+    if skills_index.exists():
+        present = {e.get("slug") for e in json.loads(skills_index.read_text(encoding="utf-8"))}
+        gaps["skills_index.json"] = sorted(expected - present)
+    kb_bundle = version_dir / "kb_bundle.json"
+    if kb_bundle.exists():
+        present = set((json.loads(kb_bundle.read_text(encoding="utf-8")).get("skills") or {}))
+        gaps["kb_bundle.json"] = sorted(expected - present)
+    return {name: slugs for name, slugs in gaps.items() if slugs}
+
+
+def add_missing(version_dir: pathlib.Path) -> dict[str, list[str]]:
+    """Insert every missing entry, keeping both indexes sorted by slug.
+
+    Refuses to index a skill that declares no licence tier; raises so the caller
+    reports it rather than writing a null tier into a consumer-facing index.
+    """
+    gaps = missing_from_indexes(version_dir)
+    skills = indexable_skills(version_dir)
+    blocked = sorted({s for slugs in gaps.values() for s in slugs if untiered(s, skills[s])})
+    if blocked:
+        raise ValueError(f"cannot index without metadata.license_tier: {', '.join(blocked)}")
+    if gaps.get("skills_index.json"):
+        path = version_dir / "skills_index.json"
+        entries = json.loads(path.read_text(encoding="utf-8"))
+        entries += [entry_from_frontmatter(s, skills[s]) for s in gaps["skills_index.json"]]
+        entries.sort(key=lambda e: e["slug"])
+        _rewrite_json(path, entries)
+    if gaps.get("kb_bundle.json"):
+        path = version_dir / "kb_bundle.json"
+        bundle = json.loads(path.read_text(encoding="utf-8"))
+        for slug in gaps["kb_bundle.json"]:
+            bundle.setdefault("skills", {})[slug] = kb_entry_from_frontmatter(skills[slug])
+        bundle["skills"] = dict(sorted(bundle["skills"].items()))
+        _rewrite_json(path, bundle)
+    return gaps
+
+
+def _version_dirs(pattern: str) -> list[pathlib.Path]:
+    return [pathlib.Path(p) for p in sorted(globlib.glob(pattern)) if (pathlib.Path(p) / "skills").is_dir()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--collections", default=DEFAULT_COLLECTION_GLOB)
+    parser.add_argument("--fix", action="store_true", help="insert the missing entries instead of failing")
+    parser.add_argument("--smoke", action="store_true", help="run the module's self-check and exit")
+    args = parser.parse_args(argv)
+
+    if args.smoke:
+        return _smoke()
+
+    violations = 0
+    for version_dir in _version_dirs(args.collections):
+        try:
+            gaps = add_missing(version_dir) if args.fix else missing_from_indexes(version_dir)
+        except ValueError as exc:
+            print(f"  {version_dir}: {exc}")
+            violations += 1
+            continue
+        for index_name, slugs in gaps.items():
+            verb = "added to" if args.fix else "MISSING from"
+            print(f"  {version_dir}/{index_name}: {len(slugs)} {verb} index -> {', '.join(slugs)}")
+            violations += 0 if args.fix else len(slugs)
+    if violations:
+        print(f"\nFAIL: {violations} skill(s) exist on disk but appear in no index.")
+        print("A skill absent from the index cannot be found by search, the MCP server, or the docs site.")
+        print("Run: python -m scripts.skill_index --fix")
+        return 1
+    print("PASS: every indexable skill is present in every index its collection publishes.")
+    return 0
+
+
+def _smoke() -> int:
+    assert is_indexable("some-skill", {}) is True
+    assert is_indexable("_router", {}) is False
+    assert is_indexable("meta-skill", {"metadata": {"role": "meta"}}) is False
+    built = entry_from_frontmatter("s", {"name": "s", "description": "d",
+                                         "metadata": {"license_tier": "noncommercial", "tools": ["T"]},
+                                         "derived_from": [{"doi": "x/y"}]})
+    assert built["license_tier"] == "noncommercial" and built["dois"] == ["x/y"] and built["tools"] == ["T"]
+    assert kb_entry_from_frontmatter({"metadata": {"repo_url": "https://example.org/r"}})["repo_urls"] == ["https://example.org/r"]
+    print("PASS: skill_index smoke check")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_preprint_license.py
+++ b/tests/test_preprint_license.py
@@ -246,6 +246,64 @@ def test_unknown_spdx_has_no_source_reuse_entry():
     assert source_reuse_for_license("arXiv-1.0", load_map()) == "none"
 
 
+# --- Several declared licences: the most restrictive governs -------------------
+
+@pytest.mark.parametrize("order", [[CC_BY, CC_BY_NC_ND], [CC_BY_NC_ND, CC_BY]])
+def test_admission_does_not_depend_on_registry_array_order(order):
+    """Crossref lists the accepted manuscript and version of record separately."""
+    entries = [{"URL": url, "content-version": "vor"} for url in order]
+    fetch = fetch_from({"api.crossref.org": {"message": {"type": "posted-content", "license": entries}}})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.spdx == "CC-BY-NC-ND-4.0", order
+    assert not result.admissible_as_open_access, order
+
+
+def test_most_restrictive_license_ranks_none_below_limited_below_full():
+    assert pl.most_restrictive_license([CC_BY, ARXIV_DEFAULT])[2] == "none"
+    assert pl.most_restrictive_license([CC_BY, CC_BY_NC_ND])[2] == "limited"
+    assert pl.most_restrictive_license([CC_BY, CC_ZERO])[2] == "full"
+
+
+def test_a_recognised_licence_with_no_reuse_row_blocks_rather_than_falling_through():
+    """CC-BY-9.9 parses to an SPDX id, but the table does not know its rights."""
+    unknown_version = "https://creativecommons.org/licenses/by/9.9/"
+    url, spdx, reuse = pl.most_restrictive_license([unknown_version, CC_BY])
+    assert spdx == "CC-BY-9.9" and reuse is None
+    result = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("posted-content", [unknown_version])))
+    assert result.status == pl.STATUS_UNKNOWN_LICENCE
+    assert not result.admissible_as_open_access
+
+
+def test_a_text_mining_grant_is_not_a_redistribution_grant():
+    entries = [{"URL": CC_BY, "content-version": "tdm"}]
+    fetch = fetch_from({"api.crossref.org": {"message": {"type": "posted-content", "license": entries}}})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_NO_LICENCE_DECLARED
+    assert not result.admissible_as_open_access
+
+
+# --- A licence deed must live on the licensor's own host ----------------------
+
+@pytest.mark.parametrize("url", [
+    "https://evil.example.com/redirect?to=creativecommons.org/licenses/by/4.0",
+    "https://example.org/creativecommons.org/licenses/by/4.0/faq",
+    "https://notarxiv.org/licenses/nonexclusive-distrib/1.0/",
+])
+def test_a_deed_quoted_inside_another_host_is_not_a_licence(url):
+    assert pl.spdx_from_license_url(url) is None
+
+
+def test_real_deeds_on_the_licensors_host_still_parse():
+    assert pl.spdx_from_license_url("https://www.creativecommons.org/licenses/by-sa/4.0/") == "CC-BY-SA-4.0"
+    assert pl.spdx_from_license_url("creativecommons.org/licenses/by/4.0") == "CC-BY-4.0"
+
+
+def test_a_malformed_payload_fails_one_doi_not_the_batch():
+    fetch = fetch_from({"api.crossref.org": {"message": {"type": "posted-content",
+                                                         "license": [{"URL": {"nested": "object"}}]}}})
+    assert pl.resolve_preprint_license("d/1", fetch=fetch).status in (pl.STATUS_UNKNOWN_LICENCE, pl.STATUS_UNRESOLVED)
+
+
 # --- A rate-limited registry is not an absent DOI ------------------------------
 
 def test_absent_and_retryable_statuses_are_disjoint():

--- a/tests/test_preprint_license.py
+++ b/tests/test_preprint_license.py
@@ -1,0 +1,276 @@
+"""Pre-print licence resolution must never guess.
+
+The rule this guards: a pre-print is admissible only when its *actual* posting
+licence permits the intended reuse. Every failure mode -- unknown licence, no
+licence declared, registry unreachable -- must surface as a loud status, never as
+a permissive default and never as a restrictive default that hides a lookup bug.
+"""
+
+import ast
+import pathlib
+import sys
+import urllib.error
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import preprint_license as pl
+from scripts.license_tier import load_map, source_reuse_for_license
+
+CC_BY = "https://creativecommons.org/licenses/by/4.0/"
+CC_BY_NC_ND = "http://creativecommons.org/licenses/by-nc-nd/4.0/"
+CC_BY_ND = "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+CC_ZERO = "http://creativecommons.org/publicdomain/zero/1.0/"
+ARXIV_DEFAULT = "http://arxiv.org/licenses/nonexclusive-distrib/1.0/"
+
+
+def crossref(work_type: str, license_urls: list[str], institution: str | None = None) -> dict:
+    message = {"type": work_type, "license": [{"URL": u} for u in license_urls]}
+    if institution:
+        message["institution"] = [{"name": institution}]
+    return {"message": message}
+
+
+def server_api(token: str | None) -> dict:
+    return {"collection": [{"license": token}] if token is not None else []}
+
+
+def datacite(resource_type: str, rights_uris: list[str]) -> dict:
+    rights = [{"rightsUri": u} for u in rights_uris]
+    return {"data": {"attributes": {"types": {"resourceTypeGeneral": resource_type}, "rightsList": rights}}}
+
+
+def fetch_from(routes: dict):
+    """A hermetic fetch: returns a canned payload per URL substring, else None (404)."""
+
+    def _fetch(url: str):
+        for fragment, payload in routes.items():
+            if fragment in url:
+                return payload
+        return None
+
+    return _fetch
+
+
+def crossref_only(payload):
+    return fetch_from({"api.crossref.org": payload})
+
+
+def datacite_only(payload):
+    return fetch_from({"api.datacite.org": payload})
+
+
+# --- Positive: fires across four distinct sciences, on both registries ---------
+
+@pytest.mark.parametrize(
+    "science,doi,fetch,expected_spdx",
+    [
+        # biology (bioRxiv, Crossref)
+        ("biology", "10.1101/2020.01.01.000001", crossref_only(crossref("posted-content", [CC_BY])), "CC-BY-4.0"),
+        # clinical medicine (medRxiv, Crossref)
+        ("clinical", "10.1101/2020.03.24.20042937", crossref_only(crossref("posted-content", [CC_BY_ND])), "CC-BY-ND-4.0"),
+        # chemistry (ChemRxiv, Crossref)
+        ("chemistry", "10.26434/chemrxiv-2024-1zk33", crossref_only(crossref("posted-content", [CC_BY_NC_ND])), "CC-BY-NC-ND-4.0"),
+        # astrophysics (arXiv, DataCite) -- a science with no presence in this repo
+        ("astrophysics", "10.48550/arxiv.2502.05114", datacite_only(datacite("Preprint", [CC_ZERO])), "CC0-1.0"),
+    ],
+)
+def test_resolves_on_every_science_and_registry(science, doi, fetch, expected_spdx):
+    result = pl.resolve_preprint_license(doi, fetch=fetch)
+    assert result.status == pl.STATUS_RESOLVED, science
+    assert result.spdx == expected_spdx, science
+
+
+def test_only_full_reuse_licences_are_admissible_as_open_access():
+    admissible = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("posted-content", [CC_BY])))
+    assert admissible.admissible_as_open_access
+
+    for url in (CC_BY_NC_ND, CC_BY_ND, ARXIV_DEFAULT):
+        blocked = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("posted-content", [url])))
+        assert not blocked.admissible_as_open_access, url
+
+
+def test_arxiv_default_licence_grants_no_reuse():
+    result = pl.resolve_preprint_license("d/1", fetch=datacite_only(datacite("Preprint", [ARXIV_DEFAULT])))
+    assert result.status == pl.STATUS_RESOLVED
+    assert result.source_reuse == "none"
+    assert not result.admissible_as_open_access
+
+
+# --- Negative: stays loud on every not-applicable / unresolvable input ---------
+
+def test_journal_article_is_not_a_preprint_and_is_not_open():
+    result = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("journal-article", [CC_BY])))
+    assert result.status == pl.STATUS_NOT_A_PREPRINT
+    assert not result.admissible_as_open_access
+
+
+def test_unrecognised_licence_url_is_loud_not_defaulted():
+    result = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("posted-content", ["https://example.org/bespoke"])))
+    assert result.status == pl.STATUS_UNKNOWN_LICENCE
+    assert result.source_reuse is None
+    assert not result.admissible_as_open_access
+
+
+def test_preprint_with_no_declared_licence_is_loud():
+    result = pl.resolve_preprint_license("d/1", fetch=crossref_only(crossref("posted-content", [])))
+    assert result.status == pl.STATUS_NO_LICENCE_DECLARED
+    assert not result.admissible_as_open_access
+
+
+def test_absent_from_both_registries_is_unresolved():
+    result = pl.resolve_preprint_license("d/1", fetch=fetch_from({}))
+    assert result.status == pl.STATUS_UNRESOLVED
+    assert not result.admissible_as_open_access
+
+
+def test_network_failure_is_unresolved_never_clean():
+    def exploding_fetch(url):
+        raise urllib.error.URLError("registry unreachable")
+
+    result = pl.resolve_preprint_license("d/1", fetch=exploding_fetch)
+    assert result.status == pl.STATUS_UNRESOLVED
+    assert not result.admissible_as_open_access
+
+
+def test_empty_doi_is_unresolved():
+    assert pl.resolve_preprint_license("", fetch=fetch_from({})).status == pl.STATUS_UNRESOLVED
+
+
+# --- DOI normalisation is two-sided: strips a version marker, keeps a real segment ---
+
+def test_landing_page_version_suffix_is_stripped_only_on_retry():
+    seen = []
+
+    def fetch(url):
+        seen.append(url)
+        return crossref("posted-content", [CC_BY]) if url.endswith("000001") else None
+
+    result = pl.resolve_preprint_license("10.1101/2020.01.01.000001v3.abstract", fetch=fetch)
+    assert result.status == pl.STATUS_RESOLVED
+    assert result.doi_used == "10.1101/2020.01.01.000001"
+    assert any("v3.abstract" in url for url in seen), "the DOI as recorded must be tried first"
+
+
+def test_a_real_dot_v_segment_is_never_stripped():
+    assert pl.strip_version_suffix("10.6084/m9.figshare.28876751.v2") == "10.6084/m9.figshare.28876751.v2"
+
+
+def test_exact_doi_wins_when_it_resolves():
+    result = pl.resolve_preprint_license("10.6084/m9.figshare.28876751.v2",
+                                         fetch=crossref_only(crossref("posted-content", [CC_BY])))
+    assert result.doi_used == "10.6084/m9.figshare.28876751.v2"
+
+
+# --- Server-API fallback, routed by the registry's declared institution --------
+
+def test_server_api_recovers_a_licence_crossref_does_not_declare():
+    fetch = fetch_from({"api.crossref.org": crossref("posted-content", [], institution="bioRxiv"),
+                        "api.biorxiv.org": server_api("cc_by_nc_nd")})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_RESOLVED
+    assert result.registry == "biorxiv_api"
+    assert result.spdx == "CC-BY-NC-ND-4.0"
+    assert not result.admissible_as_open_access
+
+
+def test_server_api_recovers_when_crossref_points_at_a_faq_page():
+    faq = "https://www.biorxiv.org/about/FAQ#license"
+    fetch = fetch_from({"api.crossref.org": crossref("posted-content", [faq], institution="bioRxiv"),
+                        "api.biorxiv.org": server_api("cc_by")})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_RESOLVED
+    assert result.admissible_as_open_access
+
+
+def test_author_reserved_all_rights_is_a_known_refusal_not_an_unknown():
+    fetch = fetch_from({"api.crossref.org": crossref("posted-content", [], institution="bioRxiv"),
+                        "api.biorxiv.org": server_api("cc_no")})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_RESOLVED
+    assert result.spdx == "NoReuse-1.0"
+    assert result.source_reuse == "none"
+    assert not result.admissible_as_open_access
+
+
+def test_unknown_server_token_stays_loud():
+    fetch = fetch_from({"api.crossref.org": crossref("posted-content", [], institution="bioRxiv"),
+                        "api.biorxiv.org": server_api("some_new_token")})
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_UNKNOWN_LICENCE
+    assert result.source_reuse is None
+
+
+def test_an_unknown_institution_never_triggers_a_server_call():
+    called = []
+
+    def fetch(url):
+        called.append(url)
+        return crossref("posted-content", [], institution="Some Unlisted Server") if "crossref" in url else None
+
+    result = pl.resolve_preprint_license("d/1", fetch=fetch)
+    assert result.status == pl.STATUS_NO_LICENCE_DECLARED
+    assert not any("biorxiv" in url for url in called)
+
+
+def test_server_without_a_record_falls_back_to_the_registry_outcome():
+    fetch = fetch_from({"api.crossref.org": crossref("posted-content", [], institution="bioRxiv"),
+                        "api.biorxiv.org": server_api(None)})
+    assert pl.resolve_preprint_license("d/1", fetch=fetch).status == pl.STATUS_NO_LICENCE_DECLARED
+
+
+def test_every_server_token_maps_to_a_known_source_reuse_value():
+    """A token whose SPDX has no source_reuse row would resolve to a silent unknown."""
+    config = pl.load_servers()
+    for token, spdx in config["license_tokens"].items():
+        assert source_reuse_for_license(spdx, load_map()) is not None, f"{token} -> {spdx} has no source_reuse row"
+
+
+# --- Licence URL parsing ------------------------------------------------------
+
+@pytest.mark.parametrize("url,spdx", [
+    (CC_BY, "CC-BY-4.0"),
+    (CC_BY_NC_ND, "CC-BY-NC-ND-4.0"),
+    (CC_ZERO, "CC0-1.0"),
+    (ARXIV_DEFAULT, "arXiv-1.0"),
+    ("https://opensource.org/licenses/MIT", None),
+    ("", None),
+])
+def test_spdx_from_license_url(url, spdx):
+    assert pl.spdx_from_license_url(url) == spdx
+
+
+def test_unknown_spdx_has_no_source_reuse_entry():
+    """None means unknown; it must not collapse onto the known refusal 'none'."""
+    assert source_reuse_for_license("Totally-Made-Up-1.0", load_map()) is None
+    assert source_reuse_for_license("arXiv-1.0", load_map()) == "none"
+
+
+# --- Generality guards --------------------------------------------------------
+
+def _string_constants(module_path: pathlib.Path):
+    """Every string literal in a module, excluding docstrings (and comments)."""
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    docstrings = {ast.get_docstring(tree)}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            docstrings.add(ast.get_docstring(node))
+    return [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str) and n.value not in docstrings]
+
+
+def test_no_doi_literals_in_scripts():
+    """A DOI literal in general code is an overfit to one paper. Keep them in tests."""
+    import re
+    doi_shape = re.compile(r"\b10\.\d{4,9}/")
+    offenders = []
+    for script in sorted((pathlib.Path(__file__).parent.parent / "scripts").glob("*.py")):
+        offenders += [f"{script.name}: {s}" for s in _string_constants(script) if doi_shape.search(s)]
+    assert not offenders, f"DOI literals belong in tests/, not general code: {offenders}"
+
+
+def test_preprint_detection_never_dispatches_on_a_doi_prefix():
+    """Pre-print-ness comes from the registry's declared type, not a registrant prefix."""
+    source = (pathlib.Path(__file__).parent.parent / "scripts" / "preprint_license.py")
+    for literal in _string_constants(source):
+        assert not literal.startswith("10."), f"prefix dispatch re-entered via {literal!r}"

--- a/tests/test_preprint_license.py
+++ b/tests/test_preprint_license.py
@@ -246,6 +246,56 @@ def test_unknown_spdx_has_no_source_reuse_entry():
     assert source_reuse_for_license("arXiv-1.0", load_map()) == "none"
 
 
+# --- A rate-limited registry is not an absent DOI ------------------------------
+
+def test_absent_and_retryable_statuses_are_disjoint():
+    assert not set(pl.ABSENT_STATUS) & set(pl.RETRYABLE_STATUS)
+
+
+def test_retry_delay_honours_retry_after_then_backs_off():
+    assert pl.retry_delay(1, "7") == 7.0
+    assert pl.retry_delay(1, None) == pl.BACKOFF_BASE_S
+    assert pl.retry_delay(3, None) > pl.retry_delay(2, None)
+    assert pl.retry_delay(2, "not-a-number") == pl.retry_delay(2, None)
+
+
+def test_fetch_json_retries_a_rate_limit_then_succeeds(monkeypatch):
+    attempts = []
+
+    def flaky(url):
+        attempts.append(url)
+        if len(attempts) < 3:
+            raise urllib.error.HTTPError(url, 429, "Too Many Requests", {"Retry-After": "0"}, None)
+        return {"ok": True}
+
+    monkeypatch.setattr(pl, "_get_json", flaky)
+    monkeypatch.setattr(pl.time, "sleep", lambda _s: None)
+    assert pl.fetch_json("https://example.org/x") == {"ok": True}
+    assert len(attempts) == 3
+
+
+def test_fetch_json_gives_up_loudly_rather_than_reporting_absence(monkeypatch):
+    def always_limited(url):
+        raise urllib.error.HTTPError(url, 429, "Too Many Requests", {}, None)
+
+    monkeypatch.setattr(pl, "_get_json", always_limited)
+    monkeypatch.setattr(pl.time, "sleep", lambda _s: None)
+    with pytest.raises(urllib.error.HTTPError):
+        pl.fetch_json("https://example.org/x")
+
+
+def test_a_rate_limited_registry_never_yields_a_clean_answer(monkeypatch):
+    """The whole point: 429 must surface as unresolved, never as not_a_preprint."""
+    def always_limited(url):
+        raise urllib.error.HTTPError(url, 429, "Too Many Requests", {}, None)
+
+    monkeypatch.setattr(pl, "_get_json", always_limited)
+    monkeypatch.setattr(pl.time, "sleep", lambda _s: None)
+    result = pl.resolve_preprint_license("d/1", fetch=pl.fetch_json)
+    assert result.status == pl.STATUS_UNRESOLVED
+    assert not result.admissible_as_open_access
+
+
 # --- Generality guards --------------------------------------------------------
 
 def _string_constants(module_path: pathlib.Path):

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -1,0 +1,168 @@
+"""A skill that exists on disk must appear in every index its collection publishes.
+
+The bug this guards: a skill grounded on a tool with no paper DOI never entered
+`skills_index.json`, because the index was only ever joined onto entries that a
+paper corpus had already created. It shipped, and nothing -- search, the MCP
+server, the docs site, or CI -- could see it.
+"""
+
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import skill_index as si
+
+# Four unrelated sciences. None of this module's logic may depend on the domain.
+SCIENCES = ["metabolomics", "proteomics", "genomics", "astronomy"]
+
+
+def write_skill(version_dir: pathlib.Path, slug: str, frontmatter: dict, body: str = "body") -> None:
+    skill_dir = version_dir / "skills" / slug
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\n{yaml.safe_dump(frontmatter)}---\n{body}\n", encoding="utf-8")
+
+
+def leaf(name: str, tier: str = "open") -> dict:
+    return {"name": name, "description": f"Use when working with {name}.",
+            "metadata": {"license_tier": tier, "tools": [name.upper()]}}
+
+
+def collection(tmp_path: pathlib.Path, science: str, skills: dict, indexed: list[str]) -> pathlib.Path:
+    version_dir = tmp_path / "collections" / science / "v1"
+    version_dir.mkdir(parents=True)
+    for slug, frontmatter in skills.items():
+        write_skill(version_dir, slug, frontmatter)
+    entries = [si.entry_from_frontmatter(s, skills[s]) for s in indexed]
+    (version_dir / "skills_index.json").write_text(json.dumps(entries, indent=1, ensure_ascii=False), encoding="utf-8")
+    bundle = {"collection": science, "skills": {s: si.kb_entry_from_frontmatter(skills[s]) for s in indexed}}
+    (version_dir / "kb_bundle.json").write_text(json.dumps(bundle, indent=2, ensure_ascii=False), encoding="utf-8")
+    return version_dir
+
+
+# --- Fires on every science: an unindexed content skill is always caught -------
+
+@pytest.mark.parametrize("science", SCIENCES)
+def test_orphan_skill_is_detected_in_every_science(tmp_path, science):
+    skills = {"indexed-leaf": leaf("indexed-leaf"), "orphan-leaf": leaf("orphan-leaf")}
+    version_dir = collection(tmp_path, science, skills, indexed=["indexed-leaf"])
+    gaps = si.missing_from_indexes(version_dir)
+    assert gaps["skills_index.json"] == ["orphan-leaf"], science
+    assert gaps["kb_bundle.json"] == ["orphan-leaf"], science
+
+
+@pytest.mark.parametrize("science", SCIENCES)
+def test_fully_indexed_collection_is_clean_in_every_science(tmp_path, science):
+    skills = {"a-leaf": leaf("a-leaf"), "b-leaf": leaf("b-leaf")}
+    version_dir = collection(tmp_path, science, skills, indexed=["a-leaf", "b-leaf"])
+    assert si.missing_from_indexes(version_dir) == {}, science
+
+
+# --- Stays clean on genuinely not-indexable skills -----------------------------
+
+def test_infrastructure_and_meta_skills_are_not_required_in_the_index(tmp_path):
+    skills = {
+        "_router": leaf("_router"),
+        "collection-meta": {"name": "collection-meta", "description": "Use when starting.",
+                            "metadata": {"role": "meta", "license_tier": "open"}},
+        "real-leaf": leaf("real-leaf"),
+    }
+    version_dir = collection(tmp_path, "metabolomics", skills, indexed=["real-leaf"])
+    assert si.missing_from_indexes(version_dir) == {}
+
+
+def test_exclusion_is_by_declarative_property_not_by_name():
+    assert si.is_indexable("masster", {"metadata": {"license_tier": "noncommercial"}})
+    assert not si.is_indexable("_anything", {})
+    assert not si.is_indexable("named-whatever", {"metadata": {"role": "meta"}})
+
+
+def test_collection_publishing_no_index_is_not_flagged(tmp_path):
+    version_dir = tmp_path / "collections" / "genomics" / "v1"
+    write_skill(version_dir, "a-leaf", leaf("a-leaf"))
+    assert si.missing_from_indexes(version_dir) == {}
+
+
+# --- A non-open skill may never be indexed without its tier --------------------
+
+def test_untiered_skill_is_refused_not_silently_nulled(tmp_path):
+    untiered = {"name": "no-tier", "description": "Use when.", "metadata": {"tools": ["X"]}}
+    version_dir = collection(tmp_path, "metabolomics", {"no-tier": untiered}, indexed=[])
+    with pytest.raises(ValueError, match="license_tier"):
+        si.add_missing(version_dir)
+
+
+def test_untiered_predicate_rejects_every_invalid_tier():
+    assert si.untiered("s", {})
+    assert si.untiered("s", {"metadata": {"license_tier": None}})
+    assert si.untiered("s", {"metadata": {"license_tier": "permissive"}})
+    assert not si.untiered("s", {"metadata": {"license_tier": "noncommercial"}})
+
+
+def test_noncommercial_skill_keeps_its_tier_through_indexing(tmp_path):
+    skills = {"nc-leaf": leaf("nc-leaf", tier="noncommercial")}
+    version_dir = collection(tmp_path, "metabolomics", skills, indexed=[])
+    si.add_missing(version_dir)
+    entry = json.loads((version_dir / "skills_index.json").read_text())[0]
+    bundle = json.loads((version_dir / "kb_bundle.json").read_text())
+    assert entry["license_tier"] == "noncommercial"
+    assert bundle["skills"]["nc-leaf"]["license_tier"] == "noncommercial"
+
+
+# --- add_missing is correct, sorted, idempotent, format-preserving -------------
+
+def test_add_missing_inserts_sorted_and_is_idempotent(tmp_path):
+    skills = {"zzz-leaf": leaf("zzz-leaf"), "aaa-leaf": leaf("aaa-leaf")}
+    version_dir = collection(tmp_path, "proteomics", skills, indexed=["zzz-leaf"])
+    si.add_missing(version_dir)
+    slugs = [e["slug"] for e in json.loads((version_dir / "skills_index.json").read_text())]
+    assert slugs == sorted(slugs) == ["aaa-leaf", "zzz-leaf"]
+    assert si.missing_from_indexes(version_dir) == {}
+    si.add_missing(version_dir)
+    assert len(json.loads((version_dir / "skills_index.json").read_text())) == 2
+
+
+def test_add_missing_preserves_the_files_own_indent(tmp_path):
+    skills = {"a-leaf": leaf("a-leaf"), "b-leaf": leaf("b-leaf")}
+    version_dir = collection(tmp_path, "genomics", skills, indexed=["a-leaf"])
+    si.add_missing(version_dir)
+    raw = (version_dir / "skills_index.json").read_text()
+    assert raw.startswith("[\n {\n"), "skills_index.json is written with indent=1"
+    assert not raw.endswith("\n"), "the generator writes no trailing newline"
+
+
+def test_entry_is_derived_from_frontmatter(tmp_path):
+    frontmatter = {"name": "n", "description": "d",
+                   "metadata": {"license_tier": "open", "tools": ["T"], "techniques": ["LC-MS"],
+                                "edam_operation": "op", "edam_topics": ["t1"], "repo_url": "https://example.org/r"},
+                   "derived_from": [{"doi": "x/y"}, {"title": "no doi"}]}
+    entry = si.entry_from_frontmatter("slug", frontmatter)
+    assert entry == {"slug": "slug", "name": "n", "description": "d", "edam_operation": "op",
+                     "edam_topics": ["t1"], "tools": ["T"], "dois": ["x/y"], "techniques": ["LC-MS"],
+                     "license_tier": "open"}
+    assert si.kb_entry_from_frontmatter(frontmatter)["repo_urls"] == ["https://example.org/r"]
+
+
+# --- The canonical frontmatter parser -----------------------------------------
+
+def test_a_rule_inside_frontmatter_does_not_truncate_it():
+    """`raw.split('---', 2)` silently dropped skills whose frontmatter held `-----`."""
+    text = "---\nname: s\nevidence:\n- '.mzML ----- toctree'\n---\nbody text\n"
+    frontmatter, body = si.split_frontmatter(text)
+    assert frontmatter["name"] == "s"
+    assert frontmatter["evidence"] == [".mzML ----- toctree"]
+    assert body.strip() == "body text"
+
+
+def test_split_frontmatter_reports_malformed_input_as_none():
+    assert si.split_frontmatter("no frontmatter here")[0] is None
+    assert si.split_frontmatter("---\nunterminated: [\n---\nbody")[0] is None
+    assert si.split_frontmatter("---\nname: s\nnever closed")[0] is None
+
+
+def test_body_is_everything_after_the_closing_delimiter():
+    _, body = si.split_frontmatter("---\nname: s\n---\nline one\n---\nline two\n")
+    assert body == "line one\n---\nline two"

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -146,6 +146,56 @@ def test_entry_is_derived_from_frontmatter(tmp_path):
     assert si.kb_entry_from_frontmatter(frontmatter)["repo_urls"] == ["https://example.org/r"]
 
 
+# --- The gate must never inspect nothing and call it success ------------------
+
+def test_a_gate_that_matched_no_directory_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    assert si.main([]) == 1
+    assert "no skill directories matched" in capsys.readouterr().out
+
+
+def test_every_configured_tree_is_visited(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    collection(tmp_path, "metabolomics", {"a-leaf": leaf("a-leaf")}, indexed=["a-leaf"])
+    pack = tmp_path / "packs" / "metabolomics" / "lc-ms"
+    write_skill(pack, "pack-leaf", leaf("pack-leaf"))
+    (pack / "kb_bundle.json").write_text(json.dumps({"skills": {}}), encoding="utf-8")
+    assert si.main([]) == 1, "an orphan inside packs/ must fail the gate"
+
+
+def test_default_globs_cover_both_shipped_trees():
+    assert "collections/*/v*" in si.DEFAULT_COLLECTION_GLOBS
+    assert "packs/*/*" in si.DEFAULT_COLLECTION_GLOBS
+
+
+# --- The tier vocabulary has exactly one home ---------------------------------
+
+def test_valid_tiers_are_read_from_the_canonical_map():
+    assert si.valid_tiers() == set(yaml.safe_load(
+        (pathlib.Path(__file__).parent.parent / "governance" / "license_tiers.yaml").read_text())["tiers"])
+
+
+def test_a_new_tier_in_the_canonical_map_is_accepted_without_a_code_change(monkeypatch):
+    monkeypatch.setattr(si, "valid_tiers", lambda: {"open", "noncommercial", "restricted", "academic"})
+    assert not si.untiered("s", {"metadata": {"license_tier": "academic"}})
+
+
+# --- kb_slugs are derived, not blanked ----------------------------------------
+
+def test_kb_slugs_are_derived_from_the_dois():
+    entry = si.kb_entry_from_frontmatter({"derived_from": [{"doi": "10.1093/bioinformatics/btaf045"}],
+                                          "metadata": {"license_tier": "open"}})
+    assert entry["kb_slugs"] == ["asb-paper-10-1093-bioinformatics-btaf045"]
+
+
+def test_kb_slug_honours_the_bundles_own_prefix():
+    assert si.kb_slug_for_doi("10.1/A_b", prefix="kb-") == "kb-10-1-a-b"
+
+
+def test_a_skill_without_dois_gets_no_kb_slugs():
+    assert si.kb_entry_from_frontmatter({"metadata": {"license_tier": "noncommercial"}})["kb_slugs"] == []
+
+
 # --- The canonical frontmatter parser -----------------------------------------
 
 def test_a_rule_inside_frontmatter_does_not_truncate_it():


### PR DESCRIPTION
Two follow-ups from #22, kept general so they work for any collection and any future expansion. Stacked on `consolidate/2026-07-10`; retarget to `main` once #22 lands.

## 1. Pre-prints are not always CC-BY

`OPEN_ACCESS_POLICY.md` asserted that pre-prints are "always CC-BY by repository policy". bioRxiv, medRxiv and arXiv all let the author choose, so the rule could admit text we have no right to redistribute.

`scripts/preprint_license.py` resolves the real posting licence. It reads pre-print-ness from **the registry's own declaration** — Crossref `type: posted-content`, DataCite `resourceTypeGeneral: Preprint` — never from a DOI prefix. A prefix names a registrant, not a work type: `10.1101` is Cold Spring Harbor, covering bioRxiv, medRxiv *and* CSHL journals, and bioRxiv now also registers under openRxiv's `10.64898`. Any server either registry covers therefore resolves with no code change.

Where a registry declares no usable licence, it falls back to the server's own API, routed by the `institution[].name` the registry itself reports. Servers and licence tokens live in `governance/preprint_servers.yaml`; adding one is a data edit.

Three corrections to the guidance in #22, all established by calling the live APIs:

- **arXiv's Atom API exposes no licence.** Use DataCite (or OAI-PMH `arXivRaw`). arXiv's default `nonexclusive-distrib` grants **no reuse rights**.
- **ChemRxiv's public API is behind Cloudflare** and answers `403`. Resolve it through Crossref, which carries its licence.
- **Crossref sometimes points `license[].URL` at a FAQ page**, not a deed. That is an unknown, not a licence.

### A second licence axis, because the existing one asks a different question

`license_tier` answers *"what may I do with the tool?"* — `open` means commercial use is fine. A **paper's** licence answers *"may we redistribute the source?"*. These disagree: CC-BY-ND permits commercial use but forbids derivative text, so reading it through the tool tier would call it open. Mapping paper licences onto `license_tier`, as originally proposed, is a category error.

So `governance/license_tiers.yaml` grows a second canonical table, `source_reuse` (`full` / `limited` / `none`). Adding `CC-BY-ND-4.0` and `CC-BY-NC-ND-4.0` to the tool map changes no behaviour — both previously reached the same answer through the fallback — it only makes them explicit.

**An unlisted licence returns `None`, never a default.** `None` (we failed to establish the rights) and `none` (the rights were withheld) are different answers and the code refuses to collapse them.

### Audit of what is already shipped — reported, not dropped

Of 600 corpus DOIs, 56 are pre-prints. Only **15 are full-reuse**; 32 are NC/ND; **9 grant no reuse at all** (8 bioRxiv `cc_no`, 1 arXiv default) and are `status: included`. Full findings, the 9 entries, and 24 malformed DOIs the audit surfaced are in #24. No entry was removed and no gate was weakened — every one of the 56 was admitted on `repo-oa`, not on the pre-print rule, so this is the same `access.type` conflation tracked in #23.

A rate-limited registry used to be indistinguishable from a missing DOI, which silently marked resolvable pre-prints `unresolved`. `fetch_json` now retries `429`/`5xx` with backoff and honours `Retry-After`; only `403/404/410` means "no record". That mistake inflated the first audit run by 2 entries.

## 2. A skill that ships must be findable

`collections/metabolomics/v2/skills/masster/SKILL.md` existed on disk but appeared in **none** of `skills_index.json`, `kb_bundle.json` or `docs-site/search_index.json` — invisible to search, the MCP server and the docs site.

The cause is structural. `propagate_license_tiers.py` joins tiers onto entries the index *already has*, keyed by DOI; it never adds one. Masster has no DOI and no corpus entry, so it could never enter by that route. And `check_license_tiers.py` only cross-checks skills already indexed, so CI never noticed.

**Chosen fix: derive the index from the skills directory (option a), not admit non-OA tools into the paper corpus (option b).** `corpus.yaml` is a *paper* corpus keyed by DOI and `access.type`; a tool with no paper has no source to redistribute, so gating its discoverability on an open-access field is wrong by construction. Option (b) would have coupled discovery to the legal gate and let non-OA content into the corpus `verify-paper` polices — weakening a gate the brief forbids weakening.

`scripts/skill_index.py` derives an entry from a skill's own frontmatter, and a new CI gate fails when a skill exists on disk but in no index. Skills are excluded by **declarative property** — an `_`-prefixed directory (the convention `release_gate.py` already uses) or `metadata.role: meta` — never by a hardcoded name list.

The acknowledgment gate is preserved: `--fix` **refuses** to index a skill with no `metadata.license_tier`, so a non-open skill can never become searchable while shedding the label that governs its use. Masster ships `license_tier: noncommercial` with `requires_ack: true`, and `check_license_tiers.py` now cross-checks it because it is finally visible.

### A second orphan, found on the way — larger than it first looked

`docs-site/build_search_index.py` split frontmatter on the *substring* `---`, so any skill whose frontmatter contained a rule was truncated. **41 of 7,722 skills parsed differently**, not the 2 I first reported:

- **2 were dropped entirely** — `mzml-data-parsing-pymzml-pyopenms` in v1 and v2, whose evidence span contains `-----`. YAML failed, and the skill vanished from the index.
- **39 parsed as valid dicts but with truncated frontmatter**, silently losing keys like `provenance`, `attribution` and `claims` into the body — which then polluted their `search_text` and `summary`. Those 39 were mis-indexed, not missing, which is why a naive count found only 2.

Verified with a parser-vs-parser diff over all 7,722 files: 41 changed, **zero regressions** (no file lost a key or gained pollution). Both consumers now share one canonical `split_frontmatter()`.

Search index: `7718 -> 7722`, exactly the 7,722 SKILL.md on disk. The four new entries are the 2 recovered skills, `masster`, and `asb-metabolomics` (the committed index predated it). Zero removals; papers and tools unchanged.

## Generality

The maintainer asked that these stay general for library and collection expansion. Enforced by tests, not by intent:

- `test_no_doi_literals_in_scripts` walks the AST of every `scripts/*.py` and fails on any DOI-shaped string constant outside a docstring.
- `test_preprint_detection_never_dispatches_on_a_doi_prefix` fails if a `10.` literal re-enters the resolver.
- Both resolvers and the index gate are tested across four unrelated sciences — metabolomics, proteomics, genomics and astronomy — none of which the code may branch on.
- Every failure mode has a negative test: unknown licence, no licence declared, rate limit, absent DOI, journal article, untiered skill, meta skill, a collection publishing no index.

Each guard was mutation-tested: reintroducing the bug turns the test red.

## Verification

- `285 passed` (was 253; +32 new, no regressions)
- `python -m scripts.skill_index` exits 1 naming `masster` before the fix, 0 after
- `check_license_tiers.py` green; description-discipline lint green over 7,722 skills
- Index diffs are pure additions in the files' own indent — 26 inserted lines, 0 removed


## Review findings folded in

Two independent adversarial reviews. What changed:

**One blocking defect, in the direction that matters.** `_first_recognised_spdx` returned the *first* licence a registry declared. Crossref lists the accepted manuscript and the version of record separately and does not guarantee their order, so a work declaring both CC-BY and CC-BY-NC-ND resolved to whichever came first — `admissible_as_open_access` flipped on array position. A `content-version: tdm` entry (a text-mining grant, not a redistribution grant) was also read as a licence to reuse. Both reproduced, then fixed: **the most restrictive declared licence now governs**, TDM grants are excluded, and a recognised SPDX with no `source_reuse` row blocks rather than falling through to a permissive sibling.

**A licence deed quoted inside an unrelated URL was accepted.** `https://evil.example.com/redirect?to=creativecommons.org/licenses/by/4.0` resolved to CC-BY. The host is now checked before the path.

**The gate could inspect nothing and pass.** Run from the wrong directory, `skill_index` printed `PASS` having visited zero collections. It now fails when no skill directory matches.

**`packs/` was unguarded** — 4,961 shipped skills with a `kb_bundle.json` the gate never visited, able to reproduce the exact bug this PR fixes. Now covered; the gate walks 12 directories.

**The tier vocabulary had three copies** (`license_tiers.yaml`, `check_license_tiers.py`, and the new `skill_index.py`). Both scripts now read the canonical map, so adding a tier is a data edit.

Also: `kb_slugs` are derived from a skill's DOIs instead of written empty; a malformed registry payload fails its own DOI rather than aborting a bulk audit; and `unresolved` is no longer cached, so a transient outage cannot freeze into a permanent verdict.

I did **not** accept one finding: `10.64898/…` is a genuine bioRxiv DOI (prefix registered to openRxiv), verified against Crossref's prefix API and `api.biorxiv.org`.

Re-resolving all 15 previously-`full` pre-prints under most-restrictive-wins changed **none** of them, so the numbers in #24 stand.

## Verification

- `303 passed` (was 253 on the base; +50 new, no regressions)
- Every exploit above reproduced before the fix and closed after
- Every guard mutation-tested: reintroduce the bug, the test goes red
- `skill_index` exits 1 naming `masster` before the fix, 0 after, across 12 directories
- Index diffs are pure additions in each file's own indent — 26 inserted lines, 0 removed

## CI note

This PR is based on `consolidate/2026-07-10` (#22), and `validate.yml` / `verify-paper.yml` only trigger on `pull_request: branches: [main]`. **No CI runs on this PR until #22 merges and this retargets to `main`.** Both gates were therefore replayed locally by extracting and executing the workflows' own inline scripts: `PASS: description discipline OK (7722 skill files checked)` and `PASS: Paper access-tier validation OK (684 included papers checked)`.
