### PR TITLE
Port the community-contribution rails forward from the abandoned dev line

### DIFF
--- a/.github/ISSUE_TEMPLATE/claim-skill.md
+++ b/.github/ISSUE_TEMPLATE/claim-skill.md
@@ -1,0 +1,60 @@
+---
+name: Claim / contribute a skill for your tool (become a co-author)
+about: A tool's author contributes (or claims) a skill grounded on their tool/paper and is credited as a verified co-author. Keep it short — a maintainer runs the claim-skill command and stages the PR.
+title: "Claim skill: <tool / skill name>"
+labels: ["claim", "community-skill", "co-authorship", "needs-triage"]
+---
+
+<!--
+Use this when YOU are the author of the tool (or method/paper) a skill grounds
+on, and you want to contribute that skill AND be credited as a co-author. Keep
+it short: tell us the tool/paper, what the skill does, and who you are. A
+maintainer runs the `claim-skill` command, which normalizes/matches/grounds the
+skill (the propose-skill flow), writes you into the staged skill's `contributors`
+as `role: author`, and stages a reviewable PR with `Co-authored-by:` you. A
+maintainer makes the final merge decision — you cannot self-merge.
+
+Authorship is **identity-verified**: your ORCID/GitHub are checked the same way
+candidate curators are (L1 GitHub-in-ORCID, L2 ORCID-on-the-tool's-paper via
+OpenAlex, run by `vet-curator`) BEFORE you are credited. See
+governance/AUTHORSHIP.md and governance/COMMUNITY_SKILLS.md.
+-->
+
+**What does the skill do?** <!-- one line, e.g. "Use when aligning RT across batches with <tool>" -->
+
+**Your tool / method (and its paper, if any):**
+<!-- tool name + repo/homepage, and the DOI of the paper that describes it -->
+
+**Link to the skill:** <!-- a gist, repo path, or the SKILL.md pasted below — whatever you have -->
+
+**Target collection:** <!-- metabolomics (default), or another collection slug -->
+
+## You (for verified authorship credit — required)
+
+<!--
+We verify these before crediting you (governance/AUTHORSHIP.md). Make sure your
+ORCID public profile lists your GitHub URL (the L1 check) and that your ORCID
+is an author on the tool's paper above (the L2 check, via OpenAlex).
+-->
+
+- **Name (as it should appear in credit):**
+- **ORCID:** <!-- 0000-0000-0000-0000 -->
+- **GitHub:** <!-- @handle -->
+- **Email for `Co-authored-by:`** <!-- the address you want on the merge commit's trailer -->
+
+---
+<!-- Optional, all skippable — a maintainer/the command resolves these: -->
+- **Related existing skills?** <!-- slugs it overlaps or composes, if you know them -->
+- **Conflict of interest?** <!-- you authoring a skill for your own tool is disclosed, not disqualifying — the maintainer is the independent gate; see governance/AUTHORSHIP.md -->
+
+## Licensing
+
+- [ ] I am an author of the tool/method this skill grounds on, and the identity I
+      give above is mine.
+- [ ] I license my contributed skill prose (description + body) under **CC-BY-4.0**.
+
+<!--
+The CC-BY-4.0 grant covers the text you wrote. It is separate from the skill's
+`license_tier`, which describes the tool the skill grounds on (open / noncommercial
+/ restricted) — see governance/LICENSE_TIERS.md.
+-->

--- a/.github/ISSUE_TEMPLATE/propose-meta-skill.md
+++ b/.github/ISSUE_TEMPLATE/propose-meta-skill.md
@@ -1,0 +1,53 @@
+---
+name: Propose a meta-skill (super-skill / pipeline)
+about: Suggest a workflow-level super-skill that orchestrates several existing sub-skills into a canonical pipeline. Keep it short — a maintainer (or the synthesize-meta-skill command) fills in the rest.
+title: "Propose meta-skill: <name>"
+labels: ["propose", "meta-skill", "needs-triage"]
+---
+
+<!--
+Keep this short. A meta-skill (super-skill) does NOT re-implement a procedure — it
+SEQUENCES existing sub-skills into a canonical end-to-end pipeline (e.g. "molecular
+networking": feature detection/alignment → spectral similarity/networking →
+annotation/propagation → visualization). Tell us WHAT pipeline it captures, WHICH
+sub-skills/tools it should orchestrate, and WHY it's worth shipping as a super-skill.
+The `synthesize-meta-skill` command does the synthesis, grounding, and normalization,
+and stages a reviewable PR. A maintainer makes the final merge decision — you cannot
+self-merge.
+See governance/META_SKILLS.md for how super-skills are defined and curated.
+-->
+
+**What pipeline does the meta-skill capture?** <!-- one line, e.g. "End-to-end untargeted LC-MS molecular networking" -->
+
+**Why it matters (one or two sentences):**
+<!-- What canonical workflow does it name, and why is it worth grounding agent retrieval on at the workflow level rather than per-step? -->
+
+**Sub-skills / tools to orchestrate (ordered):**
+<!--
+The ordered stages the pipeline sequences, and the sub-skill slug(s) / tool(s) that
+carry each stage — as much as you know. The command resolves and completes these.
+e.g.
+  1. feature detection/alignment — <slug or tool>
+  2. spectral similarity / networking — <slug or tool>
+  3. annotation / propagation — <slug or tool>
+  4. visualization — <slug or tool>
+-->
+
+**Target collection:** <!-- metabolomics (default), or another collection slug -->
+
+---
+<!-- Optional, all skippable — a maintainer/the command resolves these: -->
+- **Decision points between stages?** <!-- the choices a user makes moving stage→stage, if you know them -->
+- **Related existing skills or super-skills?** <!-- slugs it overlaps or composes, if you know them -->
+- **You:** <!-- @handle, ORCID -->
+- **Conflict of interest?** <!-- disclosure only, never disqualifying -->
+
+## Licensing
+
+- [ ] I license my contributed meta-skill prose (description + body) under **CC-BY-4.0**.
+
+<!--
+This CC-BY-4.0 grant covers the text you wrote. A synthesized super-skill still
+declares the `license_tier` of the tools its orchestrated stages ground on (open /
+noncommercial / restricted) — see governance/LICENSE_TIERS.md.
+-->

--- a/.github/ISSUE_TEMPLATE/propose-skill.md
+++ b/.github/ISSUE_TEMPLATE/propose-skill.md
@@ -1,0 +1,41 @@
+---
+name: Propose a skill (community tier)
+about: Suggest a community-contributed skill for an ASB-Skill collection. Keep it short — a maintainer (or the propose-skill command) fills in the rest.
+title: "Propose skill: <name>"
+labels: ["propose", "community-skill", "needs-triage"]
+---
+
+<!--
+Keep this short. Tell us WHAT the skill does, WHY it's worth adding, and give a
+LINK to the skill (or paste its SKILL.md). The `propose-skill` command does the
+matching, grounding, and normalization, and stages a reviewable PR. A maintainer
+makes the final merge decision — you cannot self-merge.
+See governance/COMMUNITY_SKILLS.md for how community skills are curated.
+-->
+
+**What does the skill do?** <!-- one line, e.g. "Use when aligning RT across batches with method X" -->
+
+**Why it matters (one or two sentences):**
+<!-- What procedure does it capture, and why is it worth grounding agent retrieval on? -->
+
+**Link to the skill:** <!-- a gist, repo path, or the SKILL.md pasted below — whatever you have -->
+
+**Tool(s) it grounds on:** <!-- the software/tool the skill drives, if any -->
+
+**Target collection:** <!-- metabolomics (default), or another collection slug -->
+
+---
+<!-- Optional, all skippable — a maintainer/the command resolves these: -->
+- **Related existing skills?** <!-- slugs it overlaps or composes, if you know them -->
+- **You:** <!-- @handle, ORCID -->
+- **Conflict of interest?** <!-- disclosure only, never disqualifying -->
+
+## Licensing
+
+- [ ] I license my contributed skill prose (description + body) under **CC-BY-4.0**.
+
+<!--
+This CC-BY-4.0 grant covers the text you wrote. It is separate from the skill's
+`license_tier`, which describes the tool the skill grounds on (open / noncommercial
+/ restricted) — see governance/LICENSE_TIERS.md.
+-->

--- a/.github/workflows/proposals.yml
+++ b/.github/workflows/proposals.yml
@@ -1,0 +1,74 @@
+# proposals.yml -- Runs on PRs that touch staged skill proposals.
+# Gives contributors fast STRUCTURAL feedback: runs the same proposal-rail
+# gate a maintainer would (`scripts/check_proposals`) and posts a short
+# pass/fail PR comment so the review is about quality/fit, not structure.
+#
+# Additive: does NOT replace or disturb validate.yml. Advisory-leaning but
+# fails the check on a structural violation so the contributor sees it.
+#
+# Spec ref: governance/COMMUNITY_SKILLS.md (proposal rail)
+# Driver: scripts/check_proposals.py
+
+name: Proposals
+
+on:
+  pull_request:
+    paths:
+      - 'collections/*/proposals/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-proposals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Check staged proposals
+        id: check
+        run: |
+          set +e
+          out="$(python -m scripts.check_proposals collections/metabolomics/v2 2>&1)"
+          code=$?
+          echo "$out"
+          {
+            echo "report<<EOF"
+            echo "$out"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $code
+
+      - name: Post PR comment with proposal check result
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          # Pass untrusted check output via env (not inline interpolation) so a
+          # PR-controlled proposal path/content cannot break out of the JS body.
+          REPORT: ${{ steps.check.outputs.report }}
+          OUTCOME: ${{ steps.check.outcome }}
+        with:
+          script: |
+            const report = process.env.REPORT || "";
+            const status = process.env.OUTCOME;
+            const heading = status === "success"
+              ? "### ✅ Proposal structure check passed"
+              : "### ❌ Proposal structure check failed";
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${heading}\n\n\`\`\`\n${report}\n\`\`\`\n\nDriver: \`scripts/check_proposals.py\` · See governance/COMMUNITY_SKILLS.md`
+            });

--- a/asb_skill_collections/layout.py
+++ b/asb_skill_collections/layout.py
@@ -26,6 +26,10 @@ ADVERTISED_DIRNAME = "skills"
 # `release_gate.check_workflows`, not by the per-leaf provenance and
 # verbatim checks: a workflow composes leaves, it has no single source paper.
 WORKFLOW_DIRNAME = "workflows"
+# Community proposals in review. A staging area, deliberately outside the
+# corpus: nothing here is advertised, indexed or gated as a shipped skill until
+# `promote_proposals.py` moves it into the leaf dir.
+STAGING_DIRNAME = "proposals"
 
 
 def is_router_shaped(collection_dir: str | os.PathLike) -> bool:
@@ -42,6 +46,18 @@ def leaf_dir(collection_dir: str | os.PathLike) -> Path:
     """
     base = Path(collection_dir)
     return base / LEAF_DIRNAME if is_router_shaped(base) else base / ADVERTISED_DIRNAME
+
+
+def staging_dir(collection_dir: str | os.PathLike) -> Path:
+    """Where a community proposal is written while it is under review.
+
+    Fixed at ``proposals/skills/`` in every layout. A proposal is not part of
+    the corpus, so it does not follow the leaf/advertised split — but routing
+    through here keeps the one place that spells directory names in this
+    package, and keeps `promote_proposals` honest about where it moves files
+    *to*, which does depend on the layout.
+    """
+    return Path(collection_dir) / STAGING_DIRNAME / ADVERTISED_DIRNAME
 
 
 def skill_dirs(collection_dir: str | os.PathLike) -> list[Path]:

--- a/collections/epigenomics/v1/gate_report.json
+++ b/collections/epigenomics/v1/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-19T22:33:50.917423+00:00",
+  "generated_at": "2026-08-19T23:23:04.047595+00:00",
   "collection_dir": "collections/epigenomics/v1",
   "corpus_path": "collections/epigenomics/v1/corpus.yaml",
   "mode": "strict",

--- a/governance/AUTHORSHIP.md
+++ b/governance/AUTHORSHIP.md
@@ -1,0 +1,107 @@
+# Authorship & co-authorship of contributed skills
+
+Most ASB-Skills are distilled from peer-reviewed method papers, where authorship
+sits with the **paper**. This document defines authorship for the **second intake
+path** — skills a tool's author **contributes or claims** for their own tool
+(`provenance_tier: community`) — and how that authorship is *verified*, *credited*,
+and kept honest under the project's no-self-merge norm.
+
+It complements:
+
+- [`COMMUNITY_SKILLS.md`](COMMUNITY_SKILLS.md) — the curation model these claimed
+  skills travel through (the `proposals/` rail + maintainer merge gate). A claimed
+  skill **is** a community skill; this doc adds the *attribution* layer on top.
+- [`PROVENANCE_TIERS.md`](PROVENANCE_TIERS.md) — `provenance_tier` is **origin**;
+  authorship is **attribution**. A skill is `community` because of where its content
+  came from, and carries an author because a verified person contributed it.
+- [`COI_POLICY.md`](COI_POLICY.md) — the same self-review-is-allowed-with-safeguards
+  spirit that governs co-authored *paper reviews* governs *self-authored skills* here.
+- [`MAINTAINERS.md`](MAINTAINERS.md) — who the independent merge gate is.
+
+## The co-authorship model
+
+A tool's author files a **claim-skill** issue
+([`.github/ISSUE_TEMPLATE/claim-skill.md`](../.github/ISSUE_TEMPLATE/claim-skill.md));
+a maintainer runs the **maintainer-run** `claim-skill` command
+([`collections/metabolomics/v2/commands/claim-skill.md`](../collections/metabolomics/v2/commands/claim-skill.md)),
+which reuses the `propose-skill` flow (normalize → match → ground → stage), writes
+the author into the staged skill, and prepares a reviewable PR. The author reviews
+their own contribution; **a different maintainer merges** (never self-merge); the
+author is then credited. Three properties make this safe and durable:
+
+### 1. Verified identity (credit is never granted to an unverified claim)
+
+Authorship credit is granted **only to a verified identity**, using the **same**
+machinery as curator candidacy (`vet-curator`):
+
+- **L1** — the author's GitHub URL appears in their **ORCID public record**.
+- **L2** — the author's **ORCID is an author on the tool's paper DOI**, via OpenAlex.
+
+If the author is not yet a verified contributor, they complete
+[`CONTRIBUTING.md`](../.github/CONTRIBUTING.md) **Step 0** (a
+`candidates/<handle>.yaml` PR) first; their authorship is credited once that lands.
+Identity verification is a **hard gate** in the claim-skill command — no verified
+identity, no credit.
+
+### 2. Conflict of interest is acknowledged; the maintainer is the independent gate
+
+Authoring a skill for **your own tool** is a conflict of interest, and the author
+**reviewing their own contribution** is a self-review. As in
+[`COI_POLICY.md`](COI_POLICY.md), this is **disclosed, not disqualifying**:
+
+- the COI is disclosed on the claim-skill issue and is visible in the staged PR
+  (author requested as reviewer of their own skill);
+- the **independent gate** is the **merging maintainer**, who must be a *different*
+  person than the author and who judges quality/fit/originality (annotate or merge
+  into an existing skill rather than accepting a near-duplicate);
+- **no self-merge** — the project-wide invariant. CI checks structure only
+  (`check_proposals.py`); merit and the COI judgement are the maintainer's.
+
+### 3. Credit surfaces in three durable places
+
+Once merged, an author's contribution is credited in:
+
+- **`contributors.jsonld`** — the author-credit path of
+  [`scripts/tier_update.py`](../scripts/tier_update.py) increments the contributor's
+  `asb:authored_skills` counter and re-evaluates their tier. This path is
+  independent of the review counters and **never downgrades** an already-higher
+  tier (an authored skill reaches only the *reviewer* entry tier on its own):
+
+  ```bash
+  python scripts/tier_update.py --orcid "<author-ORCID>" \
+      --collection "<slug>" --credit-author \
+      --contributors contributors.jsonld \
+      --criteria "collections/<slug>/<vN>/curator-criteria.yaml"
+  ```
+
+- **The merge commit's `Co-authored-by:` trailer** — `Co-authored-by: <Name>
+  <email>` on the PR's commit, so the contribution shows on the author's GitHub
+  history. The claim-skill command emits this trailer for the merging maintainer.
+
+- **`CITATION.cff`** — at release, collection authorship (the Zenodo author list)
+  is reconciled from `contributors.jsonld`, so a verified skill author appears in
+  the citable record of the release they contributed to.
+
+The author is also written into the **skill's own** `contributors` frontmatter
+block as `role: author` (keys `name`/`role`/`orcid`/`github`; roles validated
+against `VALID_CONTRIBUTOR_ROLES` by `check_proposals.py`), so attribution travels
+with the skill file itself.
+
+## Invariants (summary)
+
+| Concern | Rule | Enforced by |
+|---|---|---|
+| Identity | author credited only after L1+L2 verification | `vet-curator`, claim-skill command (hard gate) |
+| COI | self-authoring/self-review disclosed; merging maintainer is independent | claim-skill command, `MAINTAINERS.md` |
+| Merge | maintainer-only; merger ≠ author; no self-merge | `MAINTAINERS.md`, `CODEOWNERS` |
+| In-skill credit | `contributors` entry `role: author`, well-formed keys | `normalize_skill.contributor_violations`, `check_proposals.py` |
+| Registry credit | `asb:authored_skills` ++ , tier re-evaluated, never downgraded | `scripts/tier_update.py --credit-author` |
+| Commit credit | `Co-authored-by:` trailer on the merge commit | claim-skill command |
+| Licensing | skill prose contributed under **CC-BY-4.0** | claim-skill issue + PR template |
+
+## Licensing of contributed prose
+
+The **skill prose** a contributing author writes (description, body) is contributed
+under **CC-BY-4.0** — the same grant as any community skill
+([`COMMUNITY_SKILLS.md`](COMMUNITY_SKILLS.md)). This is distinct from the
+`license_tier` axis, which describes the **tool the skill grounds on**.

--- a/governance/COMMUNITY_SKILLS.md
+++ b/governance/COMMUNITY_SKILLS.md
@@ -1,0 +1,105 @@
+# Community skills
+
+Most ASB-Skills are distilled from peer-reviewed method papers by the curation
+pipeline (`provenance_tier: literature`). This document defines the **second**
+intake path: skills **contributed or curated outside that pipeline**
+(`provenance_tier: community`). A community skill carries its own attribution, is
+not required to derive from a paper, and is held to the **same structural
+discipline** as a published skill so a maintainer's review is about quality and
+fit — not formatting.
+
+It complements:
+
+- [`PROVENANCE_TIERS.md`](PROVENANCE_TIERS.md) — defines the `community` tier and
+  its enforced invariant (a `related_skills` key must be present; an empty list is
+  allowed). `provenance_tier` is **origin** ("where did the content come from?").
+- [`META_SKILLS.md`](META_SKILLS.md) — the **third** intake path: workflow-level
+  *super-skills* (`skill_kind: super`) auto-synthesized from existing skills
+  (`provenance_tier: synthetic`). They reuse this same proposal rail + maintainer
+  merge gate; only the *creation* is automated synthesis rather than human
+  contribution.
+- [`LICENSE_TIERS.md`](LICENSE_TIERS.md) — the **consumer** axis: a community skill
+  still declares the `license_tier` of the tool it grounds on (`open` /
+  `noncommercial` / `restricted`), independent of its provenance.
+- [`SOURCES.md`](SOURCES.md) — the **scientific** gate for paper-derived sources.
+  Community skills are not anchored to the review series, but the same spirit of
+  auditable, principled inclusion applies.
+
+## The curation model
+
+Community skills move along a one-way **proposal rail** with a human merge gate.
+No contributor self-merges; CI checks structure; a maintainer judges fit.
+
+1. **Open submission.** Anyone may propose a skill. The contributor runs the
+   `propose-skill` command
+   ([`collections/metabolomics/v2/commands/propose-skill.md`](../collections/metabolomics/v2/commands/propose-skill.md)),
+   which normalizes the local skill, matches it against the collection to suggest
+   `related_skills` + `tools_used`, warns about near-duplicates, best-effort grounds
+   it, tiers it `community` / `hold`, and **stages** files via
+   `scripts/propose_skill.py`. Lighter-weight intake (issue first) is described in
+   [`CONTRIBUTING.md`](../.github/CONTRIBUTING.md).
+
+2. **Staging.** Staged proposals land on the proposal rail, never directly in the
+   shipped tree:
+   - `collections/<slug>/v<N>/proposals/skills/<skill-slug>/SKILL.md` — the
+     normalized skill, frontmatter `provenance_tier: community`, `status: hold`.
+   - `collections/<slug>/v<N>/proposals/wave-skills-<date>.yaml` — the proposal
+     ledger (schema `asb-skill-proposals/1.0`), the skill analogue of the paper
+     `wave-*.yaml` ledgers.
+
+3. **CI validation.** On the PR, `scripts/check_proposals.py` (wired into
+   `validate.yml` as the **Proposals gate**) holds every staged
+   `proposals/skills/*/SKILL.md` to the same discipline a published skill must pass:
+   - `metadata.provenance_tier == "community"` **and** a `related_skills` key is
+     present (the community provenance invariant);
+   - top-level `status == "hold"` (the proposal-rail invariant);
+   - description discipline (prefix ∈ {`Use when`, `Reference for`, `Explains`,
+     `Decision support for`}, 50–300 chars, no marketing terms), EDAM IRIs start
+     `http://edamontology.org/`, valid `license_tier`;
+   - every `metadata.tools_used` slug resolves in `tools_index.json`.
+
+   CI checks **structure**, never scientific merit — that is the maintainer's call.
+
+4. **Maintainer merge.** A maintainer (see [`MAINTAINERS.md`](MAINTAINERS.md))
+   reviews the proposal for quality, originality (not a near-duplicate of an
+   existing skill — annotate/merge instead), and fit, then merges. **No self-merge.**
+
+5. **Optional expert attestation.** Stronger trust signals may be attached, but are
+   **not required** to accept a community skill:
+   - an **expert attestation** — a verified domain reviewer (Reviewer tier or above,
+     per [`CONTRIBUTING.md`](../.github/CONTRIBUTING.md)) signs off on the skill via a
+     `reviews/` attestation, the same mechanism used for paper reviews; and/or
+   - a **community signal** — e.g. issue/PR endorsements, downstream use, or a
+     downstream maintainer vouching for the skill.
+
+   These raise confidence and inform promotion priority; their absence does not
+   block acceptance at the `community` tier.
+
+6. **Wave promotion.** Accepted community skills are promoted out of `proposals/`
+   into the shipped collection in **curation waves** (the same batched cadence as
+   paper inclusion). At a wave, a maintainer moves the staged `SKILL.md` into
+   `collections/<slug>/v<N>/skills/<slug>/`, registers it in `skills_index.json` (so
+   it is discoverable and its `tools_used` are reflected in each tool's
+   `used_by_skills`), and the ledger entry's `status` is flipped from `hold` to its
+   accepted state. The skill keeps `provenance_tier: community` — promotion changes
+   its *location and discoverability*, not its origin.
+
+## Invariants (summary)
+
+| Concern | Rule | Enforced by |
+|---|---|---|
+| Origin | `provenance_tier: community` + `related_skills` key present | `check_proposals.py`, `check_provenance_tiers.py` |
+| Rail | `status: hold` while in `proposals/` | `check_proposals.py` |
+| Structure | description / EDAM / `license_tier` discipline | `normalize_skill.frontmatter_violations` |
+| Tools | every `tools_used` slug resolves in `tools_index.json` | `check_proposals.py` |
+| Merge | maintainer-only; no self-merge | `MAINTAINERS.md`, `CODEOWNERS` |
+| Licensing | skill prose contributed under **CC-BY-4.0** | issue + PR template checkbox |
+
+## Licensing of contributed prose
+
+The **skill prose** a contributor writes (description, body) is contributed under
+**CC-BY-4.0**. This is the contributor's grant on their own text and is distinct
+from the `license_tier` axis, which describes the **tool the skill grounds on**.
+The CC-BY-4.0 grant is confirmed via the checkbox on the
+[`propose-skill` issue template](../.github/ISSUE_TEMPLATE/propose-skill.md) and on
+the [pull-request template](../.github/PULL_REQUEST_TEMPLATE.md).

--- a/governance/META_SKILLS.md
+++ b/governance/META_SKILLS.md
@@ -1,0 +1,145 @@
+# Meta-skills (super-skills)
+
+Most ASB-Skills are **single-procedure** skills: one method, one source. A
+**super-skill** (a *meta-skill*) is the workflow level — it **orchestrates** several
+existing sub-skills into a canonical end-to-end pipeline (e.g. "molecular
+networking": feature detection/alignment → spectral similarity/networking →
+annotation/propagation → visualization). It does not re-implement those procedures;
+it sequences them, names the decision points between stages, and points each stage
+at the sub-skill(s) and tool(s) that carry it.
+
+This document defines the super-skill concept (`skill_kind: super` /
+`orchestrates`), the three provenance origins a skill may have, and the
+**open-curation** model that governs how a synthesized super-skill reaches the
+shipped collection. It complements:
+
+- [`PROVENANCE_TIERS.md`](PROVENANCE_TIERS.md) — defines the `synthetic` tier and its
+  enforced invariant (`metadata.synthesized_from` non-empty). `provenance_tier` is
+  **origin** ("where did the content come from?"); a super-skill is `synthetic` when
+  it is auto-derived from other skills.
+- [`COMMUNITY_SKILLS.md`](COMMUNITY_SKILLS.md) — the contributed-skill intake path.
+  Super-skills reuse the **same proposal rail + maintainer merge gate**; only the
+  *creation* differs (automated synthesis vs. a human contributor).
+- [`LICENSE_TIERS.md`](LICENSE_TIERS.md) — the **consumer** axis: a super-skill still
+  declares the `license_tier` of the tools its orchestrated stages ground on (`open`
+  / `noncommercial` / `restricted`), independent of its provenance.
+
+## What makes a skill a super-skill
+
+A super-skill is distinguished by two `metadata` fields, both checked by the
+proposals gate ([`check_proposals.py`](../scripts/check_proposals.py)):
+
+| Field | Meaning | Invariant |
+|---|---|---|
+| `metadata.skill_kind` | `skill` (default, stands alone) or `super` (orchestrates others) | must be in {`skill`, `super`} |
+| `metadata.orchestrates` | the ordered sub-skill slugs the pipeline sequences | for `super`: non-empty list, **every slug resolves in `skills_index.json`** |
+
+A `super` skill is usually `provenance_tier: synthetic` (it is derived from the
+skills it orchestrates), so its `metadata.synthesized_from` lists those same
+sub-skill slugs. When the canonical pipeline is instead **grounded in a review
+article** — a survey/tutorial that defines the workflow's stages — the super-skill
+is `provenance_tier: literature` with that review's DOI in `metadata.dois` and
+`derived_from` (see *The three provenance origins* below). Either way the body is
+**genuine synthesis** — it writes the real ordered workflow and cites each stage's
+sub-skills by their actual slug; it never fabricates stages, slugs, tools, or DOIs.
+
+## The three provenance origins
+
+`provenance_tier` answers *where did this skill's content come from?* (see
+[`PROVENANCE_TIERS.md`](PROVENANCE_TIERS.md)). The three origins:
+
+- **`synthetic`** — *auto-derived from other skills.* A super-skill synthesized by
+  the [`synthesize-meta-skill`](../collections/metabolomics/v2/commands/synthesize-meta-skill.md)
+  command lands here: the clustering + frontmatter assembly + staging are
+  deterministic (`scripts/synthesize_meta_skill.py`), the identify-the-pipeline and
+  body-writing are agentic. Invariant: `metadata.synthesized_from` non-empty.
+- **`community`** — *hand-written and contributed* outside the literature pipeline
+  (see [`COMMUNITY_SKILLS.md`](COMMUNITY_SKILLS.md)). Invariant: a `related_skills`
+  key is present.
+- **`literature`** — *distilled from one or more peer-reviewed source papers* by the
+  curation pipeline (the origin of every shipped single-procedure skill today).
+  Invariant: ≥1 source DOI. A super-skill lands here when its **pipeline is grounded
+  in a review article** rather than merely composed from existing skills: the
+  `synthesize-meta-skill` command is given a `--review-doi`, and `meta_frontmatter`
+  sets `provenance_tier: literature`, `metadata.dois: [<review-doi>]`, and
+  `derived_from: [{doi: <review-doi>}]` (while keeping `skill_kind: super` +
+  `orchestrates`). This is a **review-grounded meta-skill** — the survey defines the
+  canonical stages, the sub-skills carry each stage.
+
+A super-skill therefore has **three** possible origins: `synthetic` (composed from
+the orchestrated skills, the default), `literature` (review-grounded, via a review
+DOI), or `community` (a hand-authored workflow skill contributed outside the
+pipeline). `skill_kind` (`skill` / `super`) is **orthogonal** to provenance: a
+`super` skill is usually `synthetic`, but it can be `literature` (review-grounded)
+or `community` and still set `skill_kind: super`. The two precedents below are
+hand-authored meta-skills that this rail generalizes into a synthesizable,
+openly-curated form.
+
+## The open-curation model
+
+A synthesized super-skill moves along the **same one-way proposal rail** as a
+community skill, with a human merge gate. **The synthesis is never auto-promoted.**
+
+1. **Automated synthesis (creation).** A maintainer or contributor runs the
+   `synthesize-meta-skill` command with a pipeline seed (name + short description).
+   It clusters the candidate sub-skills + tools, the agent identifies the canonical
+   ordered pipeline and writes the orchestration body, then it stages the proposal
+   `provenance_tier: synthetic`, `skill_kind: super`, `status: hold`. The command
+   **never opens or merges the PR** — it hands over the exact fork-and-PR commands to
+   review and fire.
+
+2. **Staging.** The synthesized skill lands on the proposal rail, never directly in
+   the shipped tree:
+   - `collections/<slug>/v<N>/proposals/skills/<skill-slug>/SKILL.md` — the
+     synthesized super-skill, frontmatter `provenance_tier: synthetic`,
+     `skill_kind: super`, `status: hold`.
+   - `collections/<slug>/v<N>/proposals/wave-meta-skills-<date>.yaml` — the proposal
+     ledger (its own wave, distinct from the community `wave-skills-<date>.yaml`).
+
+3. **CI validation.** On the PR, `scripts/check_proposals.py` (the **Proposals gate**)
+   holds the staged skill to the same discipline a published skill must pass, plus the
+   provenance + super invariants (reusing the `scripts/provenance_tier.py` kernel): a
+   `synthetic` proposal needs non-empty `metadata.synthesized_from`; a `literature`
+   (review-grounded) proposal needs ≥1 `metadata.dois`; a `community` proposal needs a
+   `related_skills` key. For `super` (any origin): `metadata.skill_kind ∈ {skill,
+   super}`, `metadata.orchestrates` non-empty, and **every orchestrated slug resolves
+   in `skills_index.json`**. CI checks **structure**, never scientific merit.
+
+4. **Open community/expert review.** The public PR waits for open review — the same
+   community-signal / expert-attestation mechanisms described in
+   [`COMMUNITY_SKILLS.md`](COMMUNITY_SKILLS.md) §5. A synthesized pipeline is held to
+   the same bar as a contributed one: is the workflow honest, are the stages and slugs
+   real, is it a genuine pipeline rather than a near-duplicate of an existing
+   super-skill (annotate/extend instead).
+
+5. **Maintainer merge.** A maintainer (see [`MAINTAINERS.md`](MAINTAINERS.md)) makes
+   the final merge decision after curation. **No self-merge** — and the command never
+   auto-merges.
+
+6. **Wave promotion.** Accepted super-skills are promoted out of `proposals/` into the
+   shipped collection in curation waves (a maintainer wave action), the same batched
+   cadence as paper and community-skill inclusion. The skill keeps
+   `provenance_tier: synthetic` — promotion changes its *location and discoverability*,
+   not its origin.
+
+## Precedent
+
+`skills/asb-metabolomics/SKILL.md` (the collection guide + license-tier governance
+meta-skill) and `skills/_router/SKILL.md` (the routing meta-skill) are **hand-authored
+meta-skills** already shipped in the collection. The `synthesize-meta-skill` rail
+generalizes that pattern into a synthesizable, openly-curated form: instead of a
+maintainer hand-writing each workflow-level skill, the pipeline is clustered and
+drafted by synthesis, then held to the same open-review + maintainer-merge gate as
+any other proposal.
+
+## Invariants (summary)
+
+| Concern | Rule | Enforced by |
+|---|---|---|
+| Origin | `synthetic` ⇒ `metadata.synthesized_from` non-empty; `literature` (review-grounded) ⇒ ≥1 `metadata.dois`; `community` ⇒ `related_skills` key | `check_proposals.py`, `check_provenance_tiers.py` |
+| Kind | `metadata.skill_kind ∈ {skill, super}` (default `skill`) | `check_proposals.py` |
+| Orchestration | for `super`: `metadata.orchestrates` non-empty + every slug in `skills_index.json` | `check_proposals.py` |
+| Rail | `status: hold` while in `proposals/` | `check_proposals.py` |
+| Structure | description / EDAM / `license_tier` discipline | `normalize_skill.frontmatter_violations` |
+| Tools | every `tools_used` slug resolves in `tools_index.json` | `check_proposals.py` |
+| Merge | maintainer-only; no self-merge; never auto-promoted | `MAINTAINERS.md`, `CODEOWNERS` |

--- a/governance/PROVENANCE_TIERS.md
+++ b/governance/PROVENANCE_TIERS.md
@@ -1,0 +1,63 @@
+# Provenance tiers
+
+`provenance_tier` answers an origin question — *where did this skill's content come
+from?* — and is **orthogonal** to the consumer `license_tier`
+([`LICENSE_TIERS.md`](LICENSE_TIERS.md), *what may I do with the tool this skill
+grounds on?*) and to the paper open-access axis (`access.type`, *may we
+redistribute the source?*). A single skill carries one value on each axis; they do
+not constrain each other.
+
+| Tier | Meaning | Invariant (enforced) |
+|---|---|---|
+| `literature` | Synthesized from one or more peer-reviewed source papers | requires ≥1 `doi` |
+| `synthetic` | Derived from other skills (composed / specialized / merged), not from a paper directly | requires `synthesized_from` (the source skill slugs) |
+| `community` | Contributed or curated outside the ASB literature pipeline | requires a `related_skills` key to be present (an empty list is allowed) |
+
+The canonical kernel is `scripts/provenance_tier.py` (`VALID`, `DEFAULT="literature"`,
+`validate_entry(...)`); the CI gate `scripts/check_provenance_tiers.py` enforces both
+the per-tier invariant above and that each `SKILL.md` frontmatter
+`metadata.provenance_tier` equals the `skills_index.json` value.
+
+## Current state
+
+Every shipped skill in `collections/metabolomics/v2` is **`literature`** — each is
+distilled from a peer-reviewed method paper and carries ≥1 source DOI. The
+`synthetic` and `community` tiers exist so the schema can admit those skills later
+without a migration; no skill carries them yet.
+
+The field is set **field-only** — there is no in-body banner for provenance (unlike
+the non-open `license_tier` banner). `provenance_tier` lives in
+`skills_index.json`, in `kb_bundle.json` skill records, and in each `SKILL.md`
+frontmatter `metadata.provenance_tier`.
+
+## Orthogonality to `license_tier`
+
+The two axes are independent and answer different questions:
+
+- `provenance_tier` (this file) — **origin**: was the content distilled from a
+  paper, composed from other skills, or community-contributed?
+- `license_tier` ([`LICENSE_TIERS.md`](LICENSE_TIERS.md)) — **permission**: may a
+  consumer use the underlying tool commercially (`open` / `noncommercial` /
+  `restricted`)?
+
+A `literature` skill can ground on an `open`, `noncommercial`, or `restricted`
+tool; a future `community` skill could ground on an `open` tool. Neither value is
+derivable from the other, so they are stored and gated separately.
+
+## Forward path — admitting `synthetic` and `community` skills
+
+The tiers are wired end-to-end (kernel + propagation + gate) ahead of need so the
+first non-`literature` skill is a data change, not a code change:
+
+- **`synthetic`** — when a skill is composed from existing skills (e.g. a higher-level
+  workflow stitched from several procedures), stamp `provenance_tier: synthetic` and
+  populate `synthesized_from:` with the contributing skill slugs. The gate then
+  requires that key; the skill needs no source DOI.
+- **`community`** — when a skill is contributed or curated outside the ASB pipeline
+  (see [`CONTRIBUTING`](../.github/CONTRIBUTING.md) and
+  [`SOURCES.md`](SOURCES.md)), stamp `provenance_tier: community` and include a
+  `related_skills:` key (empty list allowed) so the lineage is explicit. Such skills
+  carry their own attribution and are not required to derive from a paper.
+
+In all cases the invariant in the table above is what the CI gate checks; the
+default for backfill remains `literature`.

--- a/scripts/build_related_skills.py
+++ b/scripts/build_related_skills.py
@@ -1,0 +1,314 @@
+"""Embedding similarity graph — precompute ``related_skills`` per skill (Task B4).
+
+A complement to the lexical ``skill_match`` core: instead of TF-IDF cosine, this
+builds a *semantic* similarity graph from sentence-transformer embeddings of each
+skill's :func:`skill_match.skill_doc` text, and writes the resulting top-N
+neighbour lists into ``skills_index.json`` + ``kb_bundle.json``.
+
+Two backends, one injectable interface (``embedder_for``):
+
+* **local** — pinned MiniLM (``sentence-transformers``, ``[embed]`` extra):
+  lightweight, offline, no key.
+* **openai** — ``text-embedding-3-large`` (``openai``, ``[embed-openai]`` extra):
+  the advanced backend, the *same* model Perspicacité uses (3072-dim); needs
+  ``OPENAI_API_KEY``. The CLI defaults to this when a key is present, else local.
+
+Design constraints (see the operationalize-pipelines plan):
+
+* **Optional dependencies, lazy import.** Both backend builders import their
+  package *inside* the function, so this module imports fine without either extra,
+  and the pure graph/IO helpers (:func:`related_map`, :func:`embed_skills`,
+  :func:`build`) work with any injected embedder.
+* **No live model/network in tests.** Every entry point takes an injected
+  ``embedder`` (a ``callable(list[str]) -> list[list[float]]``); only the CLI
+  reaches for :func:`default_embedder`.
+* **Idempotent, indent-preserving writes.** Reuses
+  ``propagate_license_tiers.detect_indent`` and writes a file only when its
+  serialization changes.
+* **No git/gh side effects, no ``Date.now``.**
+
+The real 5,865-skill precompute (``pip install '.[embed]'`` then
+``python -m scripts.build_related_skills --collection collections/metabolomics/v2``)
+is a maintainer operation. Until it is run, ``related_skills`` is absent and the
+``check_related_skills`` gate passes vacuously — which is correct.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.propagate_license_tiers import detect_indent
+from scripts.skill_match import skill_doc
+
+# Pinned model: small, fast, widely cached. Behind the [embed] extra.
+_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+# Defaults for the similarity graph.
+DEFAULT_TOP_N = 8
+DEFAULT_THRESHOLD = 0.3
+
+
+def default_embedder():
+    """Return ``embed(texts) -> list[list[float]]`` backed by a pinned model.
+
+    ``sentence-transformers`` is imported here, *not* at module import time, so
+    this module loads without the ``[embed]`` extra. Calling this function
+    without the extra installed raises ``ImportError`` with install guidance.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "default_embedder requires the optional 'embed' extra: "
+            "pip install '.[embed]'  (sentence-transformers)"
+        ) from e
+
+    model = SentenceTransformer(_MODEL_NAME)
+
+    def embed(texts):
+        # convert_to_numpy=False keeps a plain list-of-lists return shape.
+        vecs = model.encode(list(texts), convert_to_numpy=False)
+        return [[float(x) for x in v] for v in vecs]
+
+    return embed
+
+
+_OPENAI_MODEL = "text-embedding-3-large"
+
+
+def openai_embedder(model=_OPENAI_MODEL, *, batch_size=256):
+    """Return ``embed(texts) -> list[list[float]]`` backed by the OpenAI
+    embeddings API (``text-embedding-3-large`` by default — the *same* model
+    Perspicacité uses, 3072-dim). Reads ``OPENAI_API_KEY`` from the environment.
+
+    ``openai`` is imported here, *not* at module import time, so this module loads
+    without it; calling without the package or a key raises with guidance.
+    """
+    try:
+        from openai import OpenAI
+    except ImportError as e:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "openai_embedder requires the optional 'embed-openai' extra: "
+            "pip install '.[embed-openai]'  (openai)"
+        ) from e
+    import os
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("openai_embedder requires OPENAI_API_KEY in the environment")
+    client = OpenAI()
+
+    def embed(texts):
+        texts = list(texts)
+        out: list[list[float]] = []
+        for i in range(0, len(texts), batch_size):
+            resp = client.embeddings.create(model=model, input=texts[i : i + batch_size])
+            out.extend([list(d.embedding) for d in resp.data])
+        return out
+
+    return embed
+
+
+def embedder_for(backend, **kwargs):
+    """Resolve a backend name to an embedder.
+
+    ``local`` — pinned MiniLM (offline, no key, lightweight);
+    ``openai`` — ``text-embedding-3-large`` (advanced, Perspicacité-aligned, needs
+    ``OPENAI_API_KEY``).
+    """
+    if backend == "local":
+        return default_embedder()
+    if backend == "openai":
+        return openai_embedder(**kwargs)
+    raise ValueError(f"unknown embedder backend {backend!r} (use 'local' or 'openai')")
+
+
+def default_backend():
+    """Prefer the advanced OpenAI backend when a key is present, else lightweight local."""
+    import os
+
+    return "openai" if os.environ.get("OPENAI_API_KEY") else "local"
+
+
+def embed_skills(skills_index, *, embedder):
+    """Embed each skill's document text into a ``{slug: vector}`` map.
+
+    Text per skill is :func:`skill_match.skill_doc` (name + description + tools +
+    EDAM topics + techniques). ``embedder`` is a ``callable(list[str]) ->
+    list[list[float]]`` (injected — never the live model in tests). Entries
+    without a ``slug`` are skipped.
+    """
+    entries = [e for e in (skills_index or []) if e.get("slug")]
+    if not entries:
+        return {}
+    docs = [skill_doc(e) for e in entries]
+    vectors = embedder(docs)
+    return {e["slug"]: list(v) for e, v in zip(entries, vectors)}
+
+
+def _cosine(a, b) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    if dot == 0.0:
+        return 0.0
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def related_map(vectors, *, top_n=DEFAULT_TOP_N, threshold=DEFAULT_THRESHOLD):
+    """Cosine top-N neighbour graph from a ``{slug: vector}`` map.
+
+    For each slug, returns the ``top_n`` other slugs with the highest cosine
+    similarity that is strictly above ``threshold``, excluding self. Ties in
+    similarity are broken by slug ascending (deterministic output). Returns
+    ``{slug: [slug, ...]}``.
+
+    Uses a vectorized numpy path when available — O(n^2 * d) pure Python does not
+    scale to thousands of high-dimensional vectors — and falls back to the
+    pure-Python implementation otherwise. Both produce identical output.
+    """
+    slugs = sorted(vectors)
+    if not slugs:
+        return {}
+    try:
+        import numpy as np
+    except ImportError:  # pragma: no cover - exercised when numpy is absent
+        return _related_map_py(slugs, vectors, top_n=top_n, threshold=threshold)
+
+    matrix = np.asarray([vectors[s] for s in slugs], dtype=float)
+    matrix[~np.isfinite(matrix)] = 0.0  # drop degenerate (NaN/inf) embedding values
+    norms = np.linalg.norm(matrix, axis=1)
+    norms[norms == 0.0] = 1.0  # zero vector -> all-zero row -> cosine 0 (matches _cosine)
+    unit = matrix / norms[:, None]
+    with np.errstate(invalid="ignore", divide="ignore", over="ignore"):
+        sims = unit @ unit.T
+    sims[~np.isfinite(sims)] = -np.inf  # degenerate similarities are never neighbours
+    np.fill_diagonal(sims, -np.inf)  # exclude self
+    out: dict[str, list[str]] = {}
+    for i, s in enumerate(slugs):
+        row = sims[i]
+        cand = np.where(row > threshold)[0]  # ascending index == ascending slug
+        # stable sort by descending similarity; equal sims keep ascending-slug order
+        order = cand[np.argsort(-row[cand], kind="stable")]
+        out[s] = [slugs[j] for j in order[:top_n]]
+    return out
+
+
+def _related_map_py(slugs, vectors, *, top_n, threshold):
+    """Pure-Python cosine top-N (numpy-free fallback)."""
+    out: dict[str, list[str]] = {}
+    for s in slugs:
+        vs = vectors[s]
+        scored = []
+        for other in slugs:
+            if other == s:
+                continue
+            sim = _cosine(vs, vectors[other])
+            if sim > threshold:
+                scored.append((sim, other))
+        # highest similarity first; tie-break by slug ascending.
+        scored.sort(key=lambda p: (-p[0], p[1]))
+        out[s] = [slug for _, slug in scored[:top_n]]
+    return out
+
+
+def _load_json(path):
+    raw = path.read_text(encoding="utf-8")
+    return json.loads(raw), detect_indent(raw)
+
+
+def _write_json_if_changed(path, obj, indent) -> bool:
+    """Write ``obj`` only when the serialization differs. Returns True if written."""
+    new = json.dumps(obj, indent=indent, ensure_ascii=False)
+    if path.exists() and path.read_text(encoding="utf-8") == new:
+        return False
+    path.write_text(new, encoding="utf-8")
+    return True
+
+
+def build(collection_dir, *, embedder=None, top_n=DEFAULT_TOP_N,
+          threshold=DEFAULT_THRESHOLD) -> dict:
+    """Compute + write the ``related_skills`` graph for a collection.
+
+    Embeds every skill in ``skills_index.json`` (via ``embedder``, defaulting to
+    :func:`default_embedder` when none is injected), builds the cosine top-N
+    graph, and writes each neighbour list into both the ``skills_index.json``
+    entry and the matching ``kb_bundle.json['skills'][slug]`` record. Writes are
+    indent-preserving and idempotent (a file unchanged in content is not
+    rewritten). Returns ``{"count": int, "written": bool}``.
+    """
+    if embedder is None:
+        embedder = default_embedder()
+
+    d = pathlib.Path(collection_dir)
+    si_path = d / "skills_index.json"
+    kb_path = d / "kb_bundle.json"
+
+    si, si_indent = _load_json(si_path)
+    kb, kb_indent = _load_json(kb_path)
+
+    vectors = embed_skills(si, embedder=embedder)
+    rel = related_map(vectors, top_n=top_n, threshold=threshold)
+
+    for entry in si:
+        slug = entry.get("slug")
+        if slug in rel:
+            entry["related_skills"] = rel[slug]
+
+    kb_skills = kb.get("skills")
+    if isinstance(kb_skills, dict):
+        for slug, neighbours in rel.items():
+            rec = kb_skills.get(slug)
+            if isinstance(rec, dict):
+                rec["related_skills"] = neighbours
+
+    wrote_si = _write_json_if_changed(si_path, si, si_indent)
+    wrote_kb = _write_json_if_changed(kb_path, kb, kb_indent)
+
+    return {"count": len(rel), "written": bool(wrote_si or wrote_kb)}
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection", required=True,
+        help="collection root (skills_index.json + kb_bundle.json)",
+    )
+    ap.add_argument(
+        "--top-n", type=int, default=DEFAULT_TOP_N,
+        help=f"neighbours per skill (default {DEFAULT_TOP_N})",
+    )
+    ap.add_argument(
+        "--threshold", type=float, default=DEFAULT_THRESHOLD,
+        help=f"minimum cosine similarity (default {DEFAULT_THRESHOLD})",
+    )
+    ap.add_argument(
+        "--backend", choices=("local", "openai"), default=None,
+        help="embedder: 'local' (MiniLM, offline) or 'openai' (text-embedding-3-large). "
+             "Default: openai when OPENAI_API_KEY is set, else local.",
+    )
+    a = ap.parse_args(argv)
+
+    # A live embedder (model / API) is constructed only here, never in build's
+    # importable path or in tests.
+    backend = a.backend or default_backend()
+    res = build(a.collection, embedder=embedder_for(backend), top_n=a.top_n,
+                threshold=a.threshold)
+    print(json.dumps({"backend": backend, **res}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_proposals.py
+++ b/scripts/check_proposals.py
@@ -1,0 +1,181 @@
+"""CI gate: every staged skill proposal is structurally valid.
+
+Validates each ``proposals/skills/*/SKILL.md`` against the SAME discipline a
+published skill must satisfy, plus the proposal invariants, so a maintainer's
+review is about quality/fit — not structure. A staged proposal is valid under ANY
+of the three provenance origins (reusing the ``scripts.provenance_tier`` kernel):
+
+* **community** — ``metadata.provenance_tier == "community"`` and a
+  ``related_skills`` key is present (the community provenance invariant);
+* **synthetic** — ``metadata.provenance_tier == "synthetic"`` and
+  ``metadata.synthesized_from`` is a non-empty list (auto-derived from other
+  skills; see governance/PROVENANCE_TIERS.md);
+* **literature** — ``metadata.provenance_tier == "literature"`` and
+  ``metadata.dois`` carries >=1 source DOI (e.g. a review-grounded super-skill
+  whose pipeline is distilled from a review article).
+
+For every staged skill, regardless of origin:
+
+* top-level ``status == "hold"`` (the proposal-rail invariant);
+* ``normalize_skill.frontmatter_violations`` is empty (description discipline,
+  EDAM IRI shape, valid ``license_tier``);
+* every ``metadata.tools_used`` slug resolves in ``tools_index.json``;
+* ``metadata.skill_kind`` ∈ {``skill``, ``super``} (default ``skill`` when
+  absent). A ``super`` skill orchestrates sub-skills: ``metadata.orchestrates``
+  must be a non-empty list and EVERY orchestrated slug must resolve to a real
+  skill in ``skills_index.json``.
+* an OPTIONAL top-level ``contributors`` block (co-authorship attribution); when
+  present each entry must be a mapping with a non-empty ``name`` and a ``role``
+  ∈ {``author``, ``reviewer``, ``curator``}. Absence is fine (not required).
+
+A collection with no ``proposals/`` (or no staged skills) yields no violations.
+``main`` exits 1 on any violation, 0 otherwise. Mirrors
+scripts/check_tools_index.py and scripts/check_provenance_tiers.py.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.normalize_skill import contributor_violations, frontmatter_violations
+from scripts.provenance_tier import validate_entry as validate_provenance
+
+# A super-skill orchestrates other skills; a plain skill stands alone.
+VALID_SKILL_KINDS = {"skill", "super"}
+DEFAULT_SKILL_KIND = "skill"
+
+
+def check_collection(collection_dir) -> list:
+    d = pathlib.Path(collection_dir)
+    violations: list = []
+
+    skills_dir = d / "proposals" / "skills"
+    if not skills_dir.is_dir():
+        return violations
+
+    md_files = sorted(skills_dir.glob("*/SKILL.md"))
+    if not md_files:
+        return violations
+
+    # tool slugs available to resolve tools_used against.
+    tool_slugs: set = set()
+    tools_path = d / "tools_index.json"
+    if tools_path.is_file():
+        tools = json.loads(tools_path.read_text(encoding="utf-8"))
+        tool_slugs = {t.get("slug") for t in tools}
+
+    # skill slugs available to resolve a super-skill's orchestrates against.
+    skill_slugs: set = set()
+    skills_path = d / "skills_index.json"
+    if skills_path.is_file():
+        idx = json.loads(skills_path.read_text(encoding="utf-8"))
+        skill_slugs = {s.get("slug") for s in idx}
+
+    for md in md_files:
+        slug = md.parent.name
+        text = md.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            violations.append(f"{md}: no frontmatter block")
+            continue
+        try:
+            fm = yaml.safe_load(text.split("---\n", 2)[1]) or {}
+        except yaml.YAMLError as e:
+            violations.append(f"{md}: invalid frontmatter YAML: {e}")
+            continue
+        if not isinstance(fm, dict):
+            violations.append(f"{md}: frontmatter is not a mapping")
+            continue
+
+        meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+
+        # provenance invariant: valid under community, synthetic, OR literature
+        # (review-grounded super-skills) origin. Reuses the provenance_tier kernel
+        # semantics: literature ⇒ >=1 doi, synthetic ⇒ synthesized_from,
+        # community ⇒ related_skills key present.
+        prov = meta.get("provenance_tier")
+        prov_violations = validate_provenance(
+            prov,
+            dois=meta.get("dois"),
+            synthesized_from=meta.get("synthesized_from"),
+            related_skills=fm.get("related_skills") if "related_skills" in fm else None,
+        )
+        for msg in prov_violations:
+            violations.append(f"{md}: {msg}")
+
+        # skill_kind invariant (default 'skill' when absent); a 'super' skill
+        # must orchestrate a non-empty list of resolvable sub-skill slugs.
+        kind = meta.get("skill_kind", DEFAULT_SKILL_KIND)
+        if kind not in VALID_SKILL_KINDS:
+            violations.append(
+                f"{md}: metadata.skill_kind {kind!r} not in "
+                f"{sorted(VALID_SKILL_KINDS)}"
+            )
+        elif kind == "super":
+            orchestrates = meta.get("orchestrates")
+            if not (isinstance(orchestrates, list) and orchestrates):
+                violations.append(
+                    f"{md}: super skill requires non-empty metadata.orchestrates list"
+                )
+            else:
+                for ref in orchestrates:
+                    if ref not in skill_slugs:
+                        violations.append(
+                            f"{md}: orchestrates {ref!r} not in skills_index.json"
+                        )
+
+        # proposal-rail invariant
+        status = fm.get("status")
+        if status != "hold":
+            violations.append(f"{md}: status {status!r} != 'hold'")
+
+        # description + EDAM + license_tier discipline (CI parity)
+        for msg in frontmatter_violations(fm):
+            violations.append(f"{md}: {msg}")
+
+        # tools_used slugs must resolve in the tool catalog
+        for ref in meta.get("tools_used") or []:
+            if ref not in tool_slugs:
+                violations.append(
+                    f"{md}: tools_used {ref!r} not in tools_index.json"
+                )
+
+        # contributors (co-authorship attribution) — OPTIONAL; validate shape
+        # only when present (top-level key; absence is fine).
+        if "contributors" in fm:
+            for msg in contributor_violations(fm.get("contributors")):
+                violations.append(f"{md}: {msg}")
+
+    return violations
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        print("usage: check_proposals <collection_dir> [...]", file=sys.stderr)
+        return 2
+    failed = False
+    for col in argv:
+        v = check_collection(col)
+        if v:
+            failed = True
+            print(f"FAIL {col}:")
+            for x in v:
+                print(f"  - {x}")
+        else:
+            print(f"OK   {col}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_provenance_tiers.py
+++ b/scripts/check_provenance_tiers.py
@@ -1,0 +1,83 @@
+"""CI gate: every skills_index entry carries a valid provenance_tier (per
+scripts.provenance_tier.validate_entry), and each SKILL.md
+``metadata.provenance_tier`` matches its skills_index entry. Exit 1 on
+violations. Mirrors scripts/check_license_tiers.py.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.provenance_tier import validate_entry
+
+
+def check_collection(collection_dir) -> list[str]:
+    d = pathlib.Path(collection_dir)
+    violations: list[str] = []
+
+    si = json.loads((d / "skills_index.json").read_text(encoding="utf-8"))
+    # Build slug→index_tier map for cross-check against SKILL.md frontmatter.
+    slug_to_index_tier: dict[str, str] = {}
+    for e in si:
+        slug = e.get("slug")
+        tier = e.get("provenance_tier")
+        for msg in validate_entry(
+            tier,
+            dois=e.get("dois"),
+            synthesized_from=e.get("synthesized_from"),
+            related_skills=e.get("related_skills"),
+        ):
+            violations.append(f"skills_index {slug!r}: {msg}")
+        if not validate_entry(tier, dois=e.get("dois")):
+            slug_to_index_tier[slug] = tier
+
+    for md in (d / "skills").glob("*/SKILL.md"):
+        text = md.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            continue
+        fm = yaml.safe_load(text.split("---\n", 2)[1]) or {}
+        slug = md.parent.name
+        if slug not in slug_to_index_tier:
+            continue
+        fm_tier = (fm.get("metadata") or {}).get("provenance_tier")
+        index_tier = slug_to_index_tier[slug]
+        if fm_tier is None:
+            violations.append(f"{md}: metadata.provenance_tier missing")
+        elif fm_tier != index_tier:
+            violations.append(
+                f"{md}: metadata.provenance_tier {fm_tier!r} != skills_index {index_tier!r}"
+            )
+    return violations
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        print("usage: check_provenance_tiers <collection_dir> [...]", file=sys.stderr)
+        return 2
+    failed = False
+    for col in argv:
+        v = check_collection(col)
+        if v:
+            failed = True
+            print(f"FAIL {col}:")
+            for x in v:
+                print(f"  - {x}")
+        else:
+            print(f"OK   {col}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_related_skills.py
+++ b/scripts/check_related_skills.py
@@ -1,0 +1,81 @@
+"""CI gate: every ``related_skills`` reference resolves to a real skill.
+
+The embedding similarity graph (scripts.build_related_skills) writes a
+``related_skills`` neighbour list onto each ``skills_index.json`` entry. This gate
+checks referential integrity: every slug listed in any entry's ``related_skills``
+must itself be a slug present in ``skills_index.json``.
+
+The field is *optional* — it is absent until a maintainer runs the
+embedding precompute (``pip install '.[embed]'`` then
+``python -m scripts.build_related_skills``). A collection with no
+``related_skills`` anywhere (the default real-data state) yields no violations,
+so the gate passes vacuously, which is correct.
+
+``main`` exits 1 on any dangling reference, 0 otherwise. Mirrors
+scripts/check_proposals.py and scripts/check_provenance_tiers.py.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def check_collection(collection_dir) -> list[str]:
+    d = pathlib.Path(collection_dir)
+    violations: list[str] = []
+
+    si_path = d / "skills_index.json"
+    if not si_path.is_file():
+        return violations
+
+    si = json.loads(si_path.read_text(encoding="utf-8"))
+    if isinstance(si, dict):
+        si = si.get("skills") or si.get("entries") or []
+    if not isinstance(si, list):
+        return violations
+
+    known = {e.get("slug") for e in si if isinstance(e, dict)}
+
+    for entry in si:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("slug")
+        related = entry.get("related_skills")
+        if related is None:
+            continue
+        if not isinstance(related, list):
+            violations.append(
+                f"skills_index {slug!r}: related_skills is not a list"
+            )
+            continue
+        for ref in related:
+            if ref not in known:
+                violations.append(
+                    f"skills_index {slug!r}: related_skills {ref!r} "
+                    f"not in skills_index.json"
+                )
+
+    return violations
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        print("usage: check_related_skills <collection_dir> [...]", file=sys.stderr)
+        return 2
+    failed = False
+    for col in argv:
+        v = check_collection(col)
+        if v:
+            failed = True
+            print(f"FAIL {col}:")
+            for x in v:
+                print(f"  - {x}")
+        else:
+            print(f"OK   {col}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tools_index.py
+++ b/scripts/check_tools_index.py
@@ -1,0 +1,87 @@
+"""CI gate: the enriched tool catalog is internally consistent. Verifies that
+every tool ``license_tier`` is valid, every skill ``tools_used`` slug resolves to
+a real tool, and every tool ``used_by_skills`` slug resolves to a real skill.
+Exit 1 on violations. Mirrors scripts/check_license_tiers.py and
+scripts/check_provenance_tiers.py.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import yaml
+
+_VALID = {"open", "noncommercial", "restricted"}
+
+
+def check_collection(collection_dir) -> list[str]:
+    d = pathlib.Path(collection_dir)
+    violations: list[str] = []
+
+    tools = json.loads((d / "tools_index.json").read_text(encoding="utf-8"))
+    skills = json.loads((d / "skills_index.json").read_text(encoding="utf-8"))
+
+    tool_slugs = {t.get("slug") for t in tools}
+    skill_slugs = {s.get("slug") for s in skills}
+    tier_by_slug = {t.get("slug"): t.get("license_tier") for t in tools}
+
+    # Every tool license_tier is valid; every used_by_skills slug resolves.
+    for t in tools:
+        slug = t.get("slug")
+        if t.get("license_tier") not in _VALID:
+            violations.append(f"tools_index {slug!r}: missing/invalid license_tier")
+        for ref in t.get("used_by_skills") or []:
+            if ref not in skill_slugs:
+                violations.append(
+                    f"tools_index {slug!r}: used_by_skills {ref!r} not in skills_index"
+                )
+
+    # Per-tool YAML license_tier must equal its tools_index license_tier.
+    # Tools that have no tools/<slug>.yaml are skipped (not every tool has one).
+    tools_dir = d / "tools"
+    if tools_dir.is_dir():
+        for yaml_path in sorted(tools_dir.glob("*.yaml")):
+            slug = yaml_path.stem
+            if slug not in tier_by_slug:
+                continue
+            rec = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+            yaml_tier = rec.get("license_tier")
+            if yaml_tier != tier_by_slug[slug]:
+                violations.append(
+                    f"tools/{slug}.yaml: license_tier {yaml_tier!r} != "
+                    f"tools_index {tier_by_slug[slug]!r}"
+                )
+
+    # Every skill tools_used slug resolves to a real tool.
+    for s in skills:
+        slug = s.get("slug")
+        for ref in s.get("tools_used") or []:
+            if ref not in tool_slugs:
+                violations.append(
+                    f"skills_index {slug!r}: tools_used {ref!r} not in tools_index"
+                )
+
+    return violations
+
+
+def main(argv=None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        print("usage: check_tools_index <collection_dir> [...]", file=sys.stderr)
+        return 2
+    failed = False
+    for col in argv:
+        v = check_collection(col)
+        if v:
+            failed = True
+            print(f"FAIL {col}:")
+            for x in v:
+                print(f"  - {x}")
+        else:
+            print(f"OK   {col}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/enrich_tool_yaml.py
+++ b/scripts/enrich_tool_yaml.py
@@ -1,0 +1,115 @@
+"""Propagate per-tool license fields from ``tools_index.json`` into the LinkML
+per-tool records ``tools/<slug>.yaml``.
+
+``tools_index.json`` already carries ``license_tier`` / ``license`` /
+``license_detection`` (written by ``enrich_tools_index.py``); the 909 generated
+``tools/<slug>.yaml`` records do not. This post-processor joins by ``slug`` and
+writes those three fields into each tool YAML, idempotently and style-preserving.
+
+Design mirrors ``propagate_license_tiers.py`` / ``enrich_tools_index.py``:
+- idempotent, format-preserving writer over committed artifacts;
+- no git / gh / network; no ``Date.now``-style nondeterminism;
+- the license fields land immediately after ``schema_version`` (before any
+  later-appended block such as ``techniques``), a deterministic position so
+  re-runs are byte-stable.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import yaml
+
+_LICENSE_KEYS = ("license_tier", "license", "license_detection")
+
+
+def _yaml_dump(data: dict) -> str:
+    """Match ``collect_metabolomics_collection.render_tool_yaml`` serialization."""
+    return yaml.safe_dump(
+        data, sort_keys=False, allow_unicode=True, default_flow_style=False, width=1000
+    )
+
+
+def tier_map(tools_index) -> dict:
+    """``{slug: {license_tier, license, license_detection}}`` from the index.
+
+    Missing ``license`` / ``license_detection`` default to ``None`` so every row
+    is complete; entries without a ``slug`` are skipped.
+    """
+    out: dict[str, dict] = {}
+    for t in tools_index:
+        slug = t.get("slug")
+        if not slug:
+            continue
+        out[slug] = {
+            "license_tier": t.get("license_tier"),
+            "license": t.get("license"),
+            "license_detection": t.get("license_detection"),
+        }
+    return out
+
+
+def _reorder_with_license(data: dict, fields: dict) -> dict:
+    """Return a new dict with the three license fields placed right after
+    ``schema_version`` (or appended if absent), preserving all other key order.
+    """
+    # Strip any existing license keys so we can re-place them deterministically.
+    base = {k: v for k, v in data.items() if k not in _LICENSE_KEYS}
+    rebuilt: dict = {}
+    inserted = False
+    for k, v in base.items():
+        rebuilt[k] = v
+        if k == "schema_version":
+            for lk in _LICENSE_KEYS:
+                rebuilt[lk] = fields[lk]
+            inserted = True
+    if not inserted:
+        for lk in _LICENSE_KEYS:
+            rebuilt[lk] = fields[lk]
+    return rebuilt
+
+
+def enrich(collection_dir) -> dict:
+    d = pathlib.Path(collection_dir)
+    tools_index = json.loads((d / "tools_index.json").read_text(encoding="utf-8"))
+    tiers = tier_map(tools_index)
+
+    tools_dir = d / "tools"
+    enriched = 0
+    skipped = 0
+    if not tools_dir.is_dir():
+        return {"enriched": 0, "skipped": 0}
+
+    for yaml_path in sorted(tools_dir.glob("*.yaml")):
+        slug = yaml_path.stem
+        fields = tiers.get(slug)
+        if fields is None:
+            skipped += 1
+            continue
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        rebuilt = _reorder_with_license(data, fields)
+        new_text = _yaml_dump(rebuilt)
+        if new_text != yaml_path.read_text(encoding="utf-8"):
+            yaml_path.write_text(new_text, encoding="utf-8")
+        enriched += 1
+
+    return {"enriched": enriched, "skipped": skipped}
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection",
+        required=True,
+        help="collection dir with tools_index.json and a tools/ subdir of <slug>.yaml",
+    )
+    a = ap.parse_args(argv)
+    res = enrich(a.collection)
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/enrich_tools_index.py
+++ b/scripts/enrich_tools_index.py
@@ -1,0 +1,142 @@
+"""Enrich the tool catalog with consumer license fields + bidirectional
+skill<->tool links, by DOI intersection against the corpus.
+
+Idempotent, key-order / indent preserving post-processor over committed
+artifacts (the propagate_license_tiers.py / stamp_skill_license.py pattern).
+Reuses _ORDER, corpus license mapping, and detect_indent from
+propagate_license_tiers; does not fork the collector or touch tools/<slug>.yaml.
+
+Writes back, in collection_dir:
+- tools_index.json : + license_tier, license, license_detection, used_by_skills
+- skills_index.json: + tools_used
+- kb_bundle.json   : + tools_used on each skill record
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.propagate_license_tiers import _ORDER, detect_indent
+
+
+def corpus_by_doi(corpus_path) -> dict:
+    """doi -> full paper dict, as shaped in corpus.yaml (papers list)."""
+    doc = yaml.safe_load(pathlib.Path(corpus_path).read_text(encoding="utf-8"))
+    out = {}
+    for p in doc.get("papers", []):
+        doi = p.get("doi")
+        if doi:
+            out[doi] = p
+    return out
+
+
+def tool_license(tool_dois, corpus_papers) -> tuple:
+    """Most-restrictive (tier, license, detection) across a tool's matched corpus
+    DOIs. Conservative default ("restricted", None, None) when nothing matches.
+
+    license comes from access.license; detection from top-level license_detection
+    (mirrors corpus_tier_by_doi / check_license_tiers conventions).
+    """
+    best = None  # (rank, tier, license, detection)
+    for d in tool_dois or []:
+        p = corpus_papers.get(d)
+        if not p:
+            continue
+        tier = p.get("license_tier")
+        if tier not in _ORDER:
+            continue
+        rank = _ORDER[tier]
+        if best is None or rank > best[0]:
+            lic = (p.get("access") or {}).get("license")
+            det = p.get("license_detection")
+            best = (rank, tier, lic, det)
+    if best is None:
+        return ("restricted", None, None)
+    return (best[1], best[2], best[3])
+
+
+def link_maps(skills_index, tools_index) -> tuple:
+    """Bidirectional skill<->tool maps via DOI intersection.
+
+    Returns (tools_used_by_skill_slug, used_by_skills_by_tool_slug); each value
+    is a sorted list of slugs. Mutual inverses by construction.
+    """
+    tools_used: dict[str, list] = {}
+    used_by: dict[str, list] = {t["slug"]: [] for t in tools_index}
+    tool_dois = [(t["slug"], set(t.get("dois") or [])) for t in tools_index]
+    for s in skills_index:
+        s_dois = set(s.get("dois") or [])
+        matched = sorted(slug for slug, t_dois in tool_dois if s_dois & t_dois)
+        tools_used[s["slug"]] = matched
+        for tslug in matched:
+            used_by[tslug].append(s["slug"])
+    for tslug in used_by:
+        used_by[tslug] = sorted(used_by[tslug])
+    return tools_used, used_by
+
+
+def enrich(collection_dir) -> dict:
+    d = pathlib.Path(collection_dir)
+    ti_path = d / "tools_index.json"
+    si_path = d / "skills_index.json"
+    kb_path = d / "kb_bundle.json"
+
+    ti_raw = ti_path.read_text(encoding="utf-8")
+    si_raw = si_path.read_text(encoding="utf-8")
+    kb_raw = kb_path.read_text(encoding="utf-8")
+    tools = json.loads(ti_raw)
+    skills = json.loads(si_raw)
+    kb = json.loads(kb_raw)
+
+    papers = corpus_by_doi(d / "corpus.yaml")
+    tools_used, used_by = link_maps(skills, tools)
+
+    tool_tiers: dict[str, int] = {}
+    for t in tools:
+        tier, lic, det = tool_license(t.get("dois"), papers)
+        t["license_tier"] = tier
+        t["license"] = lic
+        t["license_detection"] = det
+        t["used_by_skills"] = used_by.get(t["slug"], [])
+        tool_tiers[tier] = tool_tiers.get(tier, 0) + 1
+
+    skills_linked = 0
+    for s in skills:
+        used = tools_used.get(s["slug"], [])
+        s["tools_used"] = used
+        if used:
+            skills_linked += 1
+
+    for slug, rec in (kb.get("skills") or {}).items():
+        rec["tools_used"] = tools_used.get(slug, [])
+
+    ti_path.write_text(json.dumps(tools, indent=detect_indent(ti_raw), ensure_ascii=False), encoding="utf-8")
+    si_path.write_text(json.dumps(skills, indent=detect_indent(si_raw), ensure_ascii=False), encoding="utf-8")
+    kb_path.write_text(json.dumps(kb, indent=detect_indent(kb_raw), ensure_ascii=False), encoding="utf-8")
+
+    return {"tools": len(tools), "skills_linked": skills_linked, "tool_tiers": tool_tiers}
+
+
+def main(argv=None) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--collection", required=True,
+                    help="collection dir with tools_index.json + skills_index.json + kb_bundle.json + corpus.yaml")
+    a = ap.parse_args(argv)
+    res = enrich(a.collection)
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ground_skill.py
+++ b/scripts/ground_skill.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""ground_skill — executable, best-effort literature grounding for a skill claim.
+
+The *propose-skill* flow (``commands/propose-skill.md`` step 4) lets a contributor
+propose a candidate source DOI for a community skill. This module turns that into
+an executable check: it ensures the canonical per-paper KB
+(``asb-paper-<doi-slug>`` — the SAME slug the build + binder use, see
+:func:`scripts.perspicacite_kb_bind.kb_slug`) exists in a running Perspicacité
+instance, then asks — over ``/api/chat`` scoped to that KB — whether the paper
+**supports the skill's claims**, and parses a structured verdict + evidence quote.
+
+Design contract (mirrors the binder's generate-on-use + graceful-degrade rails):
+
+* :func:`verify_doi_support` **never raises**. Any error — unreachable server,
+  malformed reply, missing answer — degrades to
+  ``{supported: False, confidence: "low", evidence: ""}`` (plus the ``doi``).
+* The HTTP client is **injected** (``http``), a callable matching
+  ``perspicacite_kb_bind._http(method, path, body=None, timeout=...)``. Tests pass
+  a mock; the CLI uses the real ``_http``. No live network in importable code.
+* No git/gh side effects. No ``Date.now``.
+
+A *supportive* verdict at ``high``/``medium`` confidence is the signal the command
+uses to attach ``derived_from`` + ``metadata.literature_upgrade_candidate: true``.
+
+Examples
+--------
+    python -m scripts.ground_skill --doi <doi> \
+        --skill-md path/to/SKILL.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.perspicacite_kb_bind import _http as _real_http
+from scripts.perspicacite_kb_bind import kb_slug
+
+UNSUPPORTED = {"supported": False, "confidence": "low", "evidence": ""}
+
+_PROMPT = (
+    "You are grounding a candidate skill against a single source paper. Using ONLY "
+    "the retrieved passages from this paper, decide whether the paper SUPPORTS the "
+    "claims/methods of the skill below.\n\n"
+    "Reply in EXACTLY this structured form:\n"
+    "VERDICT: SUPPORTED or NOT_SUPPORTED\n"
+    "CONFIDENCE: high, medium, or low\n"
+    'EVIDENCE: a short verbatim quote from the paper (or "" if none)\n\n'
+    "Skill:\n{skill}\n"
+)
+
+
+def _ensure_kb(slug: str, doi: str, http) -> None:
+    """Best-effort create+ingest the per-DOI KB via the injected ``http``.
+
+    Mirrors :func:`scripts.perspicacite_kb_bind.prepare_kb` but uses the injected
+    client so it stays network-free under test. Swallows every error — grounding is
+    best-effort and the chat call degrades on its own if the KB is absent.
+    """
+    try:
+        stats = http("GET", f"/api/kb/{slug}/stats", timeout=30)
+        if isinstance(stats, dict) and (stats.get("chunk_count") or 0) > 0:
+            return  # already present
+    except Exception:
+        pass  # 404 / unreachable — fall through to (re)create
+    try:
+        http("POST", "/api/kb",
+             {"name": slug, "description": f"ASB grounding KB ({doi})"}, timeout=60)
+    except Exception:
+        pass  # 400/409 already-exists, or unreachable
+    try:
+        http("POST", f"/api/kb/{slug}/dois", {"dois": [doi]}, timeout=1200)
+    except Exception:
+        pass
+
+
+def _answer_text(resp) -> str:
+    """Pull the assistant answer out of a /api/chat response (binder's shape)."""
+    if isinstance(resp, dict):
+        ans = resp.get("answer") or resp.get("response") or resp.get("content")
+        if isinstance(ans, str):
+            return ans
+        if ans is not None:
+            return json.dumps(ans)
+    if isinstance(resp, str):
+        return resp
+    return ""
+
+
+def _parse_verdict(text: str) -> dict:
+    """Parse the structured VERDICT/CONFIDENCE/EVIDENCE reply.
+
+    Tolerant: missing/garbled fields degrade to unsupported+low rather than raise.
+    """
+    if not text:
+        return dict(UNSUPPORTED)
+    m_verdict = re.search(r"VERDICT\s*:\s*(SUPPORTED|NOT[_\s-]?SUPPORTED)", text, re.I)
+    if not m_verdict:
+        return dict(UNSUPPORTED)
+    supported = m_verdict.group(1).upper().replace(" ", "_").replace("-", "_") == "SUPPORTED"
+
+    conf = "low"
+    m_conf = re.search(r"CONFIDENCE\s*:\s*(high|medium|low)", text, re.I)
+    if m_conf:
+        conf = m_conf.group(1).lower()
+    elif supported:
+        conf = "medium"  # supported but unspecified confidence -> conservative medium
+
+    evidence = ""
+    m_ev = re.search(r"EVIDENCE\s*:\s*(.+)", text, re.I | re.S)
+    if m_ev:
+        evidence = m_ev.group(1).strip().strip('"').strip()
+
+    if not supported:
+        # never advertise high confidence for a negative verdict downstream
+        conf = "low" if conf == "high" else conf
+
+    return {"supported": supported, "confidence": conf, "evidence": evidence}
+
+
+def verify_doi_support(skill_text: str, doi: str, *, http=None, prepare: bool = True) -> dict:
+    """Ask whether ``doi``'s paper supports ``skill_text``'s claims. Never raises.
+
+    Parameters
+    ----------
+    skill_text : str
+        The skill's claims/body (e.g. its SKILL.md text) to ground.
+    doi : str
+        Candidate source DOI; its KB is ``asb-paper-<doi-slug>``.
+    http : callable, optional
+        ``http(method, path, body=None, timeout=...)`` (the binder's ``_http``
+        shape). Defaults to the real Perspicacité client.
+    prepare : bool
+        When True, best-effort create+ingest the KB before querying.
+
+    Returns
+    -------
+    dict
+        ``{doi, supported: bool, confidence: "high"|"medium"|"low", evidence: str}``.
+        On any failure: ``{doi, supported: False, confidence: "low", evidence: ""}``.
+    """
+    if http is None:
+        http = _real_http
+    result = dict(UNSUPPORTED)
+    result["doi"] = doi
+    try:
+        slug = kb_slug(doi)
+        if prepare:
+            _ensure_kb(slug, doi, http)
+        payload = {
+            "query": _PROMPT.format(skill=skill_text or ""),
+            "kb_names": [slug],
+            "mode": "paper",
+            "stream": False,
+        }
+        resp = http("POST", "/api/chat", payload, timeout=600)
+        parsed = _parse_verdict(_answer_text(resp))
+        parsed["doi"] = doi
+        return parsed
+    except Exception:
+        # Unreachable / unexpected — best-effort grounding degrades, never raises.
+        return result
+
+
+def main(argv=None, *, http=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--doi", required=True, help="candidate source DOI to ground against")
+    ap.add_argument("--skill-md", required=True,
+                    help="path to the SKILL.md whose claims to verify")
+    a = ap.parse_args(argv)
+
+    try:
+        from pathlib import Path
+        skill_text = Path(a.skill_md).read_text(encoding="utf-8")
+    except Exception as e:  # missing/unreadable file is a real CLI error
+        print(json.dumps({"error": f"cannot read --skill-md: {str(e)[:160]}"}, indent=2))
+        return 1
+
+    out = verify_doi_support(skill_text, a.doi, http=http)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/normalize_skill.py
+++ b/scripts/normalize_skill.py
@@ -1,0 +1,235 @@
+"""Deterministic normalizer for a community-contributed ASB skill.
+
+Mirrors the CI gates so a contributed SKILL.md can be checked + assembled into a
+schema-correct, community-tier frontmatter *before* a human reviews it. Pure
+logic + frontmatter parsing — no network, no fabrication of content. The EDAM
+IRIs and the description prose are the contributor's (or the command's LLM)
+responsibility; this module asserts/assembles structure only.
+
+Reuses ``scripts.stamp_skill_license._split`` for frontmatter parsing and the
+tier vocabularies from ``scripts.license_tier`` / ``scripts.provenance_tier``.
+
+See governance/PROVENANCE_TIERS.md and governance/LICENSE_TIERS.md.
+"""
+from __future__ import annotations
+
+import copy
+import re
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from scripts.provenance_tier import VALID as VALID_PROVENANCE
+from scripts.stamp_skill_license import _split
+
+# CI parity (see plan "## Global Constraints" + governance gates).
+EDAM_PREFIX = "http://edamontology.org/"
+DESC_PREFIXES = ("Use when", "Reference for", "Explains", "Decision support for")
+DESC_MIN, DESC_MAX = 50, 300
+MARKETING_TERMS = ("best", "state-of-the-art", "revolutionary", "leading", "superior")
+VALID_LICENSE_TIERS = {"open", "noncommercial", "restricted"}
+# Co-authorship attribution roles for the optional ``contributors`` block:
+# ``author`` (a tool's author who contributed the skill), ``reviewer`` (vetted
+# it), ``curator`` (a maintainer who staged/shaped it). See governance/AUTHORSHIP.md.
+VALID_CONTRIBUTOR_ROLES = {"author", "reviewer", "curator"}
+# Well-formed contributor keys: ``name``/``role`` required, ``orcid``/``github``
+# optional. Only these keys are emitted into a normalized block.
+CONTRIBUTOR_KEYS = ("name", "role", "orcid", "github")
+
+
+def slugify(name: str) -> str:
+    """Lowercase, hyphenate, strip non-alphanumerics. Idempotent on slugs."""
+    s = (name or "").lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-")
+
+
+def valid_edam(iri) -> bool:
+    """True iff ``iri`` is a canonical EDAM IRI (``http://edamontology.org/...``)."""
+    return isinstance(iri, str) and iri.startswith(EDAM_PREFIX) and len(iri) > len(EDAM_PREFIX)
+
+
+def check_description(desc) -> list[str]:
+    """Return violation strings for the description discipline (empty = valid).
+
+    Checks: allowed prefix, 50–300 chars, no marketing terms.
+    """
+    violations: list[str] = []
+    if not isinstance(desc, str) or not desc.strip():
+        return ["description missing"]
+    text = desc.strip()
+    if not text.startswith(DESC_PREFIXES):
+        violations.append(
+            f"description prefix must be one of {DESC_PREFIXES}"
+        )
+    n = len(text)
+    if n < DESC_MIN:
+        violations.append(f"description too short ({n} < {DESC_MIN} chars)")
+    elif n > DESC_MAX:
+        violations.append(f"description too long ({n} > {DESC_MAX} chars)")
+    low = text.lower()
+    # Substring match for CI parity with validate.yml Gate 5
+    # (`if term.lower() in desc.lower()`), not word-boundary — the gate the
+    # contributed skill must satisfy after the PR is opened uses substrings.
+    for term in MARKETING_TERMS:
+        if term in low:
+            violations.append(f"description uses marketing term {term!r}")
+    return violations
+
+
+def parse_skill_md(text: str) -> tuple[dict | None, str | None]:
+    """Split a SKILL.md into ``(frontmatter_dict, body)``.
+
+    Returns ``(None, None)`` when there is no leading ``---`` frontmatter block
+    (reuses ``stamp_skill_license._split``).
+    """
+    fm_raw, body = _split(text)
+    if fm_raw is None:
+        return None, None
+    return (yaml.safe_load(fm_raw) or {}), body
+
+
+def frontmatter_violations(fm: dict) -> list[str]:
+    """Validate description + EDAM IRIs + license_tier against the CI gates."""
+    violations: list[str] = []
+    fm = fm or {}
+    violations.extend(check_description(fm.get("description")))
+
+    meta = fm.get("metadata") or {}
+
+    op = meta.get("edam_operation")
+    if op is not None and not valid_edam(op):
+        violations.append(f"invalid EDAM operation IRI: {op!r}")
+    topics = meta.get("edam_topics") or []
+    if not isinstance(topics, list):
+        # A bare string (or other scalar) would iterate per-character and emit
+        # one violation per char; emit a single clear message instead.
+        violations.append("edam_topics must be a list")
+    else:
+        for topic in topics:
+            if not valid_edam(topic):
+                violations.append(f"invalid EDAM topic IRI: {topic!r}")
+
+    tier = meta.get("license_tier")
+    if tier not in VALID_LICENSE_TIERS:
+        violations.append(
+            f"invalid license_tier {tier!r} (must be one of {sorted(VALID_LICENSE_TIERS)})"
+        )
+    return violations
+
+
+def contributor_violations(contributors) -> list[str]:
+    """Validate an optional ``contributors`` block (empty = valid/absent).
+
+    The block is OPTIONAL: ``None`` (absent) yields no violations. When present
+    it must be a list of mappings, each with a non-empty ``name`` and a ``role``
+    in :data:`VALID_CONTRIBUTOR_ROLES`. ``orcid``/``github`` are optional and not
+    further validated here. See governance/AUTHORSHIP.md.
+    """
+    if contributors is None:
+        return []
+    violations: list[str] = []
+    if not isinstance(contributors, list):
+        return ["contributors must be a list"]
+    for i, entry in enumerate(contributors):
+        if not isinstance(entry, dict):
+            violations.append(f"contributor[{i}] must be a mapping")
+            continue
+        name = entry.get("name")
+        if not (isinstance(name, str) and name.strip()):
+            violations.append(f"contributor[{i}] missing non-empty name")
+        role = entry.get("role")
+        if role not in VALID_CONTRIBUTOR_ROLES:
+            violations.append(
+                f"contributor[{i}] role {role!r} not in {sorted(VALID_CONTRIBUTOR_ROLES)}"
+            )
+    return violations
+
+
+def normalized_frontmatter(
+    raw_fm: dict,
+    *,
+    related_skills,
+    tools_used,
+    license_tier: str,
+    provenance_tier: str = "community",
+    status: str = "hold",
+    derived_from=None,
+    contributors=None,
+) -> dict:
+    """Assemble a schema-correct community frontmatter from ``raw_fm``.
+
+    Preserves the contributor's ``name``/``description`` and the provided EDAM
+    block (does NOT fabricate them). Sets the metadata tier block plus
+    ``related_skills``/``tools_used``/``status``/``provenance_tier``/
+    ``license_tier``. ``derived_from`` is included only when provided. Does not
+    mutate ``raw_fm``.
+
+    ``contributors`` (the co-authorship attribution block) is emitted only when
+    provided. Each entry is reduced to its well-formed keys
+    (:data:`CONTRIBUTOR_KEYS`: ``name``/``role`` required, ``orcid``/``github``
+    optional; unknown keys dropped); the input is not mutated.
+    """
+    if provenance_tier not in VALID_PROVENANCE:
+        raise ValueError(f"invalid provenance_tier {provenance_tier!r}")
+    src = copy.deepcopy(raw_fm or {})
+    src_meta = src.get("metadata") if isinstance(src.get("metadata"), dict) else {}
+
+    meta: dict = {}
+    # Preserve provided EDAM/tool/technique content (do not fabricate).
+    for key in ("edam_operation", "edam_topics", "tools", "techniques"):
+        if key in src_meta:
+            meta[key] = src_meta[key]
+    meta["license_tier"] = license_tier
+    meta["provenance_tier"] = provenance_tier
+    meta["tools_used"] = list(tools_used)
+
+    fm: dict = {}
+    if "name" in src:
+        fm["name"] = src["name"]
+    if "description" in src:
+        fm["description"] = src["description"]
+    fm["license"] = src.get("license", "CC-BY-4.0")
+    fm["metadata"] = meta
+    fm["status"] = status
+    # provenance_tier == community requires the related_skills KEY present (even if empty).
+    fm["related_skills"] = list(related_skills)
+    if derived_from is not None:
+        fm["derived_from"] = copy.deepcopy(derived_from)
+    if contributors is not None:
+        emitted: list[dict] = []
+        for entry in contributors:
+            src_entry = entry if isinstance(entry, dict) else {}
+            emitted.append(
+                {k: src_entry[k] for k in CONTRIBUTOR_KEYS if k in src_entry}
+            )
+        fm["contributors"] = emitted
+    return fm
+
+
+def main(argv=None) -> int:
+    import argparse
+    import json
+    import pathlib
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skill-md", required=True, help="path to a SKILL.md to validate")
+    a = ap.parse_args(argv)
+    fm, _ = parse_skill_md(pathlib.Path(a.skill_md).read_text(encoding="utf-8"))
+    if fm is None:
+        print(json.dumps({"violations": ["no frontmatter block"]}, indent=2))
+        return 1
+    v = frontmatter_violations(fm)
+    print(json.dumps({"violations": v}, indent=2))
+    return 1 if v else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_proposals.py
+++ b/scripts/promote_proposals.py
@@ -1,0 +1,300 @@
+"""Promote a staged skill proposal into the published collection.
+
+The maintainer-side, mechanical half of the curation flow: a staged
+``proposals/skills/<slug>/SKILL.md`` (``status: hold``) that has passed review is
+*moved* into ``skills/<slug>/SKILL.md`` with ``status: included``, and the three
+committed indices are updated so the promoted skill is indistinguishable from a
+pipeline-built one:
+
+* ``skills_index.json`` — a new entry derived from the frontmatter
+  (``slug, name, description, edam_operation, edam_topics, techniques, tools,
+  dois, provenance_tier, tools_used, license_tier``);
+* ``kb_bundle.json`` — a new skill record (``dois, tools, kb_slugs, repo_urls,
+  license_tier, provenance_tier, tools_used``);
+* the SKILL.md is re-stamped (``metadata.provenance_tier`` /
+  ``metadata.license_tier``) so it matches its index entry under the
+  provenance / license CI gates.
+
+Reuses the existing machinery rather than re-implementing it:
+``normalize_skill.parse_skill_md`` (frontmatter parse), ``propose_skill``'s
+rendering conventions, ``perspicacite_kb_bind.kb_slug`` (KB-slug derivation),
+``propagate_license_tiers.detect_indent`` (indent-preserving JSON),
+``stamp_provenance.stamp_skill_provenance`` (frontmatter re-stamp).
+
+Invariants:
+
+* **Idempotent.** An already-promoted slug (present in ``skills_index.json``) is a
+  no-op and reported under ``skipped``; JSON files are written only when content
+  changes.
+* **No git/gh side effects.** A maintainer runs git/gh after reviewing the move.
+* **No ``Date.now`` in importable code.** ``promote`` takes ``date`` as an
+  argument; only :func:`main` may default it.
+
+See governance/PROVENANCE_TIERS.md and governance/COMMUNITY_SKILLS.md.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from asb_skill_collections import layout
+from scripts.normalize_skill import parse_skill_md
+from scripts.perspicacite_kb_bind import kb_slug
+from scripts.propagate_license_tiers import detect_indent
+from scripts.propose_skill import render_skill_md
+from scripts.stamp_provenance import stamp_skill_provenance
+
+# skills_index entry fields derived from frontmatter (order = output key order).
+_INDEX_KEYS = (
+    "slug",
+    "name",
+    "description",
+    "edam_operation",
+    "edam_topics",
+    "tools",
+    "dois",
+    "techniques",
+    "license_tier",
+    "provenance_tier",
+    "tools_used",
+)
+
+
+def staged_slugs(collection_dir) -> list[str]:
+    """Slugs under ``proposals/skills/`` whose SKILL.md is held (``status: hold``).
+
+    Sorted, deduplicated. A collection with no ``proposals/skills/`` yields []."""
+    base = layout.staging_dir(collection_dir)
+    if not base.is_dir():
+        return []
+    out: list[str] = []
+    for md in sorted(base.glob("*/SKILL.md")):
+        fm, _ = parse_skill_md(md.read_text(encoding="utf-8"))
+        if isinstance(fm, dict) and fm.get("status") == "hold":
+            out.append(md.parent.name)
+    return out
+
+
+def _index_entry(slug: str, fm: dict) -> dict:
+    """Build the skills_index entry for ``slug`` from its frontmatter.
+
+    Pulls the top-level ``description``/``name`` and the ``metadata`` block
+    (EDAM, tools, techniques, dois, tiers, tools_used). For a community proposal
+    the ``related_skills`` key is carried onto the index so the provenance gate's
+    ``validate_entry(community, related_skills=...)`` is satisfied.
+    """
+    meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+    src = {
+        "slug": slug,
+        "name": fm.get("name") or slug,
+        "description": fm.get("description"),
+        "edam_operation": meta.get("edam_operation"),
+        "edam_topics": list(meta.get("edam_topics") or []),
+        "tools": list(meta.get("tools") or []),
+        "dois": list(meta.get("dois") or fm.get("dois") or []),
+        "techniques": list(meta.get("techniques") or []),
+        "license_tier": meta.get("license_tier"),
+        "provenance_tier": meta.get("provenance_tier"),
+        "tools_used": list(meta.get("tools_used") or []),
+    }
+    entry = {k: src[k] for k in _INDEX_KEYS}
+    # provenance-tier invariants carried onto the index entry.
+    if "related_skills" in fm:
+        entry["related_skills"] = list(fm.get("related_skills") or [])
+    if "synthesized_from" in meta:
+        entry["synthesized_from"] = list(meta.get("synthesized_from") or [])
+    return entry
+
+
+def _kb_record(fm: dict) -> dict:
+    """Build the kb_bundle skill record from frontmatter (KB slugs from dois)."""
+    meta = fm.get("metadata") if isinstance(fm.get("metadata"), dict) else {}
+    dois = list(meta.get("dois") or fm.get("dois") or [])
+    return {
+        "dois": dois,
+        "tools": list(meta.get("tools") or []),
+        "kb_slugs": [kb_slug(d) for d in dois],
+        "repo_urls": list(meta.get("repo_urls") or []),
+        "license_tier": meta.get("license_tier"),
+        "provenance_tier": meta.get("provenance_tier"),
+        "tools_used": list(meta.get("tools_used") or []),
+    }
+
+
+def _load_json(path):
+    raw = path.read_text(encoding="utf-8")
+    return json.loads(raw), detect_indent(raw)
+
+
+def _write_json_if_changed(path, obj, indent) -> bool:
+    """Write ``obj`` only when the serialization differs. Returns True if written."""
+    new = json.dumps(obj, indent=indent, ensure_ascii=False)
+    if path.exists() and path.read_text(encoding="utf-8") == new:
+        return False
+    path.write_text(new, encoding="utf-8")
+    return True
+
+
+def promote(collection_dir, slugs, *, date: str, dry_run: bool = False) -> dict:
+    """Promote staged proposal ``slugs`` into the published collection.
+
+    For each slug: move ``proposals/skills/<slug>/SKILL.md`` into the
+    collection's leaf directory with ``status`` flipped to ``included``; append a
+    ``skills_index.json`` entry + ``kb_bundle.json`` record; re-stamp the SKILL.md
+    so it matches its index entry. Idempotent: a slug already present in
+    ``skills_index.json`` is a no-op and reported under ``skipped`` (so are slugs
+    that are not staged / not held).
+
+    Parameters
+    ----------
+    collection_dir : path-like
+        Collection root (the leaf corpus, ``proposals/``, the three indices).
+    slugs : iterable[str]
+        Proposal slugs to promote.
+    date : str
+        Curation date (``YYYY-MM-DD``). Required (no ``Date.now`` here). Recorded
+        for symmetry with the proposal ledger; not embedded in the artifacts.
+    dry_run : bool
+        When True, write nothing; ``promoted`` lists the slugs that *would* be
+        promoted (the plan).
+
+    Returns ``{"promoted": [...], "skipped": [...]}``.
+    """
+    if not date:
+        raise ValueError("promote requires an explicit date (YYYY-MM-DD)")
+
+    d = pathlib.Path(collection_dir)
+    si_path = d / "skills_index.json"
+    kb_path = d / "kb_bundle.json"
+
+    si, si_indent = _load_json(si_path)
+    kb, kb_indent = _load_json(kb_path)
+    existing_slugs = {e.get("slug") for e in si}
+
+    promoted: list[str] = []
+    skipped: list[str] = []
+    promoted_tools: list = []  # (slug, tools_used) — for used_by_skills back-links
+
+    for slug in slugs:
+        proposal_md = layout.staging_dir(d) / slug / "SKILL.md"
+        # already published, not staged, or not held → skip (idempotent / safe).
+        if slug in existing_slugs or not proposal_md.is_file():
+            skipped.append(slug)
+            continue
+        fm, body = parse_skill_md(proposal_md.read_text(encoding="utf-8"))
+        if not isinstance(fm, dict) or fm.get("status") != "hold":
+            skipped.append(slug)
+            continue
+
+        promoted.append(slug)
+        if dry_run:
+            continue
+
+        # --- move SKILL.md, flip status hold -> included --------------------- #
+        fm = dict(fm)
+        fm["status"] = "included"
+        # A router-shaped collection advertises everything in `skills/`; a
+        # promoted community skill belongs in the leaf corpus with the rest.
+        published_md = layout.leaf_dir(d) / slug / "SKILL.md"
+        published_md.parent.mkdir(parents=True, exist_ok=True)
+        published_md.write_text(render_skill_md(fm, body), encoding="utf-8")
+        proposal_md.unlink()
+        # drop the now-empty proposal directory (best-effort).
+        try:
+            proposal_md.parent.rmdir()
+        except OSError:
+            pass
+
+        # --- append index entry + kb record --------------------------------- #
+        si.append(_index_entry(slug, fm))
+        existing_slugs.add(slug)
+        kb.setdefault("skills", {})[slug] = _kb_record(fm)
+        promoted_tools.append((slug, (fm.get("metadata") or {}).get("tools_used") or []))
+
+        # --- re-stamp the SKILL.md to match the index (idempotent) ----------- #
+        tier = (fm.get("metadata") or {}).get("provenance_tier")
+        if tier:
+            stamp_skill_provenance(published_md, tier)
+
+    if not dry_run and promoted:
+        _write_json_if_changed(si_path, si, si_indent)
+        _write_json_if_changed(kb_path, kb, kb_indent)
+        _link_used_by_skills(d / "tools_index.json", promoted_tools)
+
+    return {"promoted": promoted, "skipped": skipped}
+
+
+def _link_used_by_skills(tools_path, promoted_tools) -> None:
+    """Keep the tool catalog's inverse index in sync after promotion.
+
+    The forward ``tools_used`` is carried verbatim from the proposal frontmatter
+    (curated by the matcher / synthesis); this adds each promoted skill to those
+    tools' ``used_by_skills`` so the bidirectional link is consistent — without a
+    full DOI re-derive (``enrich_tools_index``), which would drop curated
+    community/synthetic links whose skills carry no matching corpus DOI.
+    Idempotent: a slug already present is left untouched.
+    """
+    if not promoted_tools or not tools_path.is_file():
+        return
+    tools, indent = _load_json(tools_path)
+    by_slug = {t.get("slug"): t for t in tools}
+    for slug, tools_used in promoted_tools:
+        for tool_slug in tools_used:
+            tool = by_slug.get(tool_slug)
+            if tool is None:
+                continue
+            ubs = tool.get("used_by_skills") or []
+            if slug not in ubs:
+                tool["used_by_skills"] = sorted([*ubs, slug])
+    _write_json_if_changed(tools_path, tools, indent)
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection",
+        required=True,
+        help="collection root (skills/ + proposals/ + the three indices)",
+    )
+    ap.add_argument(
+        "--slug",
+        action="append",
+        default=None,
+        dest="slugs",
+        help="proposal slug to promote (repeatable; default: all staged/held)",
+    )
+    ap.add_argument(
+        "--date",
+        default=None,
+        help="curation date YYYY-MM-DD (default: today, only in the CLI)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="print the plan; write nothing"
+    )
+    a = ap.parse_args(argv)
+
+    # Date.now lives ONLY here (the importable promote takes date as arg).
+    date = a.date
+    if not date:
+        import datetime
+
+        date = datetime.date.today().isoformat()
+
+    slugs = a.slugs if a.slugs else staged_slugs(a.collection)
+    res = promote(a.collection, slugs, date=date, dry_run=a.dry_run)
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/propose_skill.py
+++ b/scripts/propose_skill.py
@@ -1,0 +1,218 @@
+"""Stage a community-contributed skill into a collection's ``proposals/`` rail.
+
+The deterministic, mechanical half of the ``propose-skill`` flow (the agentic
+``commands/propose-skill.md`` does the matching/grounding/normalization and then
+invokes this to write files). This module:
+
+* writes ``proposals/skills/<slug>/SKILL.md`` (frontmatter + body), and
+* appends/updates an entry in ``proposals/wave-skills-<date>.yaml`` — the skill
+  proposal ledger, schema ``asb-skill-proposals/1.0`` (the skill analogue of the
+  paper ``wave-*.yaml`` ledgers).
+
+Invariants:
+
+* **Idempotent.** Re-staging the same slug rewrites the SKILL.md only when the
+  content changed and replaces (never duplicates) the slug's ledger entry; the
+  ledger ``proposals`` list is kept slug-sorted for byte-stable output.
+* **No git/gh side effects.** The shipped command runs git/gh *after* a human
+  reviews what this wrote.
+* **No ``Date.now`` in importable code.** ``stage_proposal`` requires the wave
+  ``date`` as an argument; only :func:`main` (the CLI) may default it.
+
+Reuses :func:`scripts.normalize_skill.slugify` for the proposal directory name.
+See governance/COMMUNITY_SKILLS.md and the design doc.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from asb_skill_collections import layout
+from scripts.normalize_skill import slugify
+
+LEDGER_SCHEMA = "asb-skill-proposals/1.0"
+
+
+def _skill_slug(frontmatter: dict, ledger_meta: dict) -> str:
+    """The proposal slug: explicit ``ledger_meta['slug']`` wins, else slugified
+    frontmatter ``name``."""
+    slug = (ledger_meta or {}).get("slug")
+    if slug:
+        return slug
+    return slugify((frontmatter or {}).get("name") or "")
+
+
+def render_skill_md(frontmatter: dict, body: str) -> str:
+    """Render ``SKILL.md`` text from frontmatter + body (deterministic)."""
+    fm_yaml = yaml.safe_dump(frontmatter or {}, sort_keys=False, allow_unicode=True)
+    body = body or ""
+    if body and not body.endswith("\n"):
+        body += "\n"
+    return "---\n" + fm_yaml + "---\n" + body
+
+
+def _ledger_entry(slug: str, ledger_meta: dict, date: str) -> dict:
+    """Build the ledger entry for ``slug`` from ``ledger_meta`` (schema 1.0).
+
+    Stamps ``slug``/``status``/``submitted_on`` from the explicit inputs;
+    ``status`` defaults to ``hold`` (the proposal-rail invariant), and a missing
+    ``submitted_on`` is filled from the passed wave ``date``.
+    """
+    entry = dict(ledger_meta or {})
+    entry["slug"] = slug
+    entry.setdefault("status", "hold")
+    entry.setdefault("submitted_on", date)
+    return entry
+
+
+def _merge_ledger(existing: dict, entry: dict) -> dict:
+    """Return a ledger dict with ``entry`` inserted/replaced by slug.
+
+    The ``proposals`` list is kept slug-sorted so the serialized file is stable
+    regardless of staging order (idempotence).
+    """
+    ledger = dict(existing or {})
+    ledger["schema"] = LEDGER_SCHEMA
+    proposals = list(ledger.get("proposals") or [])
+    proposals = [e for e in proposals if e.get("slug") != entry["slug"]]
+    proposals.append(entry)
+    proposals.sort(key=lambda e: e.get("slug") or "")
+    ledger["proposals"] = proposals
+    return ledger
+
+
+def stage_proposal(
+    collection_dir,
+    frontmatter: dict,
+    body: str,
+    ledger_meta: dict,
+    *,
+    date: str,
+    dry_run: bool = False,
+) -> dict:
+    """Write the staged SKILL.md + append/update the wave ledger. Idempotent.
+
+    Parameters
+    ----------
+    collection_dir : path-like
+        The collection root (e.g. ``collections/metabolomics/v2``); files land
+        under ``<collection_dir>/proposals/``.
+    frontmatter, body : dict, str
+        The normalized SKILL.md frontmatter and markdown body.
+    ledger_meta : dict
+        The proposal ledger entry fields (``contributor``, ``related_skills``,
+        ``tools_used``, ``license_tier``, ``grounding``, ...). ``slug``/``status``/
+        ``submitted_on`` are stamped here.
+    date : str
+        The wave date (``YYYY-MM-DD``) — selects ``wave-skills-<date>.yaml`` and
+        the default ``submitted_on``. Required (no ``Date.now`` here).
+    dry_run : bool
+        When True, write nothing; return the plan (paths + ``dry_run: True``).
+
+    Returns the written/planned paths: ``{slug, skill_md, ledger, dry_run}``.
+    """
+    if not date:
+        raise ValueError("stage_proposal requires an explicit date (YYYY-MM-DD)")
+
+    root = pathlib.Path(collection_dir)
+    slug = _skill_slug(frontmatter, ledger_meta)
+    if not slug:
+        raise ValueError("cannot determine proposal slug (no name/slug provided)")
+
+    skill_md = layout.staging_dir(root) / slug / "SKILL.md"
+    ledger_path = root / "proposals" / f"wave-skills-{date}.yaml"
+
+    result = {
+        "slug": slug,
+        "skill_md": str(skill_md),
+        "ledger": str(ledger_path),
+        "dry_run": bool(dry_run),
+    }
+    if dry_run:
+        return result
+
+    # --- SKILL.md (write only when content changed: idempotent) --------------
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    new_text = render_skill_md(frontmatter, body)
+    if not (skill_md.exists() and skill_md.read_text(encoding="utf-8") == new_text):
+        skill_md.write_text(new_text, encoding="utf-8")
+
+    # --- wave ledger (insert/replace by slug, slug-sorted) -------------------
+    existing = {}
+    if ledger_path.exists():
+        existing = yaml.safe_load(ledger_path.read_text(encoding="utf-8")) or {}
+    entry = _ledger_entry(slug, ledger_meta, date)
+    ledger = _merge_ledger(existing, entry)
+    new_ledger_text = yaml.safe_dump(ledger, sort_keys=False, allow_unicode=True)
+    if not (
+        ledger_path.exists()
+        and ledger_path.read_text(encoding="utf-8") == new_ledger_text
+    ):
+        ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        ledger_path.write_text(new_ledger_text, encoding="utf-8")
+
+    return result
+
+
+def main(argv=None) -> int:
+    import argparse
+    import json
+
+    from scripts.normalize_skill import parse_skill_md
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection", required=True, help="collection root (proposals/ written here)"
+    )
+    ap.add_argument(
+        "--skill-md", required=True, help="path to the normalized SKILL.md to stage"
+    )
+    ap.add_argument(
+        "--date",
+        default=None,
+        help="wave date YYYY-MM-DD (default: today, only in the CLI)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="print the plan; write nothing"
+    )
+    a = ap.parse_args(argv)
+
+    # Date.now lives ONLY here (the importable stage_proposal takes date as arg).
+    date = a.date
+    if not date:
+        import datetime
+
+        date = datetime.date.today().isoformat()
+
+    text = pathlib.Path(a.skill_md).read_text(encoding="utf-8")
+    fm, body = parse_skill_md(text)
+    if fm is None:
+        print(json.dumps({"error": "no frontmatter block in --skill-md"}, indent=2))
+        return 1
+
+    meta = fm.get("metadata") or {}
+    ledger_meta = {
+        "slug": slugify(fm.get("name") or ""),
+        "related_skills": list(fm.get("related_skills") or []),
+        "tools_used": list(meta.get("tools_used") or []),
+        "license_tier": meta.get("license_tier"),
+        "status": fm.get("status", "hold"),
+    }
+    res = stage_proposal(
+        a.collection, fm, body, ledger_meta, date=date, dry_run=a.dry_run
+    )
+    print(json.dumps(res, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/provenance_tier.py
+++ b/scripts/provenance_tier.py
@@ -1,0 +1,43 @@
+"""Provenance-tier kernel for ASB skills.
+
+A skill's *provenance* records where its content came from, orthogonally to the
+consumer `license_tier` (see scripts/license_tier.py). Three tiers:
+
+- ``literature``  — synthesized from one or more source papers (requires >=1 doi).
+- ``synthetic``   — derived from other skills (requires ``synthesized_from``).
+- ``community``   — contributed/curated outside the literature pipeline (requires
+  a ``related_skills`` key to be present, even if empty).
+
+Pure logic: no data-file I/O. See governance/PROVENANCE_TIERS.md.
+"""
+from __future__ import annotations
+
+VALID: set[str] = {"literature", "synthetic", "community"}
+DEFAULT = "literature"
+
+
+def validate_entry(
+    tier,
+    *,
+    dois=None,
+    synthesized_from=None,
+    related_skills=None,
+) -> list[str]:
+    """Return human-readable violation strings (empty list = valid).
+
+    - ``tier`` not in :data:`VALID` → one ``invalid provenance_tier`` violation
+      (and no further checks).
+    - ``literature`` with no ``dois`` → requires >=1 doi.
+    - ``synthetic`` with no ``synthesized_from`` → requires synthesized_from.
+    - ``community`` with ``related_skills is None`` → requires the key present.
+      An empty list is allowed (``None`` means the key is absent).
+    """
+    if tier not in VALID:
+        return [f"invalid provenance_tier {tier!r}"]
+    if tier == "literature" and not dois:
+        return ["literature requires >=1 doi"]
+    if tier == "synthetic" and not synthesized_from:
+        return ["synthetic requires synthesized_from"]
+    if tier == "community" and related_skills is None:
+        return ["community requires related_skills key"]
+    return []

--- a/scripts/skill_match.py
+++ b/scripts/skill_match.py
@@ -1,0 +1,218 @@
+"""skill_match — match a (possibly ungrounded) candidate skill against the
+existing collection's skills and tools, using a serverless lexical core.
+
+Pure-Python TF-IDF cosine ranking over an in-memory ``skills_index`` /
+``tools_index``, plus a near-duplicate flag. It depends on nothing external, so
+a contributor without any server still gets useful ``related_skills`` /
+``tools_used`` suggestions.
+
+Skill-similarity matching is intentionally **lexical, not Perspicacité-backed**:
+Perspicacité is a paper/literature RAG system and exposes no "index arbitrary
+docs, semantic-search them back as slugs" surface, so it is not the right tool
+for skill↔skill matching. Perspicacité's role in this pipeline is the optional
+*literature grounding* step — finding/verifying a supporting paper for a skill —
+which the ``propose-skill`` command performs via ``perspicacite_kb_bind`` against
+the real per-DOI KB API. See ``commands/propose-skill.md``.
+
+The functions never raise on sparse/odd entries and never touch the network.
+Each skill is reduced to a single searchable *document* by :func:`skill_doc`
+(name + description + tools + EDAM topics + techniques); the query text is scored
+against those documents with TF-IDF cosine similarity.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import Counter
+from pathlib import Path
+
+# Tokenizer: lowercase alphanumeric runs, but keep intra-token '-', '/', '_', '.'
+# so identifiers like ``LC-MS``, ``MS/MS``, ``topic_3172`` survive as units while
+# also yielding their sub-parts (we additionally split on those for recall).
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9./_-]*")
+_SPLIT_RE = re.compile(r"[\s./_-]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenize to lowercase terms, emitting both the joined identifier and its
+    sub-parts (so ``LC-MS`` matches ``lc-ms`` *and* ``lc``/``ms``)."""
+    if not text:
+        return []
+    low = text.lower()
+    toks: list[str] = []
+    for m in _TOKEN_RE.findall(low):
+        toks.append(m)
+        parts = [p for p in _SPLIT_RE.split(m) if p]
+        if len(parts) > 1:
+            toks.extend(parts)
+    return toks
+
+
+def skill_doc(entry: dict) -> str:
+    """Join an index entry's searchable fields into one text document.
+
+    Folds ``name`` + ``description`` + ``tools`` + ``edam_topics`` +
+    ``techniques`` (and ``slug`` for good measure). Tolerant of missing keys.
+    """
+    parts: list[str] = []
+    for key in ("slug", "name", "description"):
+        val = entry.get(key)
+        if isinstance(val, str) and val:
+            parts.append(val)
+    for key in ("tools", "tools_used", "edam_topics", "techniques"):
+        val = entry.get(key)
+        if isinstance(val, (list, tuple)):
+            parts.extend(str(v) for v in val if v)
+        elif isinstance(val, str) and val:
+            parts.append(val)
+    return " ".join(parts)
+
+
+def _tf_idf_vectors(docs: list[list[str]]):
+    """Return (idf, [tf-idf Counter per doc]) for a corpus of token lists."""
+    n = len(docs)
+    df: Counter = Counter()
+    for toks in docs:
+        for term in set(toks):
+            df[term] += 1
+    idf = {t: math.log((1 + n) / (1 + d)) + 1.0 for t, d in df.items()}
+    vecs: list[dict] = []
+    for toks in docs:
+        tf = Counter(toks)
+        total = sum(tf.values()) or 1
+        vecs.append({t: (c / total) * idf.get(t, 0.0) for t, c in tf.items()})
+    return idf, vecs
+
+
+def _cosine(a: dict, b: dict) -> float:
+    if not a or not b:
+        return 0.0
+    # iterate the smaller vector
+    if len(a) > len(b):
+        a, b = b, a
+    dot = sum(w * b.get(t, 0.0) for t, w in a.items())
+    if dot == 0.0:
+        return 0.0
+    na = math.sqrt(sum(w * w for w in a.values()))
+    nb = math.sqrt(sum(w * w for w in b.values()))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def lexical_match(text: str, skills_index: list[dict], *, k: int = 10) -> list[dict]:
+    """Rank ``skills_index`` against ``text`` by TF-IDF cosine similarity.
+
+    Returns up to ``k`` hits ``{slug, score, backend:"lexical"}`` sorted by
+    descending score; entries with zero overlap are dropped. Never raises.
+    """
+    entries = [e for e in (skills_index or []) if e.get("slug")]
+    if not entries:
+        return []
+    doc_tokens = [_tokenize(skill_doc(e)) for e in entries]
+    # the query joins the corpus so IDF reflects both query and documents
+    query_tokens = _tokenize(text)
+    idf, doc_vecs = _tf_idf_vectors(doc_tokens + [query_tokens])
+    q_vec = doc_vecs[-1]
+    doc_vecs = doc_vecs[:-1]
+    scored = []
+    for entry, vec in zip(entries, doc_vecs):
+        s = _cosine(q_vec, vec)
+        if s > 0.0:
+            scored.append({"slug": entry["slug"], "score": float(s), "backend": "lexical"})
+    scored.sort(key=lambda h: (-h["score"], h["slug"]))
+    return scored[:k]
+
+
+def match_tools(
+    matched_slugs: list[str],
+    skills_index: list[dict],
+    tools_index: list[dict],
+    text: str | None = None,
+) -> list[dict]:
+    """Suggest tool slugs for a candidate skill.
+
+    Union of (a) the ``tools_used`` of every matched skill and (b) lexical
+    tool-name hits when ``text`` is supplied (a tool whose slug or name appears
+    as a token in ``text``). Returns deduped ``{slug, score}`` ordered by score
+    then slug; score 1.0 for a direct text/name hit, 0.5 for a union-only hit.
+    """
+    by_slug = {e["slug"]: e for e in (skills_index or []) if e.get("slug")}
+    tools = [t for t in (tools_index or []) if t.get("slug")]
+    scores: dict[str, float] = {}
+
+    # (a) union of matched skills' tools_used
+    for slug in matched_slugs or []:
+        entry = by_slug.get(slug)
+        if not entry:
+            continue
+        for tool_slug in entry.get("tools_used") or []:
+            if tool_slug:
+                scores[tool_slug] = max(scores.get(tool_slug, 0.0), 0.5)
+
+    # (b) lexical tool-name hits in the supplied text
+    if text:
+        text_tokens = set(_tokenize(text))
+        for t in tools:
+            names = {t["slug"]} | set(_tokenize(t.get("name") or ""))
+            names |= set(_tokenize(t["slug"]))
+            if text_tokens & names:
+                scores[t["slug"]] = 1.0
+
+    res = [{"slug": s, "score": float(sc)} for s, sc in scores.items()]
+    res.sort(key=lambda r: (-r["score"], r["slug"]))
+    return res
+
+
+def near_duplicates(candidates: list[dict], *, threshold: float = 0.0) -> list[str]:
+    """Slugs of candidates whose score is strictly greater than ``threshold``.
+
+    The caller sets the threshold to decide what counts as "too close, annotate
+    or merge instead of adding a new skill". The default (``0.0``) is a no-op
+    that flags nothing — near-duplicate detection is opt-in by passing a
+    positive threshold. Order is preserved from ``candidates``.
+    """
+    if threshold <= 0.0:
+        return []
+    out: list[str] = []
+    for c in candidates or []:
+        slug = c.get("slug")
+        score = c.get("score")
+        if slug is None or score is None:
+            continue
+        if float(score) > threshold:
+            out.append(slug)
+    return out
+
+
+# ===========================================================================
+# Collection-level matching — load skills_index.json and rank lexically.
+# (Skill-similarity matching is lexical by design; Perspicacité is used for the
+# separate literature-grounding step, not here — see the module docstring.)
+# ===========================================================================
+
+
+def _load_skills_index(collection_dir) -> list[dict]:
+    """Load ``skills_index.json`` for the lexical fallback. Never raises —
+    a missing/garbled file yields an empty index (callers degrade to no hits)."""
+    p = Path(str(collection_dir)) / "skills_index.json"
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if isinstance(data, dict):
+        # tolerate a wrapped {"skills": [...]} shape
+        data = data.get("skills") or data.get("entries") or []
+    return data if isinstance(data, list) else []
+
+
+def match_skills(text: str, collection_dir, *, k: int = 10) -> list[dict]:
+    """Match ``text`` against the collection's skills (serverless lexical core).
+
+    Scores the query against each skill's :func:`skill_doc` with TF-IDF cosine
+    over ``skills_index.json`` and returns up to ``k`` hits ``{slug, score,
+    backend:"lexical"}``, best first. Always returns a list and never raises — a
+    broken/empty collection yields ``[]``.
+    """
+    return lexical_match(text, _load_skills_index(collection_dir), k=k)

--- a/scripts/stamp_provenance.py
+++ b/scripts/stamp_provenance.py
@@ -1,0 +1,132 @@
+"""Propagate provenance_tier onto the committed artifacts.
+
+Backfills ``provenance_tier`` (DEFAULT = ``literature``) onto every skills_index
+entry and kb_bundle skill record that carries >=1 doi, and stamps
+``metadata.provenance_tier`` into each SKILL.md frontmatter. Field-only — no
+banner. Idempotent, indent / key-order preserving. Orthogonal to license_tier
+(see scripts/license_tier.py / scripts/propagate_license_tiers.py).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+
+from asb_skill_collections import layout
+from scripts.propagate_license_tiers import detect_indent
+from scripts.provenance_tier import DEFAULT
+from scripts.stamp_skill_license import _split
+
+
+def propagate_indices(skills_index_path, kb_bundle_path) -> dict:
+    """Set ``provenance_tier=DEFAULT`` on every skills_index entry and kb_bundle
+    skill record that has >=1 doi. Returns ``{tier: count}`` over skills_index.
+    Preserves JSON indent (``detect_indent``) and key order. Idempotent."""
+    si_path, kb_path = pathlib.Path(skills_index_path), pathlib.Path(kb_bundle_path)
+    si_raw = si_path.read_text(encoding="utf-8")
+    kb_raw = kb_path.read_text(encoding="utf-8")
+    si = json.loads(si_raw)
+    kb = json.loads(kb_raw)
+    si_indent = detect_indent(si_raw)
+    kb_indent = detect_indent(kb_raw)
+    summary: dict[str, int] = {}
+    for entry in si:
+        if entry.get("dois"):
+            entry["provenance_tier"] = DEFAULT
+            summary[DEFAULT] = summary.get(DEFAULT, 0) + 1
+    for rec in (kb.get("skills") or {}).values():
+        if rec.get("dois"):
+            rec["provenance_tier"] = DEFAULT
+    si_path.write_text(
+        json.dumps(si, indent=si_indent, ensure_ascii=False), encoding="utf-8"
+    )
+    kb_path.write_text(
+        json.dumps(kb, indent=kb_indent, ensure_ascii=False), encoding="utf-8"
+    )
+    return summary
+
+
+def stamp_skill_provenance(md_path, tier: str) -> bool:
+    """Set ``metadata.provenance_tier`` in SKILL.md frontmatter (no banner).
+
+    Creates the ``metadata`` dict if missing, guarding a ``metadata: null``
+    frontmatter. Round-trips via the license stamper's conventions
+    (``yaml.safe_dump(sort_keys=False, allow_unicode=True)``). Returns True iff
+    the file changed. Idempotent."""
+    p = pathlib.Path(md_path)
+    text = p.read_text(encoding="utf-8")
+    fm_raw, body = _split(text)
+    if fm_raw is None:
+        return False
+    fm = yaml.safe_load(fm_raw) or {}
+    if not isinstance(fm.get("metadata"), dict):
+        fm["metadata"] = {}
+    fm["metadata"]["provenance_tier"] = tier
+    new_text = (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+        + "---\n"
+        + body
+    )
+    if new_text == text:
+        return False
+    p.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def stamp_all(collection_dir, index_path) -> dict:
+    """Stamp each skill's SKILL.md with its index ``provenance_tier``.
+
+    Resolves through the canonical layout: a router-shaped collection keeps its
+    corpus in ``leaves/``, and sweeping a hardcoded ``skills/`` there would stamp
+    nothing while still reporting a clean run.
+
+    Returns ``{"changed": n, "tiers": {...}, "indexed_but_absent": n}``."""
+    si = json.loads(pathlib.Path(index_path).read_text(encoding="utf-8"))
+    roots = layout.skill_dirs(pathlib.Path(collection_dir))
+    changed = 0
+    tiers: dict[str, int] = {}
+    missing = 0
+    for e in si:
+        tier = e.get("provenance_tier")
+        if not tier:
+            continue
+        md = next((r / e["slug"] / "SKILL.md" for r in roots
+                   if (r / e["slug"] / "SKILL.md").is_file()), None)
+        if md is None:
+            missing += 1
+            continue
+        changed += 1 if stamp_skill_provenance(md, tier) else 0
+        tiers[tier] = tiers.get(tier, 0) + 1
+    return {"changed": changed, "tiers": tiers, "indexed_but_absent": missing}
+
+
+def main(argv=None):
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--collection",
+        required=True,
+        help="collection dir (holds skills_index.json + kb_bundle.json)",
+    )
+    a = ap.parse_args(argv)
+    prop = propagate_indices(
+        f"{a.collection}/skills_index.json", f"{a.collection}/kb_bundle.json"
+    )
+    res = stamp_all(a.collection, f"{a.collection}/skills_index.json")
+    print(json.dumps({"propagated": prop, **res}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/synthesize_meta_skill.py
+++ b/scripts/synthesize_meta_skill.py
@@ -1,0 +1,210 @@
+"""Synthesizer helper for auto-created **super-skills** (synthetic, or
+review-grounded **literature**, provenance).
+
+The deterministic half of the ``synthesize-meta-skill`` flow (the agentic
+``commands/synthesize-meta-skill.md`` does the identify-the-pipeline + body
+writing, then invokes this to cluster, assemble frontmatter, and stage). Three
+pieces, all pure logic + the community pipeline's real APIs — no LLM, no git/gh,
+no network beyond the *injected* matcher:
+
+* :func:`cluster_subskills` — a thin wrapper over the matcher
+  (:func:`scripts.skill_match.match_skills`, injectable for tests) that gathers
+  the candidate sub-skills clustered around a pipeline seed plus the tools they
+  ground on (via :func:`scripts.skill_match.match_tools`).
+* :func:`meta_frontmatter` — assemble a schema-correct ``super`` frontmatter,
+  reusing :func:`scripts.normalize_skill.normalized_frontmatter`
+  (``status="hold"``) and adding ``metadata.skill_kind="super"`` +
+  ``metadata.orchestrates``. The default origin is ``synthetic`` (derived from the
+  orchestrated skills); passing a ``review_doi`` instead grounds the pipeline in a
+  *review article* → ``provenance_tier="literature"`` with ``metadata.dois`` +
+  ``derived_from`` carrying that DOI. ``related_skills`` mirrors ``orchestrates``
+  so the result also satisfies the community ``related_skills``-key expectation.
+  Yields zero :func:`scripts.normalize_skill.frontmatter_violations`.
+* :func:`stage_meta_skill` — stage the synthesized SKILL.md + a
+  ``wave-meta-skills-<date>.yaml`` ledger, **reusing
+  :mod:`scripts.propose_skill`'s** idempotent writers (DRY; same proposals rail).
+  No git/gh side effects.
+
+See governance/META_SKILLS.md, governance/PROVENANCE_TIERS.md, and the design
+doc (docs/superpowers/specs/2026-06-26-synthetic-meta-skill-design.md).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import yaml
+
+from asb_skill_collections import layout
+from scripts import propose_skill
+from scripts.normalize_skill import normalized_frontmatter
+from scripts.skill_match import match_skills, match_tools
+
+
+def _load_index(collection_dir, filename: str) -> list[dict]:
+    """Load a JSON index file (``skills_index.json`` / ``tools_index.json``).
+
+    Never raises — a missing/garbled file yields an empty index (callers degrade
+    to no tool suggestions), tolerating a wrapped ``{"skills": [...]}`` shape.
+    """
+    p = pathlib.Path(str(collection_dir)) / filename
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — degrade gracefully like the matcher
+        return []
+    if isinstance(data, dict):
+        data = data.get("skills") or data.get("tools") or data.get("entries") or []
+    return data if isinstance(data, list) else []
+
+
+def cluster_subskills(
+    seed_text: str,
+    collection_dir,
+    *,
+    k: int = 15,
+    matcher=None,
+) -> dict:
+    """Cluster the candidate sub-skills + tools around a pipeline ``seed_text``.
+
+    Runs the matcher (default :func:`scripts.skill_match.match_skills`, injectable
+    so tests can pass a network-free fake) to gather up to ``k`` related sub-skills,
+    then resolves the tools those sub-skills ground on (plus lexical tool-name hits
+    in ``seed_text``) via :func:`scripts.skill_match.match_tools`.
+
+    Returns ``{"subskills": [{slug, score, ...}], "tools": [{slug, score}]}`` —
+    ``subskills`` is the matcher's output verbatim (so callers keep its ``score``/
+    ``backend``); ``tools`` is the ``{slug, score}`` cluster from ``match_tools``.
+    """
+    matcher = matcher or match_skills
+    subskills = list(matcher(seed_text, collection_dir, k=k) or [])
+
+    skills_index = _load_index(collection_dir, "skills_index.json")
+    tools_index = _load_index(collection_dir, "tools_index.json")
+    matched_slugs = [s.get("slug") for s in subskills if s.get("slug")]
+    tools = match_tools(matched_slugs, skills_index, tools_index, text=seed_text)
+
+    return {"subskills": subskills, "tools": tools}
+
+
+def meta_frontmatter(
+    *,
+    name: str,
+    description: str,
+    orchestrates,
+    synthesized_from,
+    tools_used,
+    license_tier: str = "open",
+    review_doi: str | None = None,
+) -> dict:
+    """Assemble a schema-correct super-skill frontmatter (synthetic or literature).
+
+    Reuses :func:`scripts.normalize_skill.normalized_frontmatter` and
+    ``status="hold"`` (so the deterministic EDAM/tool/tier assembly is shared with
+    the community rail), then layers the super-skill invariants the proposals gate
+    checks:
+
+    * ``metadata.skill_kind = "super"``,
+    * ``metadata.orchestrates = orchestrates`` (the sub-skill slugs it sequences),
+    * ``metadata.synthesized_from = synthesized_from`` (the source skill slugs;
+      kept non-empty for the synthetic invariant and as provenance even for a
+      review-grounded super-skill).
+
+    Origin (``provenance_tier``):
+
+    * **default (synthetic)** — ``review_doi is None``: the super-skill is derived
+      from the skills it orchestrates (``provenance_tier="synthetic"``).
+    * **literature** — when a ``review_doi`` is given, the pipeline is grounded in a
+      *review article*: ``provenance_tier="literature"``, ``metadata.dois =
+      [review_doi]`` (the literature ⇒ ≥1 doi invariant), and
+      ``derived_from = [{"doi": review_doi}]``. The super orchestration
+      (``skill_kind``/``orchestrates``/``synthesized_from``) is preserved.
+
+    ``related_skills`` mirrors ``orchestrates`` so the super-skill also satisfies
+    any community ``related_skills``-key expectation. The result yields zero
+    :func:`scripts.normalize_skill.frontmatter_violations`. Inputs are not mutated.
+    """
+    raw = {"name": name, "description": description}
+    if review_doi:
+        provenance_tier = "literature"
+        derived_from = [{"doi": review_doi}]
+    else:
+        provenance_tier = "synthetic"
+        derived_from = None
+    fm = normalized_frontmatter(
+        raw,
+        related_skills=list(orchestrates),
+        tools_used=list(tools_used),
+        license_tier=license_tier,
+        provenance_tier=provenance_tier,
+        status="hold",
+        derived_from=derived_from,
+    )
+    meta = fm["metadata"]
+    meta["skill_kind"] = "super"
+    meta["orchestrates"] = list(orchestrates)
+    meta["synthesized_from"] = list(synthesized_from)
+    if review_doi:
+        meta["dois"] = [review_doi]
+    return fm
+
+
+def _wave_date(ledger_meta: dict) -> str:
+    """Resolve the wave date from ``ledger_meta`` (``date`` or ``submitted_on``).
+
+    Required — there is **no** ``Date.now`` in importable code (mirrors
+    :func:`scripts.propose_skill.stage_proposal`); the command/CLI supplies it.
+    """
+    date = (ledger_meta or {}).get("date") or (ledger_meta or {}).get("submitted_on")
+    if not date:
+        raise ValueError(
+            "stage_meta_skill requires a wave date in ledger_meta "
+            "('date' or 'submitted_on', YYYY-MM-DD)"
+        )
+    return date
+
+
+def stage_meta_skill(collection_dir, frontmatter: dict, body: str, ledger_meta: dict) -> dict:
+    """Stage a synthesized super-skill into the ``proposals/`` rail. Idempotent.
+
+    Delegates to :mod:`scripts.propose_skill` (DRY — the SKILL.md slug/render and
+    the ledger insert/merge/idempotence logic are reused, not reimplemented). The
+    only difference from the community path is the ledger filename:
+    ``proposals/wave-meta-skills-<date>.yaml`` (vs ``wave-skills-<date>.yaml``) so
+    auto-synthesized meta-skills land in their own wave. No git/gh side effects.
+
+    Parameters mirror :func:`scripts.propose_skill.stage_proposal`; the wave
+    ``date`` is read from ``ledger_meta`` (``date`` / ``submitted_on``).
+
+    Returns ``{"slug", "skill_md", "ledger"}`` — the written paths.
+    """
+    date = _wave_date(ledger_meta)
+    root = pathlib.Path(collection_dir)
+
+    # Reuse propose_skill to resolve the slug + render the SKILL.md text.
+    slug = propose_skill._skill_slug(frontmatter, ledger_meta)
+    if not slug:
+        raise ValueError("cannot determine proposal slug (no name/slug provided)")
+
+    skill_md = layout.staging_dir(root) / slug / "SKILL.md"
+    ledger_path = root / "proposals" / f"wave-meta-skills-{date}.yaml"
+
+    # --- SKILL.md (write only when content changed: idempotent) --------------
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    new_text = propose_skill.render_skill_md(frontmatter, body)
+    if not (skill_md.exists() and skill_md.read_text(encoding="utf-8") == new_text):
+        skill_md.write_text(new_text, encoding="utf-8")
+
+    # --- wave-meta-skills ledger (insert/replace by slug, slug-sorted) -------
+    existing = {}
+    if ledger_path.exists():
+        existing = yaml.safe_load(ledger_path.read_text(encoding="utf-8")) or {}
+    entry = propose_skill._ledger_entry(slug, ledger_meta, date)
+    ledger = propose_skill._merge_ledger(existing, entry)
+    new_ledger_text = yaml.safe_dump(ledger, sort_keys=False, allow_unicode=True)
+    if not (
+        ledger_path.exists()
+        and ledger_path.read_text(encoding="utf-8") == new_ledger_text
+    ):
+        ledger_path.write_text(new_ledger_text, encoding="utf-8")
+
+    return {"slug": slug, "skill_md": str(skill_md), "ledger": str(ledger_path)}

--- a/scripts/tier_update.py
+++ b/scripts/tier_update.py
@@ -1,8 +1,19 @@
 """
 Tier update script -- called by tier-update.yml on merge of review PRs.
 
-Increments review counters in contributors.jsonld and re-evaluates
-the contributor's tier per curator-criteria.yaml for the collection.
+Two credit paths, both keyed on a contributor's ORCID in contributors.jsonld:
+
+* **Review path** (``--orcid ...``, the default): increments review counters
+  (``asb:total_reviews`` + ``asb:external_reviews``/``asb:self_authored_reviews``)
+  on merge of a review attestation, then re-evaluates the tier.
+* **Author-credit path** (``--credit-author``): a contributor listed as a skill
+  ``author`` (role ``author`` in a merged skill's ``contributors`` block) is
+  credited via a separate ``asb:authored_skills`` counter, then the tier is
+  re-evaluated. This never touches the review counters and never downgrades an
+  already-higher tier. See governance/AUTHORSHIP.md.
+
+Both re-evaluate the contributor's tier per curator-criteria.yaml for the
+collection.
 
 Exit codes:
   0 -- update applied
@@ -47,10 +58,17 @@ def evaluate_tier(
     total_reviews: int,
     external_reviews: int,
     criteria: dict,
+    authored_skills: int = 0,
 ) -> str:
     """
     Return the highest tier the contributor qualifies for based on review counts.
     Note: pub count + h-index are checked during candidacy vetting, not here.
+
+    The higher tiers (domain_contributor and above) are earned through
+    **reviews**. ``authored_skills`` participates only at the **reviewer** entry
+    tier: a contributor who has authored >=1 merged skill qualifies as a
+    reviewer even with zero reviews, matching the author-credit path. Backward
+    compatible — the default ``authored_skills=0`` reproduces the old behavior.
     """
     thresholds = criteria.get("thresholds", {})
 
@@ -70,7 +88,7 @@ def evaluate_tier(
         return "domain_contributor"
 
     reviewer = thresholds.get("reviewer", {})
-    if total_reviews >= reviewer.get("min_reviews", 1):
+    if total_reviews >= reviewer.get("min_reviews", 1) or authored_skills >= 1:
         return "reviewer"
 
     return "none"
@@ -105,9 +123,10 @@ def update_contributor(
 
     total = contrib["asb:total_reviews"]
     external = contrib.get("asb:external_reviews", 0)
+    authored = contrib.get("asb:authored_skills", 0)
 
-    # Re-evaluate tier
-    new_tier = evaluate_tier(total, external, criteria)
+    # Re-evaluate tier (authored skills count toward the reviewer entry tier).
+    new_tier = evaluate_tier(total, external, criteria, authored_skills=authored)
     contrib["asb:tier"] = new_tier
 
     save_contributors(registry, contributors_path)
@@ -119,20 +138,77 @@ def update_contributor(
                 "new_tier": new_tier,
                 "total_reviews": total,
                 "external_reviews": external,
+                "authored_skills": authored,
             }
         )
     )
 
 
-def main() -> None:
+def credit_author(
+    contributors_path: Path,
+    criteria_path: Path,
+    orcid: str,
+    collection_slug: str,
+) -> None:
+    """Credit a skill **author** on merge of their authored skill.
+
+    Increments the contributor's ``asb:authored_skills`` counter and
+    re-evaluates the tier. This path is independent of the review counters and,
+    by construction of :func:`evaluate_tier`, never downgrades an already-higher
+    tier (authored skills only reach the reviewer entry tier). See
+    governance/AUTHORSHIP.md.
+    """
+    registry = load_contributors(contributors_path)
+    criteria = load_criteria(criteria_path)
+
+    contrib = find_contributor(registry, orcid)
+    if contrib is None:
+        print(
+            f"ERROR: contributor {orcid} not found in contributors.jsonld",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    contrib["asb:authored_skills"] = contrib.get("asb:authored_skills", 0) + 1
+
+    total = contrib.get("asb:total_reviews", 0)
+    external = contrib.get("asb:external_reviews", 0)
+    authored = contrib["asb:authored_skills"]
+
+    new_tier = evaluate_tier(total, external, criteria, authored_skills=authored)
+    contrib["asb:tier"] = new_tier
+
+    save_contributors(registry, contributors_path)
+    print(
+        json.dumps(
+            {
+                "orcid": orcid,
+                "collection": collection_slug,
+                "credited": "author",
+                "new_tier": new_tier,
+                "authored_skills": authored,
+            }
+        )
+    )
+
+
+def main(argv=None) -> None:
     parser = argparse.ArgumentParser(
-        description="Update contributor tier after review merge."
+        description="Update contributor tier after a review or authored-skill merge."
     )
     parser.add_argument("--orcid", required=True)
     parser.add_argument(
         "--collection", required=True, help="Collection slug (e.g., metabolomics)"
     )
     parser.add_argument("--is-self-authored", action="store_true")
+    parser.add_argument(
+        "--credit-author",
+        action="store_true",
+        help=(
+            "Author-credit path: credit the contributor as a merged-skill author "
+            "(increments asb:authored_skills) instead of a reviewer."
+        ),
+    )
     parser.add_argument(
         "--contributors",
         default="contributors.jsonld",
@@ -143,15 +219,23 @@ def main() -> None:
         required=True,
         help="Path to curator-criteria.yaml for this collection",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    update_contributor(
-        Path(args.contributors),
-        Path(args.criteria),
-        args.orcid,
-        args.collection,
-        args.is_self_authored,
-    )
+    if args.credit_author:
+        credit_author(
+            Path(args.contributors),
+            Path(args.criteria),
+            args.orcid,
+            args.collection,
+        )
+    else:
+        update_contributor(
+            Path(args.contributors),
+            Path(args.criteria),
+            args.orcid,
+            args.collection,
+            args.is_self_authored,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_build_related_skills.py
+++ b/tests/test_build_related_skills.py
@@ -1,0 +1,277 @@
+"""Tests for the embedding similarity graph (Task B4).
+
+A FAKE deterministic embedder is used everywhere — NO sentence-transformers
+model, NO network. The fake maps each skill's text to a fixed vector keyed by a
+sentinel token in the text, so cosine neighbours are known up front.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+from scripts import build_related_skills as brs
+from scripts import check_related_skills as crs
+
+
+# --------------------------------------------------------------------------- #
+# Fake embedder: deterministic vectors picked by a token in the text.
+# --------------------------------------------------------------------------- #
+# Four 2-D unit-ish vectors. a/b are close (small angle); c is orthogonal to a;
+# d is anti-parallel to a (cosine < 0).
+_VECTORS = {
+    "AAA": [1.0, 0.0],
+    "BBB": [0.96, 0.28],   # ~16 deg from AAA  -> cosine ~0.96
+    "CCC": [0.0, 1.0],     # orthogonal to AAA -> cosine 0.0
+    "DDD": [-1.0, 0.0],    # opposite AAA      -> cosine -1.0
+}
+
+
+def _fake_embed(texts):
+    out = []
+    for t in texts:
+        for token, vec in _VECTORS.items():
+            if token in t:
+                out.append(list(vec))
+                break
+        else:  # pragma: no cover - guard, tests always tag their text
+            out.append([0.0, 0.0])
+    return out
+
+
+def _index(*pairs):
+    """Build a minimal skills_index list. Each pair = (slug, tag-token)."""
+    return [
+        {"slug": slug, "name": slug, "description": f"desc {tag}", "tools": []}
+        for slug, tag in pairs
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# related_map — pure cosine top-N.
+# --------------------------------------------------------------------------- #
+def test_related_map_orders_by_cosine_and_excludes_self_and_below_threshold():
+    vectors = {
+        "a": _VECTORS["AAA"],
+        "b": _VECTORS["BBB"],
+        "c": _VECTORS["CCC"],
+        "d": _VECTORS["DDD"],
+    }
+    rel = brs.related_map(vectors, top_n=8, threshold=0.3)
+    # a is close to b only (c=0.0 below threshold, d negative)
+    assert rel["a"] == ["b"]
+    assert rel["b"] == ["a"]
+    # c orthogonal to everything -> no neighbours above 0.3
+    assert rel["c"] == []
+    # never include self
+    for slug, neighbours in rel.items():
+        assert slug not in neighbours
+
+
+def test_related_map_respects_top_n():
+    # three mutually-close vectors plus one far one
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.99, 0.10],
+        "c": [0.98, 0.15],
+        "z": [0.0, 1.0],
+    }
+    rel = brs.related_map(vectors, top_n=1, threshold=0.3)
+    assert len(rel["a"]) == 1
+    # the single nearest neighbour of a is b (higher cosine than c)
+    assert rel["a"] == ["b"]
+
+
+def test_related_map_slug_tie_break():
+    # b and c are at the SAME cosine to a -> tie broken by slug ascending.
+    vectors = {
+        "a": [1.0, 0.0],
+        "c": [0.8, 0.6],
+        "b": [0.8, -0.6],
+    }
+    rel = brs.related_map(vectors, top_n=8, threshold=0.3)
+    assert rel["a"] == ["b", "c"]
+
+
+def test_related_map_empty():
+    assert brs.related_map({}, top_n=8, threshold=0.3) == {}
+
+
+# --------------------------------------------------------------------------- #
+# embed_skills — text via skill_match.skill_doc, vectors via injected embedder.
+# --------------------------------------------------------------------------- #
+def test_embed_skills_uses_injected_embedder():
+    idx = _index(("a", "AAA"), ("b", "BBB"))
+    vecs = brs.embed_skills(idx, embedder=_fake_embed)
+    assert set(vecs) == {"a", "b"}
+    assert vecs["a"] == _VECTORS["AAA"]
+    assert vecs["b"] == _VECTORS["BBB"]
+
+
+# --------------------------------------------------------------------------- #
+# build — writes related_skills into both indices, indent-preserving + idempotent.
+# --------------------------------------------------------------------------- #
+def _write_collection(tmp_path, pairs):
+    col = tmp_path / "col"
+    col.mkdir()
+    idx = _index(*pairs)
+    (col / "skills_index.json").write_text(
+        json.dumps(idx, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    kb = {"collection": "x", "version": 2, "skills": {
+        slug: {"dois": [], "tools": []} for slug, _ in pairs
+    }}
+    (col / "kb_bundle.json").write_text(
+        json.dumps(kb, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return col
+
+
+def test_build_writes_related_skills_into_both_indices(tmp_path):
+    col = _write_collection(
+        tmp_path, [("a", "AAA"), ("b", "BBB"), ("c", "CCC")]
+    )
+    res = brs.build(col, embedder=_fake_embed, top_n=8)
+    assert res["count"] == 3
+
+    si = json.loads((col / "skills_index.json").read_text())
+    by_slug = {e["slug"]: e for e in si}
+    assert by_slug["a"]["related_skills"] == ["b"]
+    assert by_slug["b"]["related_skills"] == ["a"]
+    assert by_slug["c"]["related_skills"] == []
+
+    kb = json.loads((col / "kb_bundle.json").read_text())
+    assert kb["skills"]["a"]["related_skills"] == ["b"]
+    assert kb["skills"]["c"]["related_skills"] == []
+
+
+def test_build_is_idempotent(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    first_si = (col / "skills_index.json").read_text()
+    first_kb = (col / "kb_bundle.json").read_text()
+
+    res2 = brs.build(col, embedder=_fake_embed, top_n=8)
+    assert res2["written"] is False
+    assert (col / "skills_index.json").read_text() == first_si
+    assert (col / "kb_bundle.json").read_text() == first_kb
+
+
+def test_build_preserves_four_space_indent(tmp_path):
+    col = tmp_path / "col"
+    col.mkdir()
+    idx = _index(("a", "AAA"), ("b", "BBB"))
+    (col / "skills_index.json").write_text(
+        json.dumps(idx, indent=4, ensure_ascii=False), encoding="utf-8"
+    )
+    kb = {"skills": {"a": {"dois": []}, "b": {"dois": []}}}
+    (col / "kb_bundle.json").write_text(
+        json.dumps(kb, indent=4, ensure_ascii=False), encoding="utf-8"
+    )
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    text = (col / "skills_index.json").read_text()
+    # a 4-space-indented file keeps 4-space indentation after the write.
+    assert '\n        "slug"' in text or '\n    {' in text
+
+
+# --------------------------------------------------------------------------- #
+# default_embedder — lazy import; module must import WITHOUT the extra.
+# --------------------------------------------------------------------------- #
+def test_module_imports_without_sentence_transformers():
+    # Re-importing the module must not require sentence-transformers.
+    mod = importlib.reload(importlib.import_module("scripts.build_related_skills"))
+    assert hasattr(mod, "default_embedder")
+    assert hasattr(mod, "related_map")
+
+
+def test_default_embedder_is_lazy(monkeypatch):
+    # Calling default_embedder() without the extra installed raises a helpful
+    # ImportError — but merely importing the module (done above) does not.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block(name, *args, **kwargs):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise ImportError("no sentence_transformers")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block)
+    with pytest.raises(ImportError):
+        brs.default_embedder()
+
+
+# --------------------------------------------------------------------------- #
+# check_related_skills gate.
+# --------------------------------------------------------------------------- #
+def test_gate_passes_on_clean_collection(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB"), ("c", "CCC")])
+    brs.build(col, embedder=_fake_embed, top_n=8)
+    assert crs.check_collection(col) == []
+
+
+def test_gate_passes_when_field_absent(tmp_path):
+    # No related_skills written anywhere -> vacuously clean (real-data state).
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    assert crs.check_collection(col) == []
+
+
+def test_gate_flags_dangling_reference(tmp_path):
+    col = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    si = json.loads((col / "skills_index.json").read_text())
+    for e in si:
+        if e["slug"] == "a":
+            e["related_skills"] = ["does-not-exist"]
+    (col / "skills_index.json").write_text(
+        json.dumps(si, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    violations = crs.check_collection(col)
+    assert violations
+    assert any("does-not-exist" in v for v in violations)
+
+
+def test_gate_main_exit_codes(tmp_path):
+    clean = _write_collection(tmp_path, [("a", "AAA"), ("b", "BBB")])
+    brs.build(clean, embedder=_fake_embed, top_n=8)
+    assert crs.main([str(clean)]) == 0
+
+    dirty = tmp_path / "dirty"
+    dirty.mkdir()
+    (dirty / "skills_index.json").write_text(
+        json.dumps([{"slug": "a", "related_skills": ["ghost"]}], indent=2),
+        encoding="utf-8",
+    )
+    (dirty / "kb_bundle.json").write_text(
+        json.dumps({"skills": {}}, indent=2), encoding="utf-8"
+    )
+    assert crs.main([str(dirty)]) == 1
+
+
+# --- backend factory (no model/network) -------------------------------------
+
+def test_embedder_for_dispatches(monkeypatch):
+    monkeypatch.setattr(brs, "default_embedder", lambda: "LOCAL")
+    monkeypatch.setattr(brs, "openai_embedder", lambda **kw: "OPENAI")
+    assert brs.embedder_for("local") == "LOCAL"
+    assert brs.embedder_for("openai") == "OPENAI"
+    with pytest.raises(ValueError):
+        brs.embedder_for("nope")
+
+
+def test_default_backend_follows_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert brs.default_backend() == "openai"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert brs.default_backend() == "local"
+
+
+def test_openai_embedder_requires_key(monkeypatch):
+    # With no key, constructing the openai backend must fail clearly (not silently).
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    import sys, types
+    fake = types.ModuleType("openai")
+    fake.OpenAI = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "openai", fake)
+    with pytest.raises(RuntimeError):
+        brs.openai_embedder()

--- a/tests/test_check_proposals.py
+++ b/tests/test_check_proposals.py
@@ -1,0 +1,458 @@
+import json
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import check_proposals as c
+
+
+VALID_DESC = (
+    "Use when you have a raw LC-MS feature table and need to filter blank "
+    "contamination before downstream statistical analysis of metabolites."
+)
+
+
+def _good_fm(slug="my-new-skill", tools_used=None, **overrides):
+    fm = {
+        "name": slug,
+        "description": VALID_DESC,
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+            "license_tier": "open",
+            "provenance_tier": "community",
+            "tools_used": ["mzmine"] if tools_used is None else tools_used,
+        },
+        "status": "hold",
+        "related_skills": ["lc-ms-feature-extraction"],
+    }
+    fm.update(overrides)
+    return fm
+
+
+def _synthetic_fm(
+    slug="my-meta-skill",
+    tools_used=None,
+    synthesized_from=("lc-ms-feature-extraction", "spectral-similarity-scoring"),
+    skill_kind="super",
+    orchestrates=("lc-ms-feature-extraction", "spectral-similarity-scoring"),
+    **overrides,
+):
+    """A synthetic-provenance (optionally super) staged proposal frontmatter.
+
+    Synthetic proposals are valid via ``metadata.synthesized_from`` rather than
+    the community ``related_skills`` key.
+    """
+    meta = {
+        "edam_operation": "http://edamontology.org/operation_3215",
+        "edam_topics": ["http://edamontology.org/topic_0091"],
+        "license_tier": "open",
+        "provenance_tier": "synthetic",
+        "tools_used": ["mzmine"] if tools_used is None else tools_used,
+    }
+    if synthesized_from is not None:
+        meta["synthesized_from"] = list(synthesized_from)
+    if skill_kind is not None:
+        meta["skill_kind"] = skill_kind
+    if orchestrates is not None:
+        meta["orchestrates"] = list(orchestrates)
+    fm = {
+        "name": slug,
+        "description": VALID_DESC,
+        "license": "CC-BY-4.0",
+        "metadata": meta,
+        "status": "hold",
+    }
+    fm.update(overrides)
+    return fm
+
+
+def _literature_fm(
+    slug="my-review-meta-skill",
+    tools_used=None,
+    dois=("10.1021/acs.analchem.0c01234",),
+    synthesized_from=("lc-ms-feature-extraction", "spectral-similarity-scoring"),
+    skill_kind="super",
+    orchestrates=("lc-ms-feature-extraction", "spectral-similarity-scoring"),
+    **overrides,
+):
+    """A review-grounded (literature-provenance) staged super-skill frontmatter.
+
+    Literature proposals are valid via >=1 source ``metadata.dois`` (the review
+    DOI), while keeping the super orchestration invariants.
+    """
+    meta = {
+        "edam_operation": "http://edamontology.org/operation_3215",
+        "edam_topics": ["http://edamontology.org/topic_0091"],
+        "license_tier": "open",
+        "provenance_tier": "literature",
+        "tools_used": ["mzmine"] if tools_used is None else tools_used,
+    }
+    if dois is not None:
+        meta["dois"] = list(dois)
+    if synthesized_from is not None:
+        meta["synthesized_from"] = list(synthesized_from)
+    if skill_kind is not None:
+        meta["skill_kind"] = skill_kind
+    if orchestrates is not None:
+        meta["orchestrates"] = list(orchestrates)
+    fm = {
+        "name": slug,
+        "description": VALID_DESC,
+        "license": "CC-BY-4.0",
+        "metadata": meta,
+        "status": "hold",
+    }
+    if dois is not None:
+        fm["derived_from"] = [{"doi": d} for d in dois]
+    fm.update(overrides)
+    return fm
+
+
+def _write_skill(col, fm, body="# Skill\n\nbody\n"):
+    slug = fm["name"]
+    d = col / "proposals" / "skills" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    text = "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n" + body
+    (d / "SKILL.md").write_text(text)
+
+
+def _collection(
+    tmp_path,
+    tool_slugs=("mzmine",),
+    skill_slugs=("lc-ms-feature-extraction", "spectral-similarity-scoring"),
+):
+    col = tmp_path / "v2"
+    col.mkdir(parents=True)
+    tools = [{"slug": s, "license_tier": "open", "used_by_skills": []} for s in tool_slugs]
+    (col / "tools_index.json").write_text(json.dumps(tools))
+    skills = [{"slug": s} for s in skill_slugs]
+    (col / "skills_index.json").write_text(json.dumps(skills))
+    return col
+
+
+# --- no proposals dir => clean -----------------------------------------------
+
+def test_no_proposals_dir_returns_empty(tmp_path):
+    col = _collection(tmp_path)
+    assert c.check_collection(str(col)) == []
+
+
+def test_empty_proposals_skills_dir_returns_empty(tmp_path):
+    col = _collection(tmp_path)
+    (col / "proposals" / "skills").mkdir(parents=True)
+    assert c.check_collection(str(col)) == []
+
+
+# --- clean staged skill passes -----------------------------------------------
+
+def test_clean_staged_skill_passes(tmp_path):
+    col = _collection(tmp_path)
+    _write_skill(col, _good_fm())
+    assert c.check_collection(str(col)) == []
+
+
+# --- bad provenance tier -----------------------------------------------------
+
+def test_unknown_provenance_tier_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["metadata"]["provenance_tier"] = "made-up"
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("provenance_tier" in x and "made-up" in x for x in v)
+
+
+# --- missing related_skills key ----------------------------------------------
+
+def test_missing_related_skills_key_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    del fm["related_skills"]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("related_skills" in x for x in v)
+
+
+# --- status not hold ---------------------------------------------------------
+
+def test_status_not_hold_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["status"] = "accepted"
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("status" in x and "hold" in x for x in v)
+
+
+# --- dangling tools_used -----------------------------------------------------
+
+def test_dangling_tools_used_fails(tmp_path):
+    col = _collection(tmp_path, tool_slugs=("mzmine",))
+    fm = _good_fm(tools_used=["mzmine", "ghost-tool"])
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("ghost-tool" in x for x in v)
+
+
+# --- marketing description (frontmatter_violations) --------------------------
+
+def test_marketing_description_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["description"] = (
+        "Use when you want the best approach to filter blank contamination "
+        "from your LC-MS feature table before statistical analysis."
+    )
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("marketing" in x.lower() or "best" in x for x in v)
+
+
+def test_bad_edam_iri_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["metadata"]["edam_operation"] = "https://edamontology.org/operation_3215"
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("edam" in x.lower() for x in v)
+
+
+def test_non_mapping_frontmatter_reports_clean_violation(tmp_path):
+    # A hand-authored proposal whose frontmatter parses to a list/scalar must yield
+    # a clean violation, not an uncaught AttributeError traceback.
+    col = _collection(tmp_path)
+    d = col / "proposals" / "skills" / "broken"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text("---\n- just\n- a\n- list\n---\n# Skill\n")
+    v = c.check_collection(str(col))
+    assert any("not a mapping" in x for x in v)
+
+
+# --- synthetic provenance + super invariants ---------------------------------
+
+def test_clean_synthetic_super_skill_passes(tmp_path):
+    # A synthetic super-skill is valid via synthesized_from + a resolvable
+    # orchestrates list — no community related_skills key required.
+    col = _collection(tmp_path)
+    _write_skill(col, _synthetic_fm())
+    assert c.check_collection(str(col)) == []
+
+
+def test_synthetic_without_synthesized_from_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(synthesized_from=None)
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("synthesized_from" in x for x in v)
+
+
+def test_synthetic_with_empty_synthesized_from_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm()
+    fm["metadata"]["synthesized_from"] = []
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("synthesized_from" in x for x in v)
+
+
+def test_super_with_empty_orchestrates_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(orchestrates=None)
+    fm["metadata"]["orchestrates"] = []
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("orchestrates" in x for x in v)
+
+
+def test_super_with_absent_orchestrates_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(orchestrates=None)  # key absent entirely
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("orchestrates" in x for x in v)
+
+
+def test_super_orchestrates_slug_not_in_index_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(
+        synthesized_from=("lc-ms-feature-extraction", "ghost-skill"),
+        orchestrates=("lc-ms-feature-extraction", "ghost-skill"),
+    )
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("ghost-skill" in x for x in v)
+
+
+def test_synthetic_skill_kind_skill_does_not_require_orchestrates(tmp_path):
+    # Default/explicit non-super kind => orchestrates is irrelevant.
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(skill_kind="skill", orchestrates=None)
+    _write_skill(col, fm)
+    assert c.check_collection(str(col)) == []
+
+
+def test_synthetic_default_skill_kind_is_skill(tmp_path):
+    # No skill_kind key => treated as 'skill', so no orchestrates needed.
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(skill_kind=None, orchestrates=None)
+    _write_skill(col, fm)
+    assert c.check_collection(str(col)) == []
+
+
+def test_invalid_skill_kind_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _synthetic_fm(skill_kind="orchestrator", orchestrates=None)
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("skill_kind" in x for x in v)
+
+
+# --- literature provenance (review-grounded super-skills) --------------------
+
+def test_clean_literature_super_skill_passes(tmp_path):
+    # A review-grounded super-skill is valid via >=1 source DOI + a resolvable
+    # orchestrates list — no community related_skills key required.
+    col = _collection(tmp_path)
+    _write_skill(col, _literature_fm())
+    assert c.check_collection(str(col)) == []
+
+
+def test_literature_without_doi_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _literature_fm(dois=None)
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("doi" in x.lower() for x in v)
+
+
+def test_literature_with_empty_dois_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _literature_fm()
+    fm["metadata"]["dois"] = []
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("doi" in x.lower() for x in v)
+
+
+def test_literature_super_still_resolves_orchestrates(tmp_path):
+    # The super invariants apply regardless of provenance: a literature super
+    # with a dangling orchestrate slug must fail.
+    col = _collection(tmp_path)
+    fm = _literature_fm(
+        synthesized_from=("lc-ms-feature-extraction", "ghost-skill"),
+        orchestrates=("lc-ms-feature-extraction", "ghost-skill"),
+    )
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("ghost-skill" in x for x in v)
+
+
+def test_community_skill_with_super_kind_resolves_orchestrates(tmp_path):
+    # skill_kind/orchestrates apply regardless of provenance; a community super
+    # with a dangling orchestrate slug must fail.
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["metadata"]["skill_kind"] = "super"
+    fm["metadata"]["orchestrates"] = ["lc-ms-feature-extraction", "ghost-skill"]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("ghost-skill" in x for x in v)
+
+
+# --- contributors (co-authorship attribution) --------------------------------
+
+def test_no_contributors_key_passes(tmp_path):
+    # contributors is optional — a staged skill without it is still valid.
+    col = _collection(tmp_path)
+    _write_skill(col, _good_fm())
+    assert c.check_collection(str(col)) == []
+
+
+def test_valid_contributors_block_passes(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = [
+        {"name": "Ada Lovelace", "role": "author", "orcid": "0000-0002-1825-0097"},
+        {"name": "Grace Hopper", "role": "reviewer"},
+    ]
+    _write_skill(col, fm)
+    assert c.check_collection(str(col)) == []
+
+
+def test_contributors_not_a_list_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = {"name": "Ada", "role": "author"}
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() for x in v)
+
+
+def test_contributor_entry_not_mapping_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = ["Ada Lovelace"]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() and "mapping" in x.lower() for x in v)
+
+
+def test_contributor_missing_name_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = [{"role": "author"}]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() and "name" in x.lower() for x in v)
+
+
+def test_contributor_empty_name_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = [{"name": "  ", "role": "author"}]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() and "name" in x.lower() for x in v)
+
+
+def test_contributor_missing_role_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = [{"name": "Ada"}]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() and "role" in x.lower() for x in v)
+
+
+def test_contributor_bad_role_fails(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["contributors"] = [{"name": "Ada", "role": "maintainer"}]
+    _write_skill(col, fm)
+    v = c.check_collection(str(col))
+    assert any("contributor" in x.lower() and "role" in x.lower() for x in v)
+
+
+# --- main(argv) exit codes ---------------------------------------------------
+
+def test_main_exits_zero_when_no_proposals(tmp_path):
+    col = _collection(tmp_path)
+    assert c.main([str(col)]) == 0
+
+
+def test_main_exits_zero_on_clean_staged(tmp_path):
+    col = _collection(tmp_path)
+    _write_skill(col, _good_fm())
+    assert c.main([str(col)]) == 0
+
+
+def test_main_exits_one_on_violation(tmp_path):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["status"] = "accepted"
+    _write_skill(col, fm)
+    assert c.main([str(col)]) == 1

--- a/tests/test_check_provenance_tiers.py
+++ b/tests/test_check_provenance_tiers.py
@@ -1,0 +1,62 @@
+import json, pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import check_provenance_tiers as c
+
+
+def _collection(tmp_path, si_entries, skills=None):
+    d = tmp_path / "v"
+    (d / "skills").mkdir(parents=True)
+    (d / "skills_index.json").write_text(json.dumps(si_entries))
+    for slug, fm in (skills or {}).items():
+        (d / "skills" / slug).mkdir()
+        (d / "skills" / slug / "SKILL.md").write_text(f"---\n{fm}---\nbody\n")
+    return d
+
+
+def test_clean_collection_passes(tmp_path):
+    d = _collection(
+        tmp_path,
+        [{"slug": "s1", "provenance_tier": "literature", "dois": ["10.1/a"]}],
+        skills={"s1": "name: s1\nmetadata:\n  provenance_tier: literature\n"},
+    )
+    assert c.check_collection(str(d)) == []
+
+
+def test_bad_tier_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        [{"slug": "s1", "provenance_tier": "bogus", "dois": ["10.1/a"]}],
+        skills={"s1": "name: s1\nmetadata:\n  provenance_tier: bogus\n"},
+    )
+    v = c.check_collection(str(d))
+    assert any("s1" in x and "provenance_tier" in x for x in v)
+
+
+def test_literature_without_doi_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        [{"slug": "s1", "provenance_tier": "literature", "dois": []}],
+        skills={"s1": "name: s1\nmetadata:\n  provenance_tier: literature\n"},
+    )
+    v = c.check_collection(str(d))
+    assert any("s1" in x and "doi" in x for x in v)
+
+
+def test_skill_md_mismatch_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        [{"slug": "s1", "provenance_tier": "literature", "dois": ["10.1/a"]}],
+        skills={"s1": "name: s1\nmetadata:\n  provenance_tier: synthetic\n"},
+    )
+    v = c.check_collection(str(d))
+    assert any("s1" in x and ("mismatch" in x or "!=" in x) for x in v)
+
+
+def test_skill_md_missing_tier_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        [{"slug": "s1", "provenance_tier": "literature", "dois": ["10.1/a"]}],
+        skills={"s1": "name: s1\nmetadata:\n  license_tier: open\n"},
+    )
+    v = c.check_collection(str(d))
+    assert any("s1" in x and "provenance_tier" in x for x in v)

--- a/tests/test_check_tools_index.py
+++ b/tests/test_check_tools_index.py
@@ -1,0 +1,164 @@
+import json, pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import check_tools_index as c
+
+
+def _collection(tmp_path, tools_index, skills_index):
+    d = tmp_path / "v"
+    d.mkdir(parents=True)
+    (d / "tools_index.json").write_text(json.dumps(tools_index))
+    (d / "skills_index.json").write_text(json.dumps(skills_index))
+    return d
+
+
+def test_clean_collection_passes(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[
+            {"slug": "t1", "license_tier": "open", "used_by_skills": ["s1"]},
+            {"slug": "t2", "license_tier": "restricted", "used_by_skills": []},
+        ],
+        skills_index=[
+            {"slug": "s1", "tools_used": ["t1"]},
+            {"slug": "s2", "tools_used": []},
+        ],
+    )
+    assert c.check_collection(str(d)) == []
+
+
+def test_bad_tool_tier_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[
+            {"slug": "t1", "license_tier": "bogus", "used_by_skills": []},
+        ],
+        skills_index=[
+            {"slug": "s1", "tools_used": []},
+        ],
+    )
+    v = c.check_collection(str(d))
+    assert any("t1" in x and "license_tier" in x for x in v)
+
+
+def test_missing_tool_tier_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[
+            {"slug": "t1", "used_by_skills": []},
+        ],
+        skills_index=[],
+    )
+    v = c.check_collection(str(d))
+    assert any("t1" in x and "license_tier" in x for x in v)
+
+
+def test_dangling_tools_used_ref_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[
+            {"slug": "t1", "license_tier": "open", "used_by_skills": []},
+        ],
+        skills_index=[
+            {"slug": "s1", "tools_used": ["t_ghost"]},
+        ],
+    )
+    v = c.check_collection(str(d))
+    assert any("s1" in x and "t_ghost" in x for x in v)
+
+
+def test_dangling_used_by_skills_ref_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[
+            {"slug": "t1", "license_tier": "open", "used_by_skills": ["s_ghost"]},
+        ],
+        skills_index=[
+            {"slug": "s1", "tools_used": []},
+        ],
+    )
+    v = c.check_collection(str(d))
+    assert any("t1" in x and "s_ghost" in x for x in v)
+
+
+def test_main_exits_nonzero_on_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "bogus", "used_by_skills": []}],
+        skills_index=[],
+    )
+    assert c.main([str(d)]) == 1
+
+
+def test_main_exits_zero_on_clean(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[{"slug": "s1", "tools_used": []}],
+    )
+    assert c.main([str(d)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-tool YAML <-> tools_index license_tier cross-check
+# ---------------------------------------------------------------------------
+
+def _write_tool_yaml(d, slug, **fields):
+    (d / "tools").mkdir(exist_ok=True)
+    lines = [f"slug: {slug}"]
+    for k, v in fields.items():
+        lines.append(f"{k}: {v}")
+    (d / "tools" / f"{slug}.yaml").write_text("\n".join(lines) + "\n")
+
+
+def test_tool_yaml_tier_match_passes(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[],
+    )
+    _write_tool_yaml(d, "t1", license_tier="open")
+    assert c.check_collection(str(d)) == []
+
+
+def test_tool_yaml_tier_mismatch_is_violation(tmp_path):
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[],
+    )
+    _write_tool_yaml(d, "t1", license_tier="restricted")
+    v = c.check_collection(str(d))
+    assert any("t1" in x and "license_tier" in x and "tools/" in x for x in v)
+
+
+def test_tool_yaml_missing_tier_is_violation(tmp_path):
+    # YAML exists but never got enriched -> the cross-check flags it.
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[],
+    )
+    _write_tool_yaml(d, "t1", name="T1")
+    v = c.check_collection(str(d))
+    assert any("t1" in x and "license_tier" in x and "tools/" in x for x in v)
+
+
+def test_tool_without_yaml_is_skipped(tmp_path):
+    # tools/<slug>.yaml absent -> no YAML cross-check violation for that tool.
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[],
+    )
+    (d / "tools").mkdir(exist_ok=True)  # dir exists but no t1.yaml
+    assert c.check_collection(str(d)) == []
+
+
+def test_no_tools_dir_is_skipped(tmp_path):
+    # No tools/ dir at all -> cross-check is a no-op (back-compat).
+    d = _collection(
+        tmp_path,
+        tools_index=[{"slug": "t1", "license_tier": "open", "used_by_skills": []}],
+        skills_index=[],
+    )
+    assert c.check_collection(str(d)) == []

--- a/tests/test_enrich_tool_yaml.py
+++ b/tests/test_enrich_tool_yaml.py
@@ -1,0 +1,151 @@
+import pathlib
+import sys
+import textwrap
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import enrich_tool_yaml as e
+
+
+# ---------------------------------------------------------------------------
+# tier_map
+# ---------------------------------------------------------------------------
+
+def test_tier_map_extracts_license_fields():
+    tools_index = [
+        {"slug": "t_open", "license_tier": "open", "license": "MIT",
+         "license_detection": "github-api"},
+        {"slug": "t_nc", "license_tier": "noncommercial", "license": "CC-BY-NC-4.0",
+         "license_detection": "readme-llm"},
+        {"slug": "t_restricted", "license_tier": "restricted", "license": None,
+         "license_detection": "none"},
+    ]
+    m = e.tier_map(tools_index)
+    assert m["t_open"] == {"license_tier": "open", "license": "MIT",
+                           "license_detection": "github-api"}
+    assert m["t_nc"]["license_tier"] == "noncommercial"
+    assert m["t_restricted"]["license"] is None
+    assert m["t_restricted"]["license_detection"] == "none"
+
+
+def test_tier_map_defaults_missing_fields():
+    # A tools_index entry that only carries the tier still yields a complete row.
+    m = e.tier_map([{"slug": "t1", "license_tier": "open"}])
+    assert m["t1"] == {"license_tier": "open", "license": None,
+                       "license_detection": None}
+
+
+# ---------------------------------------------------------------------------
+# enrich — fixture with two tool YAMLs
+# ---------------------------------------------------------------------------
+
+def _write_collection(tmp_path):
+    d = tmp_path
+    tools = d / "tools"
+    tools.mkdir()
+    # tool A: a "generated" style record ending in schema_version, with a
+    # later-appended techniques block (matches the real committed shape).
+    (tools / "tool-a.yaml").write_text(textwrap.dedent("""\
+        name: ToolA
+        slug: tool-a
+        canonical_url: https://github.com/x/tool-a
+        version_used: '1.0'
+        evidence_spans:
+        - tool-a is used here
+        derived_from:
+        - doi: 10.1/open
+          title: A paper
+        source_repos:
+        - x/tool-a
+        schema_version: 0.2.0
+        techniques:
+        - LC-MS
+        """))
+    # tool B: minimal record, no canonical_url, no techniques.
+    (tools / "tool-b.yaml").write_text(textwrap.dedent("""\
+        name: ToolB
+        slug: tool-b
+        evidence_spans:
+        - tool-b is used here
+        derived_from:
+        - doi: 10.1/restricted
+          title: Another paper
+        schema_version: 0.2.0
+        """))
+    tools_index = [
+        {"slug": "tool-a", "license_tier": "open", "license": "MIT",
+         "license_detection": "github-api"},
+        {"slug": "tool-b", "license_tier": "restricted", "license": None,
+         "license_detection": "none"},
+    ]
+    import json
+    (d / "tools_index.json").write_text(json.dumps(tools_index, indent=2))
+    return d
+
+
+def test_enrich_writes_license_fields(tmp_path):
+    d = _write_collection(tmp_path)
+    summary = e.enrich(str(d))
+    a = yaml.safe_load((d / "tools" / "tool-a.yaml").read_text())
+    b = yaml.safe_load((d / "tools" / "tool-b.yaml").read_text())
+    assert a["license_tier"] == "open"
+    assert a["license"] == "MIT"
+    assert a["license_detection"] == "github-api"
+    assert b["license_tier"] == "restricted"
+    assert b["license"] is None
+    assert b["license_detection"] == "none"
+    # untouched fields survive
+    assert a["techniques"] == ["LC-MS"]
+    assert a["canonical_url"] == "https://github.com/x/tool-a"
+    assert summary["enriched"] == 2
+
+
+def test_enrich_key_placement_after_schema_version(tmp_path):
+    # License fields land right after schema_version, before techniques —
+    # deterministic so re-runs are stable.
+    d = _write_collection(tmp_path)
+    e.enrich(str(d))
+    keys = list(yaml.safe_load((d / "tools" / "tool-a.yaml").read_text()).keys())
+    sv = keys.index("schema_version")
+    assert keys[sv + 1:sv + 4] == ["license_tier", "license", "license_detection"]
+    assert keys.index("techniques") > keys.index("license_detection")
+
+
+def test_enrich_idempotent(tmp_path):
+    d = _write_collection(tmp_path)
+    e.enrich(str(d))
+    first_a = (d / "tools" / "tool-a.yaml").read_text()
+    first_b = (d / "tools" / "tool-b.yaml").read_text()
+    e.enrich(str(d))
+    assert (d / "tools" / "tool-a.yaml").read_text() == first_a
+    assert (d / "tools" / "tool-b.yaml").read_text() == first_b
+
+
+def test_enrich_updates_stale_tier(tmp_path):
+    # If a YAML already carries a (now-stale) tier, enrich corrects it to match
+    # the tools_index source of truth.
+    d = _write_collection(tmp_path)
+    e.enrich(str(d))
+    import json
+    ti = json.loads((d / "tools_index.json").read_text())
+    for t in ti:
+        if t["slug"] == "tool-a":
+            t["license_tier"] = "noncommercial"
+            t["license"] = "CC-BY-NC-4.0"
+    (d / "tools_index.json").write_text(json.dumps(ti, indent=2))
+    e.enrich(str(d))
+    a = yaml.safe_load((d / "tools" / "tool-a.yaml").read_text())
+    assert a["license_tier"] == "noncommercial"
+    assert a["license"] == "CC-BY-NC-4.0"
+
+
+def test_enrich_skips_yaml_without_index_entry(tmp_path):
+    # A tools/<slug>.yaml with no tools_index row is left untouched.
+    d = _write_collection(tmp_path)
+    orphan = (d / "tools" / "orphan.yaml")
+    orphan.write_text("name: Orphan\nslug: orphan\nschema_version: 0.2.0\n")
+    before = orphan.read_text()
+    summary = e.enrich(str(d))
+    assert orphan.read_text() == before
+    assert summary["skipped"] == 1

--- a/tests/test_enrich_tools_index.py
+++ b/tests/test_enrich_tools_index.py
@@ -1,0 +1,162 @@
+import json, pathlib, sys, textwrap
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import enrich_tools_index as e
+
+
+# corpus_by_doi maps doi -> full paper dict (as corpus.yaml papers are shaped).
+CORPUS = {
+    "10.1/open": {
+        "doi": "10.1/open", "license_tier": "open",
+        "access": {"license": "MIT"}, "license_detection": "github-api",
+    },
+    "10.1/restricted": {
+        "doi": "10.1/restricted", "license_tier": "restricted",
+        "access": {"license": None}, "license_detection": "none",
+    },
+    "10.1/nc": {
+        "doi": "10.1/nc", "license_tier": "noncommercial",
+        "access": {"license": "CC-BY-NC-4.0"}, "license_detection": "readme-llm",
+    },
+}
+
+
+def test_tool_license_single_match():
+    assert e.tool_license(["10.1/open"], CORPUS) == ("open", "MIT", "github-api")
+
+
+def test_tool_license_most_restrictive_rollup():
+    # open + noncommercial -> noncommercial (the most restrictive of the two),
+    # and the returned license/detection come from the most-restrictive paper.
+    tier, lic, det = e.tool_license(["10.1/open", "10.1/nc"], CORPUS)
+    assert tier == "noncommercial"
+    assert lic == "CC-BY-NC-4.0"
+    assert det == "readme-llm"
+
+
+def test_tool_license_restricted_when_unmatched():
+    assert e.tool_license(["10.1/does-not-exist"], CORPUS) == ("restricted", None, None)
+    assert e.tool_license([], CORPUS) == ("restricted", None, None)
+
+
+def test_link_maps_mutual_inversion():
+    skills_index = [
+        {"slug": "s_open", "dois": ["10.1/open"]},
+        {"slug": "s_both", "dois": ["10.1/open", "10.1/nc"]},
+        {"slug": "s_none", "dois": ["10.1/unmatched"]},
+    ]
+    tools_index = [
+        {"slug": "t_open", "dois": ["10.1/open"]},
+        {"slug": "t_nc", "dois": ["10.1/nc"]},
+    ]
+    tools_used, used_by = e.link_maps(skills_index, tools_index)
+    # s_open shares a DOI with t_open only
+    assert tools_used["s_open"] == ["t_open"]
+    # s_both shares DOIs with both tools
+    assert tools_used["s_both"] == ["t_nc", "t_open"]
+    # s_none matches nothing
+    assert tools_used["s_none"] == []
+    # inverse map
+    assert used_by["t_open"] == ["s_both", "s_open"]
+    assert used_by["t_nc"] == ["s_both"]
+    # mutual inversion invariant: t in tools_used[s]  <=>  s in used_by[t]
+    for s, ts in tools_used.items():
+        for t in ts:
+            assert s in used_by[t]
+    for t, ss in used_by.items():
+        for s in ss:
+            assert t in tools_used[s]
+
+
+def _write_collection(tmp_path):
+    d = tmp_path
+    (d / "corpus.yaml").write_text(textwrap.dedent("""
+        papers:
+        - {doi: 10.1/open, license_tier: open, license_detection: github-api, access: {license: MIT}}
+        - {doi: 10.1/restricted, license_tier: restricted, license_detection: none, access: {license: null}}
+        - {doi: 10.1/nc, license_tier: noncommercial, license_detection: readme-llm, access: {license: CC-BY-NC-4.0}}
+    """))
+    (d / "tools_index.json").write_text(json.dumps([
+        {"slug": "t_open", "name": "ToolOpen", "dois": ["10.1/open"]},
+        {"slug": "t_mix", "name": "ToolMix", "dois": ["10.1/open", "10.1/nc"]},
+        {"slug": "t_unmatched", "name": "ToolU", "dois": ["10.1/ghost"]},
+    ], indent=2))
+    (d / "skills_index.json").write_text(json.dumps([
+        {"slug": "s1", "dois": ["10.1/open"]},
+        {"slug": "s2", "dois": ["10.1/nc"]},
+    ], indent=2))
+    (d / "kb_bundle.json").write_text(json.dumps({
+        "skills": {
+            "s1": {"dois": ["10.1/open"]},
+            "s2": {"dois": ["10.1/nc"]},
+        }
+    }, indent=2))
+    return d
+
+
+def test_enrich_writes_back_all_fields(tmp_path):
+    d = _write_collection(tmp_path)
+    summary = e.enrich(str(d))
+
+    tools = {t["slug"]: t for t in json.loads((d / "tools_index.json").read_text())}
+    # most-restrictive rollup on the mixed tool
+    assert tools["t_open"]["license_tier"] == "open"
+    assert tools["t_open"]["license"] == "MIT"
+    assert tools["t_open"]["license_detection"] == "github-api"
+    assert tools["t_mix"]["license_tier"] == "noncommercial"
+    # restricted-when-unmatched
+    assert tools["t_unmatched"]["license_tier"] == "restricted"
+    assert tools["t_unmatched"]["license"] is None
+    assert tools["t_unmatched"]["license_detection"] is None
+    # used_by_skills populated by DOI intersection
+    assert tools["t_open"]["used_by_skills"] == ["s1"]
+    assert tools["t_mix"]["used_by_skills"] == ["s1", "s2"]
+    assert tools["t_unmatched"]["used_by_skills"] == []
+
+    # skills_index gets tools_used (sorted)
+    si = {s["slug"]: s for s in json.loads((d / "skills_index.json").read_text())}
+    assert si["s1"]["tools_used"] == ["t_mix", "t_open"]
+    assert si["s2"]["tools_used"] == ["t_mix"]
+
+    # kb_bundle skill records get tools_used too
+    kb = json.loads((d / "kb_bundle.json").read_text())["skills"]
+    assert kb["s1"]["tools_used"] == ["t_mix", "t_open"]
+    assert kb["s2"]["tools_used"] == ["t_mix"]
+
+    # summary
+    assert summary["tools"] == 3
+    assert summary["skills_linked"] == 2
+    assert summary["tool_tiers"]["open"] == 1
+    assert summary["tool_tiers"]["noncommercial"] == 1
+    assert summary["tool_tiers"]["restricted"] == 1
+
+
+def test_enrich_idempotent(tmp_path):
+    d = _write_collection(tmp_path)
+    e.enrich(str(d))
+    after_first = {
+        "tools": (d / "tools_index.json").read_text(),
+        "skills": (d / "skills_index.json").read_text(),
+        "kb": (d / "kb_bundle.json").read_text(),
+    }
+    summary2 = e.enrich(str(d))
+    after_second = {
+        "tools": (d / "tools_index.json").read_text(),
+        "skills": (d / "skills_index.json").read_text(),
+        "kb": (d / "kb_bundle.json").read_text(),
+    }
+    assert after_first == after_second
+    assert summary2["tools"] == 3
+
+
+def test_enrich_preserves_indent(tmp_path):
+    d = tmp_path
+    (d / "corpus.yaml").write_text("papers:\n- {doi: 10.1/open, license_tier: open, license_detection: github-api, access: {license: MIT}}\n")
+    # 4-space indented tools_index
+    (d / "tools_index.json").write_text('[\n    {\n        "slug": "t_open",\n        "dois": ["10.1/open"]\n    }\n]')
+    (d / "skills_index.json").write_text('[\n    {\n        "slug": "s1",\n        "dois": ["10.1/open"]\n    }\n]')
+    (d / "kb_bundle.json").write_text('{\n  "skills": {\n    "s1": {\n      "dois": ["10.1/open"]\n    }\n  }\n}')
+    e.enrich(str(d))
+    tools_text = (d / "tools_index.json").read_text()
+    assert '\n    {\n' in tools_text, "tools_index should preserve 4-space indent"
+    kb_text = (d / "kb_bundle.json").read_text()
+    assert '\n  "skills"' in kb_text, "kb_bundle should preserve 2-space indent"

--- a/tests/test_ground_skill.py
+++ b/tests/test_ground_skill.py
@@ -1,0 +1,139 @@
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from scripts import ground_skill as gs
+
+
+# --- a mock http(method, path, body=None, timeout=...) matching kb._http ------
+
+
+class MockHttp:
+    """Records calls; returns canned bodies keyed by (method, path-substring)."""
+
+    def __init__(self, chat_reply=None, raises=False):
+        self.chat_reply = chat_reply
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, method, path, body=None, timeout=1200):
+        self.calls.append((method, path, body))
+        if self.raises:
+            raise OSError("Connection refused")
+        if path.endswith("/stats"):
+            # KB exists with chunks so prepare_kb short-circuits to "already present".
+            return {"chunk_count": 7}
+        if path == "/api/chat":
+            return self.chat_reply
+        # KB create / ingest endpoints
+        return {}
+
+
+SUPPORTIVE = (
+    'VERDICT: SUPPORTED\n'
+    'CONFIDENCE: high\n'
+    'EVIDENCE: "The authors normalize features by median fold-change before '
+    'differential testing." (Methods, p.4)'
+)
+
+NON_SUPPORTIVE = (
+    "VERDICT: NOT_SUPPORTED\n"
+    "CONFIDENCE: low\n"
+    "EVIDENCE: The paper never discusses the claimed normalization step."
+)
+
+
+def test_supportive_reply_yields_supported_with_evidence():
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    out = gs.verify_doi_support("skill claims median fold-change normalization",
+                                "10.1/xyz", http=http)
+    assert out["supported"] is True
+    assert out["confidence"] == "high"
+    assert out["doi"] == "10.1/xyz"
+    assert "median fold-change" in out["evidence"]
+    # it actually queried /api/chat scoped to the per-DOI KB slug
+    chat = [c for c in http.calls if c[1] == "/api/chat"]
+    assert chat, "expected a POST /api/chat"
+    assert chat[0][2]["kb_names"] == ["asb-paper-10-1-xyz"]
+
+
+def test_non_supportive_reply_yields_false():
+    http = MockHttp(chat_reply={"answer": NON_SUPPORTIVE})
+    out = gs.verify_doi_support("skill claims something unrelated",
+                                "10.1/xyz", http=http)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"
+    assert out["doi"] == "10.1/xyz"
+
+
+def test_http_that_raises_degrades_to_low_conf_false():
+    http = MockHttp(raises=True)
+    out = gs.verify_doi_support("anything", "10.1/down", http=http)
+    assert out == {
+        "supported": False,
+        "confidence": "low",
+        "evidence": "",
+        "doi": "10.1/down",
+    }
+
+
+def test_malformed_chat_reply_never_raises():
+    # chat returns something with no parseable verdict -> graceful False/low.
+    http = MockHttp(chat_reply={"unexpected": "shape"})
+    out = gs.verify_doi_support("x", "10.1/weird", http=http)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"
+    assert out["doi"] == "10.1/weird"
+
+
+def test_prepare_false_skips_kb_creation():
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    out = gs.verify_doi_support("x", "10.1/abc", http=http, prepare=False)
+    assert out["supported"] is True
+    # no KB create/ingest/stats calls when prepare=False — only the chat call.
+    assert all(c[1] == "/api/chat" for c in http.calls)
+
+
+def test_medium_confidence_supported():
+    reply = {"answer": "VERDICT: SUPPORTED\nCONFIDENCE: medium\nEVIDENCE: see Fig 2."}
+    http = MockHttp(chat_reply=reply)
+    out = gs.verify_doi_support("x", "10.1/m", http=http)
+    assert out["supported"] is True
+    assert out["confidence"] == "medium"
+
+
+def test_answer_under_response_or_content_key():
+    for key in ("response", "content"):
+        http = MockHttp(chat_reply={key: SUPPORTIVE})
+        out = gs.verify_doi_support("x", "10.1/k", http=http)
+        assert out["supported"] is True, key
+
+
+def test_main_writes_json_for_skill_md(tmp_path, capsys):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        "---\nname: My Skill\ndescription: Use when normalizing features.\n---\n"
+        "Body: median fold-change normalization.\n",
+        encoding="utf-8",
+    )
+    http = MockHttp(chat_reply={"answer": SUPPORTIVE})
+    rc = gs.main(["--doi", "10.1/cli", "--skill-md", str(skill)], http=http)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["supported"] is True
+    assert out["doi"] == "10.1/cli"
+
+
+def test_main_graceful_when_http_down(tmp_path, capsys):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("---\nname: S\ndescription: Use when x.\n---\nbody\n",
+                     encoding="utf-8")
+    http = MockHttp(raises=True)
+    rc = gs.main(["--doi", "10.1/down", "--skill-md", str(skill)], http=http)
+    # never raises; reports unsupported but exits cleanly (0) — grounding is best-effort.
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["supported"] is False
+    assert out["confidence"] == "low"

--- a/tests/test_normalize_skill.py
+++ b/tests/test_normalize_skill.py
@@ -1,0 +1,358 @@
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import normalize_skill as n
+
+
+# --- slugify -----------------------------------------------------------------
+
+def test_slugify_lowercases_and_hyphenates():
+    assert n.slugify("My New Skill") == "my-new-skill"
+
+
+def test_slugify_strips_punctuation_and_collapses():
+    assert n.slugify("LC-MS  Feature  Extraction!!") == "lc-ms-feature-extraction"
+
+
+def test_slugify_trims_leading_trailing_separators():
+    assert n.slugify("  --Adduct (M+H)+--  ") == "adduct-m-h"
+
+
+# --- valid_edam --------------------------------------------------------------
+
+def test_valid_edam_accepts_canonical_iri():
+    assert n.valid_edam("http://edamontology.org/operation_3215") is True
+
+
+def test_valid_edam_rejects_https_and_other_hosts():
+    assert n.valid_edam("https://edamontology.org/operation_3215") is False
+    assert n.valid_edam("http://example.org/operation_3215") is False
+    assert n.valid_edam("operation_3215") is False
+    assert n.valid_edam("") is False
+    assert n.valid_edam(None) is False
+
+
+# --- check_description -------------------------------------------------------
+
+VALID_DESC = (
+    "Use when you have a raw LC-MS feature table and need to filter blank "
+    "contamination before downstream statistical analysis of metabolites."
+)
+
+
+def test_check_description_valid_returns_empty():
+    assert n.check_description(VALID_DESC) == []
+
+
+def test_check_description_each_allowed_prefix_ok():
+    for prefix in ("Use when", "Reference for", "Explains", "Decision support for"):
+        desc = prefix + " a representative situation that is long enough to clear the fifty character minimum bound."
+        assert n.check_description(desc) == [], prefix
+
+
+def test_check_description_bad_prefix_flagged():
+    desc = "Helps you filter blank contamination from an LC-MS feature table prior to statistical analysis here."
+    violations = n.check_description(desc)
+    assert any("prefix" in v.lower() for v in violations)
+
+
+def test_check_description_too_short_flagged():
+    desc = "Use when filtering."  # < 50 chars
+    violations = n.check_description(desc)
+    assert any("50" in v or "short" in v.lower() for v in violations)
+
+
+def test_check_description_too_long_flagged():
+    desc = "Use when " + ("x" * 320)  # > 300 chars
+    violations = n.check_description(desc)
+    assert any("300" in v or "long" in v.lower() for v in violations)
+
+
+def test_check_description_marketing_terms_flagged():
+    for term in ("best", "state-of-the-art", "revolutionary", "leading", "superior"):
+        desc = f"Use when you want the {term} approach to filter blank contamination from your LC-MS feature table."
+        violations = n.check_description(desc)
+        assert any("marketing" in v.lower() for v in violations), term
+
+
+def test_check_description_marketing_substring_flagged_for_ci_parity():
+    # CI Gate 5 uses substring matching (`term in desc.lower()`); the normalizer
+    # must flag the SAME cases so a skill it pre-clears isn't later rejected by
+    # CI. "bestowing" contains "best"; "misleading" contains "leading".
+    for word, term in (("bestowing", "best"), ("misleading", "leading")):
+        desc = (
+            f"Use when {word} labels on an LC-MS feature table before downstream "
+            "statistical analysis of the resulting metabolite features."
+        )
+        violations = n.check_description(desc)
+        assert any("marketing" in v.lower() for v in violations), word
+        assert any(term in v for v in violations), term
+
+
+# --- parse_skill_md ----------------------------------------------------------
+
+def test_parse_skill_md_splits_frontmatter_and_body():
+    text = "---\nname: foo\ndescription: bar\n---\n# Title\n\nbody text\n"
+    fm, body = n.parse_skill_md(text)
+    assert fm == {"name": "foo", "description": "bar"}
+    assert "body text" in body
+
+
+def test_parse_skill_md_no_frontmatter_returns_none():
+    fm, body = n.parse_skill_md("# Just a title\n\nbody\n")
+    assert fm is None
+    assert body is None
+
+
+# --- frontmatter_violations --------------------------------------------------
+
+def _good_fm():
+    return {
+        "name": "blank-contamination-filtering",
+        "description": VALID_DESC,
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+            "license_tier": "open",
+        },
+    }
+
+
+def test_frontmatter_violations_clean_is_empty():
+    assert n.frontmatter_violations(_good_fm()) == []
+
+
+def test_frontmatter_violations_bad_description():
+    fm = _good_fm()
+    fm["description"] = "Helps with stuff and is reasonably long but lacks an allowed prefix entirely here today."
+    assert n.frontmatter_violations(fm)
+
+
+def test_frontmatter_violations_bad_edam_operation():
+    fm = _good_fm()
+    fm["metadata"]["edam_operation"] = "https://edamontology.org/operation_3215"
+    assert any("edam" in v.lower() for v in n.frontmatter_violations(fm))
+
+
+def test_frontmatter_violations_bad_edam_topic():
+    fm = _good_fm()
+    fm["metadata"]["edam_topics"] = ["http://example.org/topic_0091"]
+    assert any("edam" in v.lower() for v in n.frontmatter_violations(fm))
+
+
+def test_frontmatter_violations_string_edam_topics_single_message():
+    # A bare string instead of a list must yield ONE clear violation, not one
+    # per character (contributor-supplied frontmatter robustness).
+    fm = _good_fm()
+    fm["metadata"]["edam_topics"] = "http://edamontology.org/topic_0091"
+    violations = n.frontmatter_violations(fm)
+    topic_violations = [v for v in violations if "edam_topics" in v or "topic IRI" in v]
+    assert topic_violations == ["edam_topics must be a list"]
+
+
+def test_frontmatter_violations_bad_license_tier():
+    fm = _good_fm()
+    fm["metadata"]["license_tier"] = "proprietary"
+    assert any("license_tier" in v.lower() for v in n.frontmatter_violations(fm))
+
+
+# --- normalized_frontmatter --------------------------------------------------
+
+def test_normalized_frontmatter_sets_community_fields():
+    raw = {
+        "name": "blank-contamination-filtering",
+        "description": VALID_DESC,
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+        },
+    }
+    fm = n.normalized_frontmatter(
+        raw,
+        related_skills=["lc-ms-feature-extraction"],
+        tools_used=["mzmine"],
+        license_tier="open",
+    )
+    assert fm["related_skills"] == ["lc-ms-feature-extraction"]
+    assert fm["metadata"]["provenance_tier"] == "community"
+    assert fm["metadata"]["license_tier"] == "open"
+    assert fm["metadata"]["tools_used"] == ["mzmine"]
+    assert fm["status"] == "hold"
+    # preserves provided EDAM/description, does not fabricate
+    assert fm["description"] == VALID_DESC
+    assert fm["metadata"]["edam_operation"] == "http://edamontology.org/operation_3215"
+
+
+def test_normalized_frontmatter_round_trips_through_yaml():
+    raw = {
+        "name": "blank-contamination-filtering",
+        "description": VALID_DESC,
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+        },
+    }
+    fm = n.normalized_frontmatter(
+        raw, related_skills=[], tools_used=[], license_tier="restricted"
+    )
+    dumped = yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+    reloaded = yaml.safe_load(dumped)
+    assert reloaded == fm
+    # a community frontmatter with related_skills key present must pass the gate
+    assert n.frontmatter_violations(fm) == []
+
+
+def test_normalized_frontmatter_derived_from_optional():
+    raw = {"name": "x", "description": VALID_DESC, "metadata": {}}
+    without = n.normalized_frontmatter(
+        raw, related_skills=[], tools_used=[], license_tier="open"
+    )
+    assert "derived_from" not in without
+    with_df = n.normalized_frontmatter(
+        raw,
+        related_skills=[],
+        tools_used=[],
+        license_tier="open",
+        derived_from=[{"doi": "10.1/x", "title": "T"}],
+    )
+    assert with_df["derived_from"] == [{"doi": "10.1/x", "title": "T"}]
+
+
+def test_normalized_frontmatter_does_not_mutate_input():
+    raw = {"name": "x", "description": VALID_DESC, "metadata": {"license_tier": "open"}}
+    snapshot = {"name": "x", "description": VALID_DESC, "metadata": {"license_tier": "open"}}
+    n.normalized_frontmatter(raw, related_skills=["a"], tools_used=["b"], license_tier="restricted")
+    assert raw == snapshot
+
+
+# --- contributors (co-authorship attribution) --------------------------------
+
+def test_normalized_frontmatter_omits_contributors_when_none():
+    raw = {"name": "x", "description": VALID_DESC, "metadata": {}}
+    fm = n.normalized_frontmatter(
+        raw, related_skills=[], tools_used=[], license_tier="open"
+    )
+    assert "contributors" not in fm
+
+
+def test_normalized_frontmatter_emits_well_formed_contributors_block():
+    raw = {"name": "x", "description": VALID_DESC, "metadata": {}}
+    contributors = [
+        {
+            "name": "Ada Lovelace",
+            "role": "author",
+            "orcid": "0000-0002-1825-0097",
+            "github": "ada",
+        },
+        {"name": "Grace Hopper", "role": "reviewer"},
+    ]
+    fm = n.normalized_frontmatter(
+        raw,
+        related_skills=[],
+        tools_used=[],
+        license_tier="open",
+        contributors=contributors,
+    )
+    assert fm["contributors"] == [
+        {
+            "name": "Ada Lovelace",
+            "role": "author",
+            "orcid": "0000-0002-1825-0097",
+            "github": "ada",
+        },
+        {"name": "Grace Hopper", "role": "reviewer"},
+    ]
+    # optional keys are dropped when absent (no orcid/github key on Grace)
+    assert "orcid" not in fm["contributors"][1]
+    assert "github" not in fm["contributors"][1]
+
+
+def test_normalized_frontmatter_contributors_block_does_not_mutate_input():
+    raw = {"name": "x", "description": VALID_DESC, "metadata": {}}
+    contributors = [{"name": "Ada", "role": "author", "extra": "drop-me"}]
+    snapshot = [{"name": "Ada", "role": "author", "extra": "drop-me"}]
+    fm = n.normalized_frontmatter(
+        raw,
+        related_skills=[],
+        tools_used=[],
+        license_tier="open",
+        contributors=contributors,
+    )
+    # input is not mutated; the emitted entry keeps only the well-formed keys
+    assert contributors == snapshot
+    assert fm["contributors"] == [{"name": "Ada", "role": "author"}]
+
+
+def test_normalized_frontmatter_contributors_round_trips_through_yaml():
+    raw = {
+        "name": "blank-contamination-filtering",
+        "description": VALID_DESC,
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+        },
+    }
+    fm = n.normalized_frontmatter(
+        raw,
+        related_skills=[],
+        tools_used=[],
+        license_tier="open",
+        contributors=[{"name": "Ada Lovelace", "role": "author"}],
+    )
+    reloaded = yaml.safe_load(yaml.safe_dump(fm, sort_keys=False, allow_unicode=True))
+    assert reloaded == fm
+    # emitting a contributors block must not break the existing gate
+    assert n.frontmatter_violations(fm) == []
+
+
+# --- contributor_violations --------------------------------------------------
+
+def test_contributor_violations_valid_returns_empty():
+    contributors = [
+        {"name": "Ada Lovelace", "role": "author", "orcid": "0000-0002-1825-0097"},
+        {"name": "Grace Hopper", "role": "reviewer"},
+        {"name": "Curator C", "role": "curator", "github": "cc"},
+    ]
+    assert n.contributor_violations(contributors) == []
+
+
+def test_contributor_violations_absent_is_clean():
+    # contributors is optional — absence (None) yields no violations.
+    assert n.contributor_violations(None) == []
+
+
+def test_contributor_violations_not_a_list_flagged():
+    assert n.contributor_violations({"name": "Ada", "role": "author"})
+
+
+def test_contributor_violations_entry_not_mapping_flagged():
+    v = n.contributor_violations(["Ada Lovelace"])
+    assert any("mapping" in x.lower() for x in v)
+
+
+def test_contributor_violations_missing_name_flagged():
+    v = n.contributor_violations([{"role": "author"}])
+    assert any("name" in x.lower() for x in v)
+
+
+def test_contributor_violations_empty_name_flagged():
+    v = n.contributor_violations([{"name": "   ", "role": "author"}])
+    assert any("name" in x.lower() for x in v)
+
+
+def test_contributor_violations_missing_role_flagged():
+    v = n.contributor_violations([{"name": "Ada"}])
+    assert any("role" in x.lower() for x in v)
+
+
+def test_contributor_violations_bad_role_flagged():
+    v = n.contributor_violations([{"name": "Ada", "role": "maintainer"}])
+    assert any("role" in x.lower() for x in v)
+
+
+def test_contributor_violations_each_allowed_role_ok():
+    for role in ("author", "reviewer", "curator"):
+        assert n.contributor_violations([{"name": "X", "role": role}]) == [], role

--- a/tests/test_promote_proposals.py
+++ b/tests/test_promote_proposals.py
@@ -1,0 +1,373 @@
+"""Tests for scripts.promote_proposals — the proposals → published promotion tool.
+
+A tiny fixture collection is built in a tmp dir (skills_index.json, kb_bundle.json,
+tools_index.json, corpus.yaml, one published skill, one *staged* community
+proposal). We then exercise:
+
+* ``staged_slugs`` finds the held proposal;
+* ``promote`` moves it into ``skills/`` with ``status: included``, appends a
+  skills_index entry + kb_bundle record, and the result is gate-clean under the
+  four CI gates;
+* ``check_proposals`` no longer sees the promoted slug;
+* re-running ``promote`` is a no-op (idempotent);
+* ``--dry-run`` writes nothing.
+
+No git/gh, no network. Mirrors the propose_skill / check_proposals discipline.
+"""
+from __future__ import annotations
+
+import json
+
+import yaml
+
+from scripts import (
+    check_license_tiers,
+    check_proposals,
+    check_provenance_tiers,
+    check_tools_index,
+    promote_proposals,
+)
+
+DATE = "2026-06-26"
+
+
+# --------------------------------------------------------------------------- #
+# fixture                                                                      #
+# --------------------------------------------------------------------------- #
+def _write_json(path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _published_skill_md(slug):
+    fm = {
+        "name": slug,
+        "description": (
+            "Use when you need to detect and align LC-MS features across samples "
+            "as the first stage of an untargeted metabolomics workflow."
+        ),
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_3172"],
+            "tools": ["xcms"],
+            "techniques": ["LC-MS"],
+            "license_tier": "open",
+            "provenance_tier": "literature",
+            "tools_used": ["xcms"],
+        },
+    }
+    return (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+        + "---\n"
+        + "Published skill body.\n"
+    )
+
+
+def _staged_proposal_md(slug):
+    """A held *community* proposal: status hold, related_skills present, valid
+    frontmatter discipline, tools_used resolvable in the fixture tool catalog."""
+    fm = {
+        "name": slug,
+        "description": (
+            "Use when you need to annotate molecular network nodes against a "
+            "reference spectral library and propagate the matches to neighbours."
+        ),
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3631",
+            "edam_topics": ["http://edamontology.org/topic_3172"],
+            "tools": ["matchms"],
+            "techniques": ["LC-MS/MS"],
+            "license_tier": "open",
+            "provenance_tier": "community",
+            "tools_used": ["matchms"],
+        },
+        "status": "hold",
+        "related_skills": ["lc-ms-feature-extraction-and-alignment"],
+    }
+    return (
+        "---\n"
+        + yaml.safe_dump(fm, sort_keys=False, allow_unicode=True)
+        + "---\n"
+        + "Staged community proposal body.\n"
+    )
+
+
+def build_fixture(tmp_path):
+    """Materialize a minimal but gate-valid collection with one staged proposal."""
+    col = tmp_path / "collections" / "demo" / "v2"
+    pub = "lc-ms-feature-extraction-and-alignment"
+    proposal = "library-match-annotation"
+
+    # published skill on disk
+    (col / "skills" / pub).mkdir(parents=True, exist_ok=True)
+    (col / "skills" / pub / "SKILL.md").write_text(
+        _published_skill_md(pub), encoding="utf-8"
+    )
+
+    # staged community proposal on disk
+    (col / "proposals" / "skills" / proposal).mkdir(parents=True, exist_ok=True)
+    (col / "proposals" / "skills" / proposal / "SKILL.md").write_text(
+        _staged_proposal_md(proposal), encoding="utf-8"
+    )
+
+    # tools_index.json — two resolvable tools
+    _write_json(
+        col / "tools_index.json",
+        [
+            {
+                "slug": "xcms",
+                "name": "xcms",
+                "dois": [],
+                "license_tier": "open",
+                "license": None,
+                "license_detection": None,
+                "used_by_skills": [pub],
+            },
+            {
+                "slug": "matchms",
+                "name": "matchms",
+                "dois": [],
+                "license_tier": "open",
+                "license": None,
+                "license_detection": None,
+                "used_by_skills": [],
+            },
+        ],
+    )
+
+    # skills_index.json — just the published skill
+    _write_json(
+        col / "skills_index.json",
+        [
+            {
+                "slug": pub,
+                "name": pub,
+                "description": "Use when you need to detect and align LC-MS features.",
+                "edam_operation": "http://edamontology.org/operation_3215",
+                "edam_topics": ["http://edamontology.org/topic_3172"],
+                "tools": ["xcms"],
+                "dois": ["10.1000/demo"],
+                "techniques": ["LC-MS"],
+                "license_tier": "open",
+                "provenance_tier": "literature",
+                "tools_used": ["xcms"],
+            }
+        ],
+    )
+
+    # kb_bundle.json
+    _write_json(
+        col / "kb_bundle.json",
+        {
+            "collection": "demo",
+            "version": "v2",
+            "perspicacite_kb_mode": "paper",
+            "kb_prefix": "asb-paper",
+            "distinct_dois": 1,
+            "skills": {
+                pub: {
+                    "dois": ["10.1000/demo"],
+                    "tools": ["xcms"],
+                    "kb_slugs": ["asb-paper-10-1000-demo"],
+                    "repo_urls": [],
+                    "license_tier": "open",
+                    "provenance_tier": "literature",
+                    "tools_used": ["xcms"],
+                }
+            },
+        },
+    )
+
+    # corpus.yaml — one paper so check_license_tiers' corpus loop is happy
+    (col / "corpus.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "papers": [
+                    {
+                        "name": "demo",
+                        "doi": "10.1000/demo",
+                        "license_tier": "open",
+                        "access": {"license": "CC-BY-4.0"},
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    return col, pub, proposal
+
+
+def _assert_gates_clean(col):
+    assert check_license_tiers.check_collection(str(col)) == []
+    assert check_provenance_tiers.check_collection(str(col)) == []
+    assert check_tools_index.check_collection(str(col)) == []
+    assert check_proposals.check_collection(str(col)) == []
+
+
+# --------------------------------------------------------------------------- #
+# tests                                                                        #
+# --------------------------------------------------------------------------- #
+def test_fixture_starts_gate_clean(tmp_path):
+    col, _, _ = build_fixture(tmp_path)
+    _assert_gates_clean(col)
+
+
+def test_staged_slugs_finds_held_proposal(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    assert promote_proposals.staged_slugs(str(col)) == [proposal]
+
+
+def test_promote_moves_into_skills_with_included_status(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    res = promote_proposals.promote(str(col), [proposal], date=DATE)
+
+    assert res["promoted"] == [proposal]
+    assert res["skipped"] == []
+
+    # SKILL.md now lives under skills/ and is gone from proposals/skills/
+    new_md = col / "skills" / proposal / "SKILL.md"
+    old_md = col / "proposals" / "skills" / proposal / "SKILL.md"
+    assert new_md.is_file()
+    assert not old_md.exists()
+
+    fm = yaml.safe_load(new_md.read_text(encoding="utf-8").split("---\n", 2)[1])
+    assert fm["status"] == "included"
+
+    # appears in skills_index.json with status-independent fields populated
+    si = json.loads((col / "skills_index.json").read_text(encoding="utf-8"))
+    entry = next(e for e in si if e["slug"] == proposal)
+    assert entry["provenance_tier"] == "community"
+    assert entry["license_tier"] == "open"
+    assert entry["tools_used"] == ["matchms"]
+    assert "related_skills" in entry  # community invariant carried onto the index
+
+    # appears in kb_bundle.json
+    kb = json.loads((col / "kb_bundle.json").read_text(encoding="utf-8"))
+    assert proposal in kb["skills"]
+    assert kb["skills"][proposal]["provenance_tier"] == "community"
+
+
+def test_promote_updates_used_by_skills_backlink(tmp_path):
+    # the promoted skill must appear in its tools' used_by_skills so the catalog
+    # inverse index stays consistent (without a full DOI re-derive).
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    tools = json.loads((col / "tools_index.json").read_text(encoding="utf-8"))
+    matchms = next(t for t in tools if t["slug"] == "matchms")
+    assert proposal in matchms["used_by_skills"]
+    # idempotent: re-promote does not duplicate the back-link
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    tools2 = json.loads((col / "tools_index.json").read_text(encoding="utf-8"))
+    matchms2 = next(t for t in tools2 if t["slug"] == "matchms")
+    assert matchms2["used_by_skills"].count(proposal) == 1
+
+
+def test_promote_is_gate_clean(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    _assert_gates_clean(col)
+
+
+def test_check_proposals_no_longer_sees_promoted(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    # the proposal is gone from the proposals rail
+    assert promote_proposals.staged_slugs(str(col)) == []
+    assert check_proposals.check_collection(str(col)) == []
+
+
+def test_promote_is_idempotent(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+    kb_before = (col / "kb_bundle.json").read_text(encoding="utf-8")
+    md_before = (col / "skills" / proposal / "SKILL.md").read_text(encoding="utf-8")
+
+    res2 = promote_proposals.promote(str(col), [proposal], date=DATE)
+    assert res2["promoted"] == []
+    assert res2["skipped"] == [proposal]
+
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+    assert (col / "kb_bundle.json").read_text(encoding="utf-8") == kb_before
+    assert (col / "skills" / proposal / "SKILL.md").read_text(
+        encoding="utf-8"
+    ) == md_before
+    # still single index entry for the slug (no duplication)
+    si = json.loads(si_before)
+    assert sum(1 for e in si if e["slug"] == proposal) == 1
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+    kb_before = (col / "kb_bundle.json").read_text(encoding="utf-8")
+
+    res = promote_proposals.promote(str(col), [proposal], date=DATE, dry_run=True)
+    assert res["promoted"] == [proposal]  # the *plan*
+
+    # nothing moved, nothing appended
+    assert (col / "proposals" / "skills" / proposal / "SKILL.md").is_file()
+    assert not (col / "skills" / proposal / "SKILL.md").exists()
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+    assert (col / "kb_bundle.json").read_text(encoding="utf-8") == kb_before
+
+
+def test_main_dry_run_writes_nothing(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    si_before = (col / "skills_index.json").read_text(encoding="utf-8")
+
+    rc = promote_proposals.main(
+        [
+            "--collection",
+            str(col),
+            "--slug",
+            proposal,
+            "--date",
+            DATE,
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert not (col / "skills" / proposal / "SKILL.md").exists()
+    assert (col / "skills_index.json").read_text(encoding="utf-8") == si_before
+
+
+def test_main_promotes_all_staged_when_no_slug(tmp_path):
+    col, _, proposal = build_fixture(tmp_path)
+    rc = promote_proposals.main(["--collection", str(col), "--date", DATE])
+    assert rc == 0
+    assert (col / "skills" / proposal / "SKILL.md").is_file()
+    _assert_gates_clean(col)
+
+
+# --- layout: where a promoted proposal actually lands ------------------------
+
+def test_promotion_lands_in_the_leaf_corpus_of_a_router_shaped_collection(tmp_path):
+    """A router-shaped collection advertises everything in `skills/`.
+
+    Promoting a community skill there would push it into the host's session
+    prompt alongside the two entry points, and leave it outside the leaf corpus
+    every consumer actually reads. It belongs in `leaves/`, with the rest.
+    """
+    col, _, proposal = build_fixture(tmp_path)
+    (col / "leaves").mkdir()                      # <- makes the collection router-shaped
+
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+
+    assert (col / "leaves" / proposal / "SKILL.md").is_file()
+    assert not (col / "skills" / proposal).exists(), (
+        "a promoted proposal was written into the advertised directory"
+    )
+
+
+def test_promotion_still_lands_in_skills_for_a_legacy_collection(tmp_path):
+    """The other side: a collection with no `leaves/` keeps its single corpus dir."""
+    col, _, proposal = build_fixture(tmp_path)
+    promote_proposals.promote(str(col), [proposal], date=DATE)
+    assert (col / "skills" / proposal / "SKILL.md").is_file()
+    assert not (col / "leaves").exists()

--- a/tests/test_propose_skill.py
+++ b/tests/test_propose_skill.py
@@ -1,0 +1,188 @@
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import propose_skill as p
+
+
+# --- fixtures ----------------------------------------------------------------
+
+VALID_DESC = (
+    "Use when you have a raw LC-MS feature table and need to filter blank "
+    "contamination before downstream statistical analysis of metabolites."
+)
+
+
+def _frontmatter(slug="my-new-skill"):
+    return {
+        "name": slug,
+        "description": VALID_DESC,
+        "license": "CC-BY-4.0",
+        "metadata": {
+            "edam_operation": "http://edamontology.org/operation_3215",
+            "edam_topics": ["http://edamontology.org/topic_0091"],
+            "license_tier": "open",
+            "provenance_tier": "community",
+            "tools_used": ["mzmine"],
+        },
+        "status": "hold",
+        "related_skills": ["lc-ms-feature-extraction"],
+    }
+
+
+def _ledger_meta(slug="my-new-skill"):
+    return {
+        "slug": slug,
+        "contributor": "octocat",
+        "related_skills": ["lc-ms-feature-extraction"],
+        "tools_used": ["mzmine"],
+        "license_tier": "open",
+        "grounding": {"upgrade_candidate": False},
+        "status": "hold",
+    }
+
+
+BODY = "# My New Skill\n\nApply the procedure here.\n"
+DATE = "2026-06-26"
+
+
+# --- stage_proposal: writes the tree -----------------------------------------
+
+def test_stage_proposal_writes_skill_md_and_ledger(tmp_path):
+    res = p.stage_proposal(
+        str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE
+    )
+    skill_md = tmp_path / "proposals" / "skills" / "my-new-skill" / "SKILL.md"
+    ledger = tmp_path / "proposals" / "wave-skills-2026-06-26.yaml"
+    assert skill_md.is_file()
+    assert ledger.is_file()
+    # returned paths point at what was written
+    assert pathlib.Path(res["skill_md"]) == skill_md
+    assert pathlib.Path(res["ledger"]) == ledger
+
+
+def test_stage_proposal_skill_md_has_frontmatter_and_body(tmp_path):
+    p.stage_proposal(str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE)
+    text = (tmp_path / "proposals" / "skills" / "my-new-skill" / "SKILL.md").read_text()
+    assert text.startswith("---\n")
+    fm = yaml.safe_load(text.split("---\n", 2)[1])
+    assert fm["related_skills"] == ["lc-ms-feature-extraction"]
+    assert fm["metadata"]["provenance_tier"] == "community"
+    assert fm["status"] == "hold"
+    # body is preserved after the closing fence
+    assert "Apply the procedure here." in text.split("---\n", 2)[2]
+
+
+def test_stage_proposal_ledger_schema_and_entry(tmp_path):
+    p.stage_proposal(str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE)
+    ledger = yaml.safe_load(
+        (tmp_path / "proposals" / "wave-skills-2026-06-26.yaml").read_text()
+    )
+    assert ledger["schema"] == "asb-skill-proposals/1.0"
+    slugs = [e["slug"] for e in ledger["proposals"]]
+    assert "my-new-skill" in slugs
+    entry = next(e for e in ledger["proposals"] if e["slug"] == "my-new-skill")
+    assert entry["status"] == "hold"
+    assert entry["tools_used"] == ["mzmine"]
+    # a submitted_on date is stamped from the passed date
+    assert entry.get("submitted_on") == DATE
+
+
+# --- idempotence -------------------------------------------------------------
+
+def test_stage_proposal_is_idempotent(tmp_path):
+    first = p.stage_proposal(
+        str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE
+    )
+    md_text_1 = pathlib.Path(first["skill_md"]).read_text()
+    ledger_text_1 = pathlib.Path(first["ledger"]).read_text()
+
+    second = p.stage_proposal(
+        str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE
+    )
+    md_text_2 = pathlib.Path(second["skill_md"]).read_text()
+    ledger_text_2 = pathlib.Path(second["ledger"]).read_text()
+
+    assert md_text_1 == md_text_2
+    assert ledger_text_1 == ledger_text_2
+    # the ledger has exactly one entry for this slug (no duplicate append)
+    ledger = yaml.safe_load(ledger_text_2)
+    assert [e["slug"] for e in ledger["proposals"]].count("my-new-skill") == 1
+
+
+def test_stage_proposal_appends_distinct_slugs_to_same_wave(tmp_path):
+    p.stage_proposal(str(tmp_path), _frontmatter("skill-a"), BODY, _ledger_meta("skill-a"), date=DATE)
+    p.stage_proposal(str(tmp_path), _frontmatter("skill-b"), BODY, _ledger_meta("skill-b"), date=DATE)
+    ledger = yaml.safe_load(
+        (tmp_path / "proposals" / "wave-skills-2026-06-26.yaml").read_text()
+    )
+    slugs = sorted(e["slug"] for e in ledger["proposals"])
+    assert slugs == ["skill-a", "skill-b"]
+
+
+def test_stage_proposal_updates_existing_entry_in_place(tmp_path):
+    p.stage_proposal(str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE)
+    meta2 = _ledger_meta()
+    meta2["contributor"] = "someone-else"
+    p.stage_proposal(str(tmp_path), _frontmatter(), BODY, meta2, date=DATE)
+    ledger = yaml.safe_load(
+        (tmp_path / "proposals" / "wave-skills-2026-06-26.yaml").read_text()
+    )
+    entries = [e for e in ledger["proposals"] if e["slug"] == "my-new-skill"]
+    assert len(entries) == 1
+    assert entries[0]["contributor"] == "someone-else"
+
+
+# --- dry run -----------------------------------------------------------------
+
+def test_dry_run_writes_nothing(tmp_path):
+    res = p.stage_proposal(
+        str(tmp_path), _frontmatter(), BODY, _ledger_meta(), date=DATE, dry_run=True
+    )
+    assert not (tmp_path / "proposals").exists()
+    # still reports the paths it WOULD have written
+    assert "skill_md" in res and "ledger" in res
+    assert res.get("dry_run") is True
+
+
+# --- slug from frontmatter name ----------------------------------------------
+
+def test_stage_proposal_slugifies_name_for_dir(tmp_path):
+    fm = _frontmatter()
+    fm["name"] = "My New Skill"
+    res = p.stage_proposal(str(tmp_path), fm, BODY, _ledger_meta("my-new-skill"), date=DATE)
+    assert (tmp_path / "proposals" / "skills" / "my-new-skill" / "SKILL.md").is_file()
+    assert pathlib.Path(res["skill_md"]).parent.name == "my-new-skill"
+
+
+# --- main(argv) --------------------------------------------------------------
+
+def _write_input_skill(tmp_path):
+    fm = _frontmatter()
+    text = "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n" + BODY
+    src = tmp_path / "input_SKILL.md"
+    src.write_text(text)
+    return src
+
+
+def test_main_dry_run_writes_nothing(tmp_path, capsys):
+    src = _write_input_skill(tmp_path)
+    col = tmp_path / "col"
+    col.mkdir()
+    rc = p.main(
+        ["--collection", str(col), "--skill-md", str(src), "--date", DATE, "--dry-run"]
+    )
+    assert rc == 0
+    assert not (col / "proposals").exists()
+
+
+def test_main_stages_files(tmp_path):
+    src = _write_input_skill(tmp_path)
+    col = tmp_path / "col"
+    col.mkdir()
+    rc = p.main(["--collection", str(col), "--skill-md", str(src), "--date", DATE])
+    assert rc == 0
+    assert (col / "proposals" / "skills" / "my-new-skill" / "SKILL.md").is_file()
+    assert (col / "proposals" / "wave-skills-2026-06-26.yaml").is_file()

--- a/tests/test_provenance_tier.py
+++ b/tests/test_provenance_tier.py
@@ -1,0 +1,58 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import provenance_tier as p
+
+
+def test_constants():
+    assert p.VALID == {"literature", "synthetic", "community"}
+    assert p.DEFAULT == "literature"
+
+
+# --- one valid case per tier ------------------------------------------------
+
+def test_literature_valid_with_doi():
+    assert p.validate_entry("literature", dois=["10.1/a"]) == []
+
+
+def test_synthetic_valid_with_synthesized_from():
+    assert p.validate_entry("synthetic", synthesized_from=["s1", "s2"]) == []
+
+
+def test_community_valid_with_related_skills_present():
+    # an empty related_skills list is allowed (the key is present)
+    assert p.validate_entry("community", related_skills=[]) == []
+    assert p.validate_entry("community", related_skills=["s1"]) == []
+
+
+# --- failure cases ----------------------------------------------------------
+
+def test_unknown_tier():
+    assert p.validate_entry("bogus", dois=["10.1/a"]) == [
+        "invalid provenance_tier 'bogus'"
+    ]
+
+
+def test_literature_without_doi():
+    assert p.validate_entry("literature") == ["literature requires >=1 doi"]
+    assert p.validate_entry("literature", dois=[]) == ["literature requires >=1 doi"]
+    assert p.validate_entry("literature", dois=None) == ["literature requires >=1 doi"]
+
+
+def test_synthetic_without_synthesized_from():
+    assert p.validate_entry("synthetic") == ["synthetic requires synthesized_from"]
+    assert p.validate_entry("synthetic", synthesized_from=[]) == [
+        "synthetic requires synthesized_from"
+    ]
+    assert p.validate_entry("synthetic", synthesized_from=None) == [
+        "synthetic requires synthesized_from"
+    ]
+
+
+def test_community_without_related_skills_key():
+    # None means the key is absent → violation
+    assert p.validate_entry("community") == ["community requires related_skills key"]
+    assert p.validate_entry("community", related_skills=None) == [
+        "community requires related_skills key"
+    ]

--- a/tests/test_skill_match.py
+++ b/tests/test_skill_match.py
@@ -1,0 +1,227 @@
+"""Tests for the skill-matching engine (serverless lexical core).
+
+skill_doc, lexical_match, match_tools, near_duplicates operate on in-memory
+index structures with no network; match_skills is the collection-level entry
+point that ranks a query against ``skills_index.json`` lexically. (Skill
+matching is lexical by design — Perspicacité is used for the separate
+literature-grounding step, not skill↔skill matching.)
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import skill_match as sm
+
+
+# --- tiny in-memory fixtures (shape mirrors skills_index.json / tools_index.json) ---
+
+SKILLS_INDEX = [
+    {
+        "slug": "retention-time-alignment",
+        "name": "retention-time-alignment",
+        "description": (
+            "Use when you need to align chromatographic retention time across "
+            "LC-MS samples so the same feature lines up between runs."
+        ),
+        "edam_topics": ["http://edamontology.org/topic_3172"],
+        "tools": ["xcms"],
+        "techniques": ["LC-MS"],
+        "tools_used": ["xcms"],
+    },
+    {
+        "slug": "retention-time-drift-correction",
+        "name": "retention-time-drift-correction",
+        "description": (
+            "Use when retention time drifts across a long LC-MS batch and you "
+            "want to correct chromatographic alignment using anchor features."
+        ),
+        "edam_topics": ["http://edamontology.org/topic_3172"],
+        "tools": ["xcms"],
+        "techniques": ["LC-MS"],
+        "tools_used": ["xcms"],
+    },
+    {
+        "slug": "spectral-library-matching",
+        "name": "spectral-library-matching",
+        "description": (
+            "Use when annotating MS/MS spectra by cosine similarity against a "
+            "reference spectral library to assign compound identities."
+        ),
+        "edam_topics": ["http://edamontology.org/topic_3520"],
+        "tools": ["matchms"],
+        "techniques": ["MS/MS"],
+        "tools_used": ["matchms"],
+    },
+]
+
+TOOLS_INDEX = [
+    {"slug": "xcms", "name": "xcms", "used_by_skills": ["retention-time-alignment"]},
+    {"slug": "matchms", "name": "matchms", "used_by_skills": ["spectral-library-matching"]},
+    {"slug": "mzmine", "name": "MZmine", "used_by_skills": []},
+]
+
+
+# --- skill_doc --------------------------------------------------------------
+
+def test_skill_doc_joins_searchable_fields():
+    doc = sm.skill_doc(SKILLS_INDEX[0])
+    assert "retention-time-alignment" in doc
+    assert "chromatographic" in doc
+    # tools, edam topics, techniques are folded in
+    assert "xcms" in doc
+    assert "topic_3172" in doc
+    assert "LC-MS" in doc
+
+
+def test_skill_doc_tolerates_missing_fields():
+    # a sparse entry must not raise and must include what's present
+    doc = sm.skill_doc({"slug": "x", "name": "x"})
+    assert "x" in doc
+    assert isinstance(doc, str)
+
+
+# --- lexical_match ----------------------------------------------------------
+
+def test_lexical_match_ranks_obviously_related_first():
+    text = (
+        "I need to align retention time across my LC-MS runs so the same "
+        "chromatographic feature matches between samples."
+    )
+    hits = sm.lexical_match(text, SKILLS_INDEX, k=3)
+    assert hits, "expected at least one hit"
+    assert hits[0]["slug"] == "retention-time-alignment"
+    # the unrelated spectral-matching skill must not outrank the RT skills
+    top_two = {h["slug"] for h in hits[:2]}
+    assert "retention-time-drift-correction" in top_two
+
+
+def test_lexical_match_shape_and_backend_tag():
+    hits = sm.lexical_match("spectral library cosine annotation", SKILLS_INDEX, k=10)
+    assert hits[0]["slug"] == "spectral-library-matching"
+    h = hits[0]
+    assert set(h) == {"slug", "score", "backend"}
+    assert h["backend"] == "lexical"
+    assert isinstance(h["score"], float)
+    assert h["score"] > 0
+
+
+def test_lexical_match_respects_k():
+    hits = sm.lexical_match("retention time chromatographic LC-MS spectral", SKILLS_INDEX, k=1)
+    assert len(hits) == 1
+
+
+def test_lexical_match_scores_sorted_descending():
+    hits = sm.lexical_match("retention time alignment chromatographic", SKILLS_INDEX, k=10)
+    scores = [h["score"] for h in hits]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_lexical_match_no_overlap_returns_empty():
+    hits = sm.lexical_match("zzqq totally unrelated tokens foobar", SKILLS_INDEX, k=10)
+    assert hits == []
+
+
+# --- match_tools ------------------------------------------------------------
+
+def test_match_tools_unions_tools_used_of_matched_skills():
+    res = sm.match_tools(
+        ["retention-time-alignment", "spectral-library-matching"],
+        SKILLS_INDEX,
+        TOOLS_INDEX,
+    )
+    slugs = {r["slug"] for r in res}
+    assert "xcms" in slugs
+    assert "matchms" in slugs
+    for r in res:
+        assert set(r) == {"slug", "score"}
+
+
+def test_match_tools_adds_lexical_tool_name_hits_from_text():
+    # text mentions MZmine by name → its slug should surface even though no
+    # matched skill uses it
+    res = sm.match_tools(
+        ["retention-time-alignment"],
+        SKILLS_INDEX,
+        TOOLS_INDEX,
+        text="processed with MZmine and xcms",
+    )
+    slugs = {r["slug"] for r in res}
+    assert "xcms" in slugs       # from the matched skill's tools_used
+    assert "mzmine" in slugs     # from the lexical tool-name hit in text
+
+
+def test_match_tools_dedupes_and_handles_empty():
+    assert sm.match_tools([], SKILLS_INDEX, TOOLS_INDEX) == []
+    # same tool reached via union + text should not duplicate
+    res = sm.match_tools(
+        ["retention-time-alignment"],
+        SKILLS_INDEX,
+        TOOLS_INDEX,
+        text="xcms xcms xcms",
+    )
+    assert [r["slug"] for r in res].count("xcms") == 1
+
+
+# --- near_duplicates --------------------------------------------------------
+
+def test_near_duplicates_default_threshold_flags_nothing():
+    candidates = [
+        {"slug": "a", "score": 0.9},
+        {"slug": "b", "score": 0.1},
+    ]
+    assert sm.near_duplicates(candidates) == []
+
+
+def test_near_duplicates_threshold_selects_above():
+    candidates = [
+        {"slug": "retention-time-alignment", "score": 0.92},
+        {"slug": "retention-time-drift-correction", "score": 0.61},
+        {"slug": "spectral-library-matching", "score": 0.10},
+    ]
+    flagged = sm.near_duplicates(candidates, threshold=0.6)
+    assert flagged == ["retention-time-alignment", "retention-time-drift-correction"]
+
+
+def test_near_duplicates_threshold_is_strict_greater():
+    candidates = [{"slug": "a", "score": 0.5}, {"slug": "b", "score": 0.51}]
+    # exactly-at-threshold is excluded; only strictly-greater is flagged
+    assert sm.near_duplicates(candidates, threshold=0.5) == ["b"]
+
+
+# === match_skills — collection-level lexical matching =======================
+#
+# Skill-similarity matching is intentionally lexical (Perspicacité is a paper
+# RAG system, used elsewhere for literature grounding — not skill↔skill
+# matching). These tests exercise the collection-level entry point over a real
+# ``skills_index.json``.
+
+
+@pytest.fixture
+def collection_dir(tmp_path):
+    """A throwaway collection dir with a tiny ``skills_index.json``."""
+    coll = tmp_path / "metabolomics" / "v2"
+    coll.mkdir(parents=True)
+    (coll / "skills_index.json").write_text(json.dumps(SKILLS_INDEX), encoding="utf-8")
+    return coll
+
+
+def test_match_skills_ranks_lexically_over_the_index(collection_dir):
+    hits = sm.match_skills("align retention time chromatographic", collection_dir)
+    assert hits
+    assert all(h["backend"] == "lexical" for h in hits)
+    assert hits[0]["slug"] == "retention-time-alignment"
+
+
+def test_match_skills_respects_k(collection_dir):
+    hits = sm.match_skills("spectral library cosine annotation", collection_dir, k=1)
+    assert len(hits) <= 1
+
+
+def test_match_skills_never_raises_on_broken_collection(tmp_path):
+    # no skills_index.json, no server → must return [] rather than raise
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert sm.match_skills("anything", empty) == []

--- a/tests/test_stamp_provenance.py
+++ b/tests/test_stamp_provenance.py
@@ -1,0 +1,168 @@
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import stamp_provenance as P
+from scripts.provenance_tier import DEFAULT
+
+
+def _skill(tmp, slug, body="# t\n\nuse it.\n", meta=None, null_meta=False, corpus_dir="skills"):
+    d = tmp / corpus_dir / slug
+    d.mkdir(parents=True)
+    if null_meta:
+        (d / "SKILL.md").write_text(
+            "---\nname: " + slug + "\nmetadata:\n---\n" + body, encoding="utf-8"
+        )
+    else:
+        fm = {"name": slug, "license": "CC-BY-4.0", "metadata": (meta or {})}
+        (d / "SKILL.md").write_text(
+            "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n" + body,
+            encoding="utf-8",
+        )
+    return d / "SKILL.md"
+
+
+def _collection(tmp, corpus_dir="skills"):
+    """One skill with metadata:, one without; matching skills_index + kb_bundle."""
+    _skill(tmp, "with-meta", meta={"license_tier": "restricted"}, corpus_dir=corpus_dir)
+    _skill(tmp, "null-meta", null_meta=True, corpus_dir=corpus_dir)
+    si = [
+        {"slug": "with-meta", "dois": ["10.1/a"], "license_tier": "restricted"},
+        {"slug": "null-meta", "dois": ["10.2/b"], "license_tier": "open"},
+    ]
+    kb = {
+        "collection": "x",
+        "skills": {
+            "with-meta": {"dois": ["10.1/a"]},
+            "null-meta": {"dois": ["10.2/b"]},
+        },
+    }
+    (tmp / "skills_index.json").write_text(json.dumps(si, indent=2), encoding="utf-8")
+    (tmp / "kb_bundle.json").write_text(json.dumps(kb, indent=2), encoding="utf-8")
+    return tmp
+
+
+# --- propagate_indices -------------------------------------------------------
+
+def test_propagate_sets_default_on_entries_with_dois(tmp_path):
+    _collection(tmp_path)
+    summary = P.propagate_indices(
+        tmp_path / "skills_index.json", tmp_path / "kb_bundle.json"
+    )
+    assert summary == {DEFAULT: 2}
+    si = json.loads((tmp_path / "skills_index.json").read_text())
+    assert all(e["provenance_tier"] == DEFAULT for e in si)
+    kb = json.loads((tmp_path / "kb_bundle.json").read_text())
+    assert all(r["provenance_tier"] == DEFAULT for r in kb["skills"].values())
+
+
+def test_propagate_skips_entries_without_dois(tmp_path):
+    si = [{"slug": "a", "dois": ["10.1/a"]}, {"slug": "b", "dois": []}, {"slug": "c"}]
+    kb = {"skills": {"a": {"dois": ["10.1/a"]}, "b": {"dois": []}, "c": {}}}
+    (tmp_path / "skills_index.json").write_text(json.dumps(si, indent=2), encoding="utf-8")
+    (tmp_path / "kb_bundle.json").write_text(json.dumps(kb, indent=2), encoding="utf-8")
+    summary = P.propagate_indices(
+        tmp_path / "skills_index.json", tmp_path / "kb_bundle.json"
+    )
+    assert summary == {DEFAULT: 1}
+    si2 = json.loads((tmp_path / "skills_index.json").read_text())
+    assert si2[0]["provenance_tier"] == DEFAULT
+    assert "provenance_tier" not in si2[1]
+    assert "provenance_tier" not in si2[2]
+
+
+def test_propagate_is_idempotent(tmp_path):
+    _collection(tmp_path)
+    P.propagate_indices(tmp_path / "skills_index.json", tmp_path / "kb_bundle.json")
+    first_si = (tmp_path / "skills_index.json").read_text()
+    first_kb = (tmp_path / "kb_bundle.json").read_text()
+    P.propagate_indices(tmp_path / "skills_index.json", tmp_path / "kb_bundle.json")
+    assert (tmp_path / "skills_index.json").read_text() == first_si
+    assert (tmp_path / "kb_bundle.json").read_text() == first_kb
+
+
+# --- stamp_skill_provenance --------------------------------------------------
+
+def test_stamp_sets_field_no_banner(tmp_path):
+    md = _skill(tmp_path, "s", meta={"license_tier": "open"})
+    assert P.stamp_skill_provenance(md, "literature") is True
+    text = md.read_text()
+    fm = yaml.safe_load(text.split("---\n", 2)[1])
+    assert fm["metadata"]["provenance_tier"] == "literature"
+    assert fm["metadata"]["license_tier"] == "open"  # preserved
+    assert "asb-license-banner" not in text  # no banner added by us
+
+
+def test_stamp_handles_null_metadata(tmp_path):
+    md = _skill(tmp_path, "s-null", null_meta=True)
+    assert P.stamp_skill_provenance(md, "literature") is True
+    fm = yaml.safe_load(md.read_text().split("---\n", 2)[1])
+    assert fm["metadata"]["provenance_tier"] == "literature"
+
+
+def test_stamp_is_idempotent(tmp_path):
+    md = _skill(tmp_path, "s2", meta={"license_tier": "open"})
+    P.stamp_skill_provenance(md, "literature")
+    first = md.read_text()
+    assert P.stamp_skill_provenance(md, "literature") is False
+    assert md.read_text() == first
+
+
+def test_stamp_no_frontmatter_returns_false(tmp_path):
+    d = tmp_path / "skills" / "raw"
+    d.mkdir(parents=True)
+    md = d / "SKILL.md"
+    md.write_text("# no frontmatter\n", encoding="utf-8")
+    assert P.stamp_skill_provenance(md, "literature") is False
+
+
+# --- stamp_all + main --------------------------------------------------------
+
+@pytest.mark.parametrize("corpus_dir", ["skills", "leaves"])
+def test_stamp_all_uses_index_tier_in_either_layout(tmp_path, corpus_dir):
+    """A router-shaped collection keeps its corpus in `leaves/`.
+
+    Sweeping a hardcoded `skills/` there stamps nothing and still reports a
+    clean run -- the same silent no-op the licence stamper shipped with.
+    """
+    _collection(tmp_path, corpus_dir=corpus_dir)
+    P.propagate_indices(tmp_path / "skills_index.json", tmp_path / "kb_bundle.json")
+    res = P.stamp_all(str(tmp_path), str(tmp_path / "skills_index.json"))
+    assert res["changed"] == 2
+    assert res["tiers"] == {DEFAULT: 2}
+    assert res["indexed_but_absent"] == 0
+    for slug in ("with-meta", "null-meta"):
+        fm = yaml.safe_load(
+            (tmp_path / corpus_dir / slug / "SKILL.md").read_text().split("---\n", 2)[1]
+        )
+        assert fm["metadata"]["provenance_tier"] == DEFAULT
+    # second pass: nothing changes
+    res2 = P.stamp_all(str(tmp_path), str(tmp_path / "skills_index.json"))
+    assert res2["changed"] == 0
+
+
+def test_stamp_all_reports_an_indexed_skill_that_is_not_on_disk(tmp_path):
+    """The count must never be silently short."""
+    _collection(tmp_path, corpus_dir="leaves")
+    si = json.loads((tmp_path / "skills_index.json").read_text())
+    si.append({"slug": "gone", "dois": ["10.3/c"], "license_tier": "open"})
+    (tmp_path / "skills_index.json").write_text(json.dumps(si, indent=2), encoding="utf-8")
+    P.propagate_indices(tmp_path / "skills_index.json", tmp_path / "kb_bundle.json")
+    assert P.stamp_all(str(tmp_path), str(tmp_path / "skills_index.json"))["indexed_but_absent"] == 1
+
+
+def test_main_runs_on_collection(tmp_path):
+    _collection(tmp_path)
+    rc = P.main(["--collection", str(tmp_path)])
+    assert rc == 0
+    si = json.loads((tmp_path / "skills_index.json").read_text())
+    assert all(e["provenance_tier"] == DEFAULT for e in si)
+    for slug in ("with-meta", "null-meta"):
+        fm = yaml.safe_load(
+            (tmp_path / "skills" / slug / "SKILL.md").read_text().split("---\n", 2)[1]
+        )
+        assert fm["metadata"]["provenance_tier"] == DEFAULT

--- a/tests/test_synthesize_meta_skill.py
+++ b/tests/test_synthesize_meta_skill.py
@@ -1,0 +1,348 @@
+"""Tests for the synthetic meta-skill synthesizer helper (Task 2).
+
+The deterministic half of the ``synthesize-meta-skill`` flow:
+
+* ``cluster_subskills`` — thin wrapper over the (injectable) matcher, returning
+  the clustered sub-skills + their tools. A FAKE matcher is injected so no
+  network/server is needed.
+* ``meta_frontmatter`` — assemble a schema-correct ``super``/``synthetic``
+  frontmatter (reusing ``normalize_skill.normalized_frontmatter``); must yield
+  zero ``frontmatter_violations``.
+* ``stage_meta_skill`` — delegate to ``propose_skill.stage_proposal`` (DRY, same
+  rail), writing a ``wave-meta-skills-<date>.yaml`` ledger; idempotent, no
+  git/gh. The staged tree must pass ``check_proposals.check_collection``.
+"""
+import json
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import check_proposals as cp
+from scripts import synthesize_meta_skill as s
+from scripts.normalize_skill import frontmatter_violations
+
+
+# --- in-memory collection fixture (mirrors skills_index / tools_index) --------
+
+SUBSKILLS = ("lc-ms-feature-extraction", "spectral-similarity-scoring")
+TOOLS = ("mzmine", "matchms")
+
+VALID_DESC = (
+    "Use when you have raw LC-MS/MS data and need to build a molecular network "
+    "by detecting features, scoring spectral similarity, and propagating "
+    "annotations across the network."
+)
+
+
+def _collection(tmp_path, skill_slugs=SUBSKILLS, tool_slugs=TOOLS):
+    col = tmp_path / "v2"
+    col.mkdir(parents=True)
+    skills = [
+        {
+            "slug": sl,
+            "name": sl,
+            "description": f"Use when you need {sl.replace('-', ' ')} in LC-MS.",
+            "tools_used": [tool_slugs[i % len(tool_slugs)]],
+        }
+        for i, sl in enumerate(skill_slugs)
+    ]
+    (col / "skills_index.json").write_text(json.dumps(skills))
+    tools = [
+        {"slug": t, "license_tier": "open", "used_by_skills": []} for t in tool_slugs
+    ]
+    (col / "tools_index.json").write_text(json.dumps(tools))
+    return col
+
+
+def _fake_matcher(returns):
+    """A drop-in for ``match_skills(text, collection_dir, *, k, http=None)``.
+
+    Records the call and returns a fixed list of ``{slug, score, backend}``
+    hits — no network, no server, deterministic.
+    """
+    calls = []
+
+    def matcher(text, collection_dir, *, k=10, http=None):
+        calls.append({"text": text, "collection_dir": str(collection_dir), "k": k})
+        return [dict(r) for r in returns]
+
+    matcher.calls = calls
+    return matcher
+
+
+# --- cluster_subskills -------------------------------------------------------
+
+def test_cluster_subskills_returns_matcher_shape(tmp_path):
+    col = _collection(tmp_path)
+    matcher = _fake_matcher(
+        [
+            {"slug": "lc-ms-feature-extraction", "score": 0.9, "backend": "lexical"},
+            {"slug": "spectral-similarity-scoring", "score": 0.7, "backend": "lexical"},
+        ]
+    )
+    out = s.cluster_subskills("molecular networking", str(col), matcher=matcher)
+    assert set(out) == {"subskills", "tools"}
+    # subskills carry the matcher's slug+score
+    sub = out["subskills"]
+    assert [x["slug"] for x in sub] == list(SUBSKILLS)
+    assert all("score" in x for x in sub)
+    # tools are {slug, score} resolved against the indexes (union of tools_used)
+    assert out["tools"], "expected at least one clustered tool"
+    assert all(set(t) >= {"slug", "score"} for t in out["tools"])
+    tool_slugs = {t["slug"] for t in out["tools"]}
+    assert tool_slugs <= set(TOOLS)
+
+
+def test_cluster_subskills_passes_k_and_seed_to_matcher(tmp_path):
+    col = _collection(tmp_path)
+    matcher = _fake_matcher([{"slug": "lc-ms-feature-extraction", "score": 0.5}])
+    s.cluster_subskills("seed text", str(col), k=15, matcher=matcher)
+    assert matcher.calls[0]["k"] == 15
+    assert matcher.calls[0]["text"] == "seed text"
+    assert matcher.calls[0]["collection_dir"] == str(col)
+
+
+def test_cluster_subskills_defaults_to_real_match_skills(tmp_path):
+    # No matcher injected => falls back to the real lexical match_skills (no
+    # server). The seed text overlaps the fixture skills lexically.
+    col = _collection(tmp_path)
+    out = s.cluster_subskills(
+        "lc-ms feature extraction spectral similarity scoring", str(col)
+    )
+    slugs = {x["slug"] for x in out["subskills"]}
+    assert slugs & set(SUBSKILLS)
+
+
+def test_cluster_subskills_empty_match_yields_empty_tools(tmp_path):
+    col = _collection(tmp_path)
+    matcher = _fake_matcher([])
+    out = s.cluster_subskills("nothing matches", str(col), matcher=matcher)
+    assert out["subskills"] == []
+    assert out["tools"] == []
+
+
+# --- meta_frontmatter --------------------------------------------------------
+
+def test_meta_frontmatter_sets_synthetic_super_fields():
+    fm = s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+    )
+    meta = fm["metadata"]
+    assert meta["provenance_tier"] == "synthetic"
+    assert meta["skill_kind"] == "super"
+    assert meta["orchestrates"] == list(SUBSKILLS)
+    assert meta["synthesized_from"] == list(SUBSKILLS)
+    assert meta["tools_used"] == list(TOOLS)
+    assert meta["license_tier"] == "open"
+    assert fm["status"] == "hold"
+    # related_skills mirrors orchestrates (so community-key expectations hold too)
+    assert fm["related_skills"] == list(SUBSKILLS)
+    assert fm["name"] == "molecular-networking"
+    assert fm["description"] == VALID_DESC
+
+
+def test_meta_frontmatter_yields_zero_violations():
+    fm = s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+        license_tier="open",
+    )
+    assert frontmatter_violations(fm) == []
+
+
+def test_meta_frontmatter_honors_license_tier():
+    fm = s.meta_frontmatter(
+        name="m",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=[],
+        license_tier="noncommercial",
+    )
+    assert fm["metadata"]["license_tier"] == "noncommercial"
+    assert frontmatter_violations(fm) == []
+
+
+def test_meta_frontmatter_does_not_mutate_inputs():
+    orch = list(SUBSKILLS)
+    syn = list(SUBSKILLS)
+    tools = list(TOOLS)
+    s.meta_frontmatter(
+        name="m",
+        description=VALID_DESC,
+        orchestrates=orch,
+        synthesized_from=syn,
+        tools_used=tools,
+    )
+    assert orch == list(SUBSKILLS)
+    assert syn == list(SUBSKILLS)
+    assert tools == list(TOOLS)
+
+
+# --- meta_frontmatter: review-grounded (literature) super-skills -------------
+
+REVIEW_DOI = "10.1021/acs.analchem.0c01234"
+
+
+def test_meta_frontmatter_review_doi_sets_literature_tier():
+    # A review DOI flips the origin to literature: provenance_tier="literature",
+    # dois=[review_doi], derived_from=[{doi: review_doi}], keeping the super
+    # orchestration intact.
+    fm = s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+        review_doi=REVIEW_DOI,
+    )
+    meta = fm["metadata"]
+    assert meta["provenance_tier"] == "literature"
+    assert meta["dois"] == [REVIEW_DOI]
+    assert fm["derived_from"] == [{"doi": REVIEW_DOI}]
+    # super orchestration is preserved
+    assert meta["skill_kind"] == "super"
+    assert meta["orchestrates"] == list(SUBSKILLS)
+    assert meta["synthesized_from"] == list(SUBSKILLS)
+    assert fm["status"] == "hold"
+    assert frontmatter_violations(fm) == []
+
+
+def test_meta_frontmatter_default_path_stays_synthetic():
+    # Without a review DOI, the default path is unchanged: synthetic, no dois,
+    # no derived_from.
+    fm = s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+    )
+    meta = fm["metadata"]
+    assert meta["provenance_tier"] == "synthetic"
+    assert "dois" not in meta
+    assert "derived_from" not in fm
+
+
+def test_meta_frontmatter_review_doi_passes_check_collection(tmp_path):
+    # A staged review-grounded (literature) super-skill is accepted by the gate.
+    col = _collection(tmp_path)
+    fm = s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+        review_doi=REVIEW_DOI,
+    )
+    ledger_meta = {
+        "slug": "molecular-networking",
+        "synthesized_from": list(SUBSKILLS),
+        "orchestrates": list(SUBSKILLS),
+        "tools_used": list(TOOLS),
+        "license_tier": "open",
+        "date": "2026-06-26",
+    }
+    s.stage_meta_skill(str(col), fm, BODY, ledger_meta)
+    assert cp.check_collection(str(col)) == []
+
+
+# --- stage_meta_skill --------------------------------------------------------
+
+BODY = "# Molecular Networking\n\nOrdered orchestration body.\n"
+DATE = "2026-06-26"
+
+
+def _ledger_meta():
+    return {
+        "slug": "molecular-networking",
+        "synthesized_from": list(SUBSKILLS),
+        "orchestrates": list(SUBSKILLS),
+        "tools_used": list(TOOLS),
+        "license_tier": "open",
+        "date": DATE,
+    }
+
+
+def _frontmatter():
+    return s.meta_frontmatter(
+        name="molecular-networking",
+        description=VALID_DESC,
+        orchestrates=list(SUBSKILLS),
+        synthesized_from=list(SUBSKILLS),
+        tools_used=list(TOOLS),
+    )
+
+
+def test_stage_meta_skill_writes_tree(tmp_path):
+    col = _collection(tmp_path)
+    res = s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    skill_md = col / "proposals" / "skills" / "molecular-networking" / "SKILL.md"
+    ledger = col / "proposals" / "wave-meta-skills-2026-06-26.yaml"
+    assert skill_md.is_file()
+    assert ledger.is_file()
+    assert pathlib.Path(res["skill_md"]) == skill_md
+    assert pathlib.Path(res["ledger"]) == ledger
+    # the SKILL.md round-trips to the synthetic/super frontmatter
+    text = skill_md.read_text()
+    assert text.startswith("---\n")
+    fm = yaml.safe_load(text.split("---\n", 2)[1])
+    assert fm["metadata"]["skill_kind"] == "super"
+    assert fm["metadata"]["provenance_tier"] == "synthetic"
+    assert "Ordered orchestration body." in text.split("---\n", 2)[2]
+
+
+def test_stage_meta_skill_ledger_schema_and_entry(tmp_path):
+    col = _collection(tmp_path)
+    s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    ledger = yaml.safe_load(
+        (col / "proposals" / "wave-meta-skills-2026-06-26.yaml").read_text()
+    )
+    assert ledger["schema"] == "asb-skill-proposals/1.0"
+    entry = next(
+        e for e in ledger["proposals"] if e["slug"] == "molecular-networking"
+    )
+    assert entry["status"] == "hold"
+    assert entry["submitted_on"] == DATE
+    assert entry["orchestrates"] == list(SUBSKILLS)
+
+
+def test_stage_meta_skill_is_idempotent(tmp_path):
+    col = _collection(tmp_path)
+    first = s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    md1 = pathlib.Path(first["skill_md"]).read_text()
+    led1 = pathlib.Path(first["ledger"]).read_text()
+    second = s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    md2 = pathlib.Path(second["skill_md"]).read_text()
+    led2 = pathlib.Path(second["ledger"]).read_text()
+    assert md1 == md2
+    assert led1 == led2
+    ledger = yaml.safe_load(led2)
+    assert [e["slug"] for e in ledger["proposals"]].count(
+        "molecular-networking"
+    ) == 1
+
+
+def test_stage_meta_skill_result_passes_check_collection(tmp_path):
+    col = _collection(tmp_path)
+    s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    assert cp.check_collection(str(col)) == []
+
+
+def test_stage_meta_skill_does_no_git_or_network(tmp_path):
+    # The helper must not import or shell out to git/gh; staging only writes the
+    # proposals tree. (A behavioral proxy: nothing outside proposals/ appears.)
+    col = _collection(tmp_path)
+    before = {p.name for p in col.iterdir()}
+    s.stage_meta_skill(str(col), _frontmatter(), BODY, _ledger_meta())
+    after = {p.name for p in col.iterdir()}
+    assert after - before == {"proposals"}

--- a/tests/test_tier_update.py
+++ b/tests/test_tier_update.py
@@ -1,0 +1,169 @@
+"""Tests for scripts/tier_update.py.
+
+Covers the existing review-attestation path (backward compatible) and the new
+author-credit path: a contributor listed as a skill ``author`` is credited in
+contributors.jsonld (a contributions counter is incremented + tier re-evaluated)
+when their authored skill is merged. See Task 5 / governance/AUTHORSHIP.md.
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import tier_update as tu
+
+
+# --- fixtures ---------------------------------------------------------------
+
+CRITERIA = {
+    "thresholds": {
+        "reviewer": {"min_reviews": 1},
+        "domain_contributor": {"min_reviews": 5},
+        "curator": {"min_reviews": 10},
+        "lead_curator": {"min_reviews": 30, "min_external_reviews": 20},
+    }
+}
+
+
+def _registry(orcid="0000-0002-1111-2222", **extra):
+    contrib = {"orcid": f"https://orcid.org/{orcid}", "asb:tier": "none"}
+    contrib.update(extra)
+    return {"contributors": [contrib]}
+
+
+def _write(tmp_path):
+    contributors = tmp_path / "contributors.jsonld"
+    criteria = tmp_path / "curator-criteria.yaml"
+    criteria.write_text(yaml.safe_dump(CRITERIA))
+    return contributors, criteria
+
+
+def _load(path):
+    return json.loads(pathlib.Path(path).read_text())["contributors"][0]
+
+
+# --- existing review path (backward compatibility) --------------------------
+
+def test_review_path_increments_reviews_and_promotes(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry()))
+
+    tu.update_contributor(
+        contributors, criteria,
+        orcid="0000-0002-1111-2222", collection_slug="metabolomics",
+        is_self_authored=False,
+    )
+
+    c = _load(contributors)
+    assert c["asb:total_reviews"] == 1
+    assert c["asb:external_reviews"] == 1
+    assert c["asb:tier"] == "reviewer"
+
+
+def test_review_path_missing_contributor_exits_1(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry(orcid="0000-0000-0000-0000")))
+
+    with pytest.raises(SystemExit) as exc:
+        tu.update_contributor(
+            contributors, criteria,
+            orcid="0000-0002-9999-9999", collection_slug="metabolomics",
+            is_self_authored=False,
+        )
+    assert exc.value.code == 1
+
+
+# --- new author-credit path -------------------------------------------------
+
+def test_author_credit_increments_contributions_and_reevaluates(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry()))
+
+    tu.credit_author(
+        contributors, criteria,
+        orcid="0000-0002-1111-2222", collection_slug="metabolomics",
+    )
+
+    c = _load(contributors)
+    # A new, separate counter — does NOT touch review counters.
+    assert c["asb:authored_skills"] == 1
+    assert "asb:total_reviews" not in c
+    # An authored, merged skill credits the contributor at >= reviewer tier.
+    assert c["asb:tier"] == "reviewer"
+
+
+def test_author_credit_accumulates(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry(**{"asb:authored_skills": 2})))
+
+    tu.credit_author(
+        contributors, criteria,
+        orcid="0000-0002-1111-2222", collection_slug="metabolomics",
+    )
+
+    assert _load(contributors)["asb:authored_skills"] == 3
+
+
+def test_author_credit_does_not_downgrade_existing_tier(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    # An established curator (12 reviews) who also authors a skill keeps curator.
+    contributors.write_text(
+        json.dumps(
+            _registry(
+                **{
+                    "asb:total_reviews": 12,
+                    "asb:external_reviews": 12,
+                    "asb:tier": "curator",
+                }
+            )
+        )
+    )
+
+    tu.credit_author(
+        contributors, criteria,
+        orcid="0000-0002-1111-2222", collection_slug="metabolomics",
+    )
+
+    c = _load(contributors)
+    assert c["asb:authored_skills"] == 1
+    assert c["asb:total_reviews"] == 12  # untouched
+    assert c["asb:tier"] == "curator"  # not downgraded to reviewer
+
+
+def test_author_credit_missing_contributor_exits_1(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry(orcid="0000-0000-0000-0000")))
+
+    with pytest.raises(SystemExit) as exc:
+        tu.credit_author(
+            contributors, criteria,
+            orcid="0000-0002-9999-9999", collection_slug="metabolomics",
+        )
+    assert exc.value.code == 1
+
+
+def test_evaluate_tier_authored_only_reaches_reviewer(tmp_path):
+    # No reviews but >=1 authored skill -> reviewer (entry tier).
+    assert tu.evaluate_tier(0, 0, CRITERIA, authored_skills=1) == "reviewer"
+    # Zero of everything -> none.
+    assert tu.evaluate_tier(0, 0, CRITERIA, authored_skills=0) == "none"
+
+
+def test_cli_credit_author_flag(tmp_path):
+    contributors, criteria = _write(tmp_path)
+    contributors.write_text(json.dumps(_registry()))
+
+    tu.main(
+        [
+            "--orcid", "0000-0002-1111-2222",
+            "--collection", "metabolomics",
+            "--credit-author",
+            "--contributors", str(contributors),
+            "--criteria", str(criteria),
+        ]
+    )
+
+    assert _load(contributors)["asb:authored_skills"] == 1


### PR DESCRIPTION
PRs #17–#21 were merged into `dev` in June 2026 and `dev` was never promoted. The v0 line was rebuilt from a different base, so that work sits on no release branch — not on `main`, not on the #28 → #29 stack. What was left behind is the community-contribution machinery, which means v0 would otherwise ship a contribution process the repository does not implement. Nine open issues here (`propose, triaged`) were filed through templates the release branch does not carry.

This is a port, not a merge. `dev` predates the router-shaped layout and the corpus rebuild, so merging it would drag 6,872 stale files onto the release line. Only the source level comes across: scripts, tests, governance and templates. No corpus.

## What lands

- **Proposal pipeline** — `propose_skill`, `check_proposals`, `promote_proposals`, `normalize_skill`, and the `propose-skill` / `propose-meta-skill` / `claim-skill` issue templates with `proposals.yml`.
- **Authorship and credit** — `governance/AUTHORSHIP.md`, `COMMUNITY_SKILLS.md`, and `tier_update.py`'s author-credit path: a contributor who authors a merged skill earns the reviewer tier through `asb:authored_skills`, without touching review counters and without downgrading a higher tier.
- **Provenance** — `provenance_tier` kernel, `stamp_provenance`, `check_provenance_tiers`, `governance/PROVENANCE_TIERS.md`.
- **Tool catalogue and related skills** — `enrich_tool_yaml`, `enrich_tools_index`, `check_tools_index`, `skill_match`, `build_related_skills`, `check_related_skills`.
- **Meta-skill synthesis** — `synthesize_meta_skill`, `governance/META_SKILLS.md`.

16 scripts, 15 test modules, 4 governance documents, 3 issue templates, 1 workflow. 892 tests pass, 2 skipped.

## What the port had to fix

The branch guards caught every one of these on the first run, which is the main argument for having landed them first.

**Promotion wrote into the wrong directory.** `promote_proposals` moved an accepted proposal into `skills/`. On a router-shaped collection that is the *advertised* directory: the skill would have been injected into every host's session prompt and would still have been missing from the leaf corpus consumers actually read. It now resolves through `layout.leaf_dir`, pinned by a test in both layouts.

**`stamp_provenance` swept a hardcoded `skills/`** — the same silent no-op the licence stamper shipped with. Layout-aware now, and it reports `indexed_but_absent` rather than quietly stamping fewer skills than the index lists.

**Nine scripts could not run by path.** No `sys.path` bootstrap, so `python scripts/x.py` died on the sibling import.

**A real DOI sat in a usage example** in `ground_skill`'s docstring, against the no-literals rule. Replaced with a placeholder.

`proposals/skills/` is now `layout.staging_dir()` — a proposal under review is deliberately outside the corpus and does not follow the leaf/advertised split, but it should not be spelled out by hand in three scripts either.

## Two things deliberately not done

**The provenance and tool-catalogue gates are not wired into CI.** They ship as tools; their producers have not been run against this corpus, so `check_provenance_tiers` and `check_tools_index` currently fail on real data. Wiring them belongs with the data commit that produces the fields, which should be reviewed on its own. `check_proposals` — the one `proposals.yml` runs — passes.

**The provenance vocabulary has no tier for a repo-grounded skill.** Running the stamper leaves exactly one entry unclassified: `masster`, admitted on the openness of its repository under a `repo-oa` rule that postdates `PROVENANCE_TIERS.md`. It fits none of `literature` (needs a DOI), `synthetic`, or `community` cleanly. That is a governance question, not a port question, so the gate is left reporting it rather than patched around.
