### PR TITLE
Harden the collection from use: a consent-gated, dedupable feedback loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-feedback.md
+++ b/.github/ISSUE_TEMPLATE/skill-feedback.md
@@ -1,0 +1,55 @@
+---
+name: Report friction using a skill
+about: A skill was wrong, stale, missing, or wasteful in practice. Reports from real use are how the collection hardens.
+title: "<kind>: <skill or capability> — <what happened>"
+labels: ["usage-feedback", "needs-triage"]
+---
+
+<!--
+The `asb-contribute` skill fills this in for you from the session where the
+problem happened, redacts paths and credentials, and shows you the result before
+anything is posted. Filling it in by hand is fine too.
+
+Before opening: search for the fingerprint below, or for the skill slug. If an
+issue already describes this, comment there instead — ten corroborations on one
+issue are worth more to a maintainer, and to you, than ten separate issues.
+-->
+
+**Kind:** <!-- defect | gap | composition | efficiency | drift -->
+
+- `defect` — an existing skill is wrong, stale, or does not work as written
+- `gap` — no skill covers the task; a new one is warranted
+- `composition` — the leaves exist but nothing composes them; a workflow is warranted
+- `efficiency` — the skill works but costs far more than it needs to
+- `drift` — the underlying tool changed and the skill no longer matches it
+
+**Target:** <!-- the skill slug, or a short name for the capability that is missing -->
+
+**Fingerprint:** <!-- from `asb-contribute`; lets other reporters find this issue -->
+
+### What happened
+
+<!-- What you ran, what the skill told you to do, and what actually occurred. -->
+
+### What the skill led you to expect
+
+<!-- Optional. Quote the line that misled you, if there was one. -->
+
+### Context
+
+<!-- Tool and version, OS, anything that makes it reproducible. No sample data,
+no absolute paths, no credentials — see the note below. -->
+
+---
+
+**Before you post, check this issue contains nothing you would not publish.**
+Automated redaction removes home directories, tokens and clinical identifiers,
+but it cannot recognise every sensitive sample name. You are the last check.
+
+<!--
+Why bother: this collection is grounded in the published literature and given
+away under CC-BY. It gets better only when people who use it say what broke.
+If you report a gap you can also propose the fix — see
+.github/ISSUE_TEMPLATE/propose-skill.md and governance/AUTHORSHIP.md, which
+records authored skills as credit toward the reviewer tier.
+-->

--- a/collections/metabolomics/v2/gate_report.json
+++ b/collections/metabolomics/v2/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-19T22:33:38.483163+00:00",
+  "generated_at": "2026-08-20T00:00:55.474278+00:00",
   "collection_dir": "collections/metabolomics/v2",
   "corpus_path": "collections/metabolomics/v2/corpus.yaml",
   "mode": "strict",
@@ -103,7 +103,7 @@
         8
       ],
       "hard_gate": true,
-      "summary": "Every skill carries provenance (source DOI or repository) + a license SPDX tag.  (5860 skills checked)",
+      "summary": "Every skill carries provenance (source DOI or repository) + a license SPDX tag.  (5861 skills checked)",
       "n_findings": 0,
       "details": []
     },

--- a/collections/metabolomics/v2/skills/asb-contribute/SKILL.md
+++ b/collections/metabolomics/v2/skills/asb-contribute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asb-contribute
-description: "Use when an ASB skill was wrong, stale, missing, or wasteful in practice — a skill's steps did not work, no skill covered the task, the leaves existed but nothing composed them, or the underlying tool has changed. Turns that friction into a redacted, dedupable report the user approves before anything is filed, and closes the credit loop for skills the user relied on."
+description: "Use when an ASB skill proved wrong, stale, missing or wasteful in practice — its steps failed, no skill covered the task, the leaves existed but nothing composed them, or the tool has changed. Turns that friction into a redacted, dedupable report the user approves before anything is filed."
 license: CC-BY-4.0
 metadata:
   role: meta

--- a/collections/metabolomics/v2/skills/asb-contribute/SKILL.md
+++ b/collections/metabolomics/v2/skills/asb-contribute/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: asb-contribute
+description: "Use when an ASB skill was wrong, stale, missing, or wasteful in practice — a skill's steps did not work, no skill covered the task, the leaves existed but nothing composed them, or the underlying tool has changed. Turns that friction into a redacted, dedupable report the user approves before anything is filed, and closes the credit loop for skills the user relied on."
+license: CC-BY-4.0
+metadata:
+  role: meta
+  helper: scripts/skill_feedback.py
+  issue_templates:
+  - .github/ISSUE_TEMPLATE/skill-feedback.md
+  - .github/ISSUE_TEMPLATE/propose-skill.md
+  - .github/ISSUE_TEMPLATE/propose-meta-skill.md
+derived_from:
+- doi: 10.5281/zenodo.20794027
+  title: ASB Metabolomics Skill Collection v2 (metabolomics-v0.1.0)
+schema_version: 0.2.0
+---
+
+# asb-contribute
+
+The collection hardens from use, not from review. This skill is how a session
+that hit friction becomes something a maintainer can act on.
+
+## When this fires
+
+Notice it yourself; do not wait to be asked. Any of these is a trigger:
+
+- a skill's procedure failed, or its parameters no longer match the tool;
+- the search returned nothing usable and the work was done unaided;
+- the right leaves existed but the user had to compose them by hand;
+- the skill worked, but at obviously avoidable cost;
+- the user says some version of "that's wrong" about a skill's content.
+
+**One offer per session per problem.** If the user declines, drop it — do not
+raise it again for the same friction. Persistent asking is how a good idea
+becomes an annoyance people disable.
+
+## Protocol
+
+### 1. Classify
+
+Pick exactly one kind: `defect`, `gap`, `composition`, `efficiency`, `drift`.
+The kind decides routing and labels, so guessing costs a maintainer real time.
+If two apply, pick the one a fix would address.
+
+### 2. Search before drafting
+
+Look for an existing issue — by fingerprint, by skill slug, by symptom:
+
+```bash
+gh issue list --repo HolobiomicsLab/asb-skill-collections --state all \
+  --search "<slug> OR <symptom keywords>" --limit 20
+```
+
+**If one matches, corroborate it. Do not open a second.** Ten corroborations on
+one issue tell a maintainer what ten near-identical issues cannot, and the
+reporter's account of the problem is read rather than buried.
+
+### 3. Draft
+
+```bash
+python scripts/skill_feedback.py --kind defect --target <slug> \
+  --symptom "..." --expected "..." --context "tool + version, OS" \
+  --collection metabolomics/v2
+```
+
+It returns the title, body, labels and fingerprint, with home directories,
+credentials and clinical identifiers already removed, and it names the
+categories it stripped.
+
+### 4. Show the user the exact body, then ask
+
+Print the rendered body verbatim — not a summary of it. The user is deciding
+whether to publish this text, and they can only decide that by reading it.
+
+State plainly what redaction does and does not do: it removes paths, tokens and
+clinical identifiers; **it cannot recognise a sensitive sample name**, so they
+are the last check. Invite edits before filing.
+
+Then make the case once, briefly and honestly. Something like: *this collection
+is grounded in published work and given away under CC-BY; it improves only when
+people who run it say what broke. Reporting this takes a minute and saves the
+next person the hour you just lost.* Do not moralise, do not repeat it, and do
+not imply an obligation.
+
+### 5. File only on an explicit yes
+
+```bash
+gh issue create --repo HolobiomicsLab/asb-skill-collections \
+  --title "<title>" --body-file <path> --label usage-feedback --label needs-triage
+```
+
+Corroborating instead:
+
+```bash
+gh issue comment <number> --body-file <path>
+```
+
+No `gh`, or no consent to use it: hand the user the rendered body and the
+`new/choose` URL for the repository, and stop. Filing on their behalf without a
+yes is publishing their words under their name.
+
+### 6. Offer the fix, when there is one
+
+A `gap` or `composition` report the user can answer themselves is worth more as
+a proposal than as a request. Point them at `propose-skill` /
+`propose-meta-skill`, and say what it earns: `governance/AUTHORSHIP.md` records
+an authored skill as credit toward the reviewer tier, and `claim-skill` links it
+to their ORCID.
+
+## Closing the credit loop
+
+When a session ends having leaned on this collection, offer the citation for
+what was actually used — the collection DOI plus the source DOIs of the skills
+applied, from each skill's `derived_from`. Reciprocity is easier to ask for
+after the user has seen the machinery work in their favour, and a methods
+section that names its sources is the point of grounding skills in literature at
+all.
+
+## What never happens here
+
+- No issue, comment, or PR without an explicit yes in this session.
+- No session transcript, file path, or dataset pasted in unredacted.
+- No second issue when an open one already describes the problem.
+- No report filed against a repository the user did not name.

--- a/collections/metabolomics/v2/skills/asb-metabolomics/SKILL.md
+++ b/collections/metabolomics/v2/skills/asb-metabolomics/SKILL.md
@@ -41,6 +41,14 @@ For the actual skill selection, delegate to the `_router` skill, which performs 
 routing over the indexes. This meta-skill owns guidance and license governance;
 `_router` owns routing.
 
+## Step 5: report what did not work
+
+The collection hardens from use. When a skill turns out to be wrong or stale, when
+the search finds nothing usable, or when the leaves exist but nothing composes them,
+delegate to **`asb-contribute`**: it turns that friction into a redacted, dedupable
+report the user approves before anything is filed. Offer once per problem, and drop
+it if declined.
+
 ## License tiers
 
 `open` = commercial use OK; `noncommercial` = academic/noncommercial only;

--- a/docs/CONTRIBUTION_LOOP.md
+++ b/docs/CONTRIBUTION_LOOP.md
@@ -1,0 +1,65 @@
+# The contribution loop
+
+How a collection built from published literature keeps improving after release.
+
+Peer review makes a skill correct **as written**. Only use makes it correct **as
+run**: a flag that changed in the tool's last minor release, a step that assumes
+a file layout nobody has, a procedure that works but costs ten times what it
+needs to. None of that is visible from the paper the skill was derived from.
+
+The obstacle is not willingness. It is that writing a good issue costs more than
+working around the problem once, so the person who found the defect pays, and
+everyone after them pays again. The loop below moves that cost onto the agent
+that was already in the session when it happened.
+
+## What ships
+
+| Piece | What it does |
+|---|---|
+| [`asb-contribute`](../collections/metabolomics/v2/skills/asb-contribute/SKILL.md) | Advertised skill. Fires on friction, classifies it, searches for an existing issue, drafts a redacted report, and files it **only** on an explicit yes. |
+| [`scripts/skill_feedback.py`](../scripts/skill_feedback.py) | Renders the report, strips outbound secrets, and computes the fingerprint that merges reports of one problem. |
+| [`.github/ISSUE_TEMPLATE/skill-feedback.md`](../.github/ISSUE_TEMPLATE/skill-feedback.md) | The manual path, for people not running an agent. |
+| Proposal rails | `propose-skill`, `propose-meta-skill`, `claim-skill`, `proposals.yml`, and [`governance/AUTHORSHIP.md`](../governance/AUTHORSHIP.md) — where a report that carries its own fix becomes credit. |
+
+## Three properties that decide whether this helps or hurts
+
+**Aggregation over volume.** A hundred separate "this did not work" issues is
+worse for a maintainer than ten issues carrying a hundred corroborations — and
+worse for the reporter, whose account disappears into a pile. Every report gets
+a fingerprint keyed on kind, target and the content words of the symptom, so a
+close restatement of a known problem lands as a comment on the open issue. The
+fingerprint catches close restatements, not arbitrary paraphrase, so the skill
+searches open issues as well.
+
+**Consent, not automation.** Nothing is posted without an explicit yes in the
+session, and the user is shown the exact body rather than a summary of it —
+they are deciding whether to publish that text, which they cannot judge from a
+paraphrase. Redaction removes home directories, credentials and the clinical
+identifiers the release gate already knows about, and names what it stripped;
+it cannot recognise a sensitive sample name, and the skill says so rather than
+implying a guarantee.
+
+**One offer per problem.** A prompt that returns after being declined stops
+being a contribution channel and becomes a reason to disable the plugin.
+
+## Companion skills considered
+
+Only one skill is advertised, because every advertised description is paid for
+in the session prompt of every user (`asb-contribute` costs ~96 tokens). The
+rest were folded in or deferred:
+
+| Candidate | Decision |
+|---|---|
+| **Citation / credit** — emit the collection DOI plus the source DOIs actually relied on | **Folded into `asb-contribute`.** Reciprocity is easier to ask for once the user has seen the credit machinery work in their favour, and it needs no separate trigger. |
+| **Claim authorship** — link an authored skill to an ORCID | **Deferred.** `claim-skill.md` and `tier_update --credit-author` already cover it; a skill would only wrap them. Revisit if the template goes unused. |
+| **Session provenance report** — what was applied, what was grounded, what was assumed | **Deferred, strongest candidate.** Genuinely useful for a methods section, but it wants a session-log surface that does not exist yet. |
+| **Pre-flight grounding check** — verify a skill's claim against its source before acting | **Not a new skill.** Already step 4 of `asb-metabolomics`, via the Perspicacité binder. Duplicating it would split the protocol. |
+
+## For maintainers
+
+Reports arrive labelled `usage-feedback` + `needs-triage`, with `propose` added
+when the reporter is asking for new work. Triage on the kind:
+
+- `defect` / `drift` → fix the skill; the fingerprint finds every corroborator to notify.
+- `gap` / `composition` → invite a proposal, or stage one; see `governance/COMMUNITY_SKILLS.md`.
+- `efficiency` → usually a workflow or a better default, rarely a new leaf.

--- a/scripts/skill_feedback.py
+++ b/scripts/skill_feedback.py
@@ -1,0 +1,196 @@
+"""Turn friction met while *using* a skill into a filable, dedupable report.
+
+A collection improves fastest when the people running it in anger tell it what
+broke. The obstacle is not willingness — it is that writing a good issue costs
+more than working around the problem once. This module removes that cost: it
+renders a structured report, redacts what should not leave the user's machine,
+and computes a fingerprint so the tenth person to hit a problem **corroborates
+the existing issue instead of opening an eleventh**.
+
+That aggregation is the point. A hundred separate "this did not work" issues is
+worse for a maintainer than ten issues carrying a hundred corroborations, and it
+is worse for the reporter, whose report disappears into a pile.
+
+Redaction is a safety net, not a guarantee. It removes the categories that leak
+by accident — home paths, credentials, hostnames, and the clinical identifiers
+the release gate already knows about — but no pattern set can recognise every
+sensitive sample name in every lab. The calling skill must show the user the
+exact rendered body and get explicit consent before anything is posted. See
+`skills/asb-contribute/SKILL.md`.
+"""
+from __future__ import annotations
+
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+
+from scripts.release_gate import PII_CONFIG
+
+# What kind of friction this is. The kind decides where the report goes and what
+# a maintainer can do with it, so it is a closed vocabulary, not free text.
+KINDS: dict[str, str] = {
+    "defect": "an existing skill is wrong, stale, or does not work as written",
+    "gap": "no skill covers the task; a new one is warranted",
+    "composition": "the leaves exist but nothing composes them; a workflow is warranted",
+    "efficiency": "the skill works but costs far more than it needs to",
+    "drift": "the underlying tool changed and the skill no longer matches it",
+}
+
+# Redaction beyond the release gate's clinical set. These are the categories that
+# leak from a *session transcript* rather than from published prose: the gate
+# never sees a home directory or a bearer token, so its patterns do not cover
+# them. Ordered longest-match-first where two could overlap.
+OUTBOUND_PATTERNS: dict[str, str] = {
+    "credential": r"\b(?:sk-|ghp_|gho_|github_pat_|xox[baprs]-)[A-Za-z0-9_\-]{10,}",
+    "authorization_header": r"(?i)\b(?:authorization|api[_-]?key|token|password)\b\s*[:=]\s*\S+",
+    "posix_home": r"/(?:Users|home)/[^/\s\"']+",
+    "windows_home": r"[A-Za-z]:\\\\?Users\\\\?[^\\\s\"']+",
+    "url_userinfo": r"(?i)\b[a-z][a-z0-9+.\-]*://[^/\s:@]+:[^/\s@]+@",
+}
+
+REDACTED = "<redacted:{name}>"
+FINGERPRINT_LENGTH = 12
+
+# Generic English function words, dropped before fingerprinting so that two
+# people describing one problem in different words still collide. Deliberately
+# domain-neutral: a metabolomics term dropped here would silently merge two
+# unrelated reports, which is the worse error.
+STOPWORDS = frozenset(
+    "a an and are as at be but by for from has have how in into is it its no not "
+    "of on or that the then there these this to was were when which with".split()
+)
+
+
+def _pii_patterns() -> dict[str, str]:
+    """The release gate's clinical/personal set — one canonical source, not a copy."""
+    return dict(PII_CONFIG["hard_fail_patterns"])
+
+
+def redact(text: str) -> tuple[str, list[str]]:
+    """Return (redacted_text, categories_removed).
+
+    Categories are reported so the calling skill can tell the user *what* was
+    removed. Silence would leave them unable to judge whether the remainder is
+    safe, which is the whole decision they are being asked to make.
+    """
+    removed: list[str] = []
+    out = text or ""
+    for name, pattern in {**OUTBOUND_PATTERNS, **_pii_patterns()}.items():
+        out, n = re.subn(pattern, REDACTED.format(name=name), out)
+        if n:
+            removed.append(name)
+    return out, sorted(removed)
+
+
+def fingerprint(kind: str, target: str, symptom: str) -> str:
+    """A stable id for "this same friction", so reports can be merged.
+
+    Keyed on the *kind*, the skill or capability it concerns, and the set of
+    content words in the symptom — not on the reporter, the timestamp, or the
+    surrounding prose, none of which two people hitting one problem would share.
+
+    This catches close restatements, not arbitrary paraphrase: "the flag is
+    wrong in the example" and "The example's flag is WRONG!" collide, but two
+    genuinely different descriptions of one bug will not. The fingerprint is
+    therefore a cheap merge, not a substitute for searching open issues — the
+    calling skill must do both.
+    """
+    words = re.sub(r"[^a-z0-9 ]+", " ", (symptom or "").lower()).split()
+    content = sorted({w for w in words if len(w) > 2 and w not in STOPWORDS})
+    payload = "␟".join((kind, (target or "").strip().lower(), " ".join(content)))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:FINGERPRINT_LENGTH]
+
+
+def labels_for(kind: str) -> list[str]:
+    """Labels a maintainer can filter on. `needs-triage` is always present."""
+    base = ["usage-feedback", "needs-triage"]
+    return base + {"gap": ["propose"], "composition": ["propose", "workflow"]}.get(kind, [])
+
+
+def render_issue(
+    kind: str,
+    target: str,
+    symptom: str,
+    expected: str = "",
+    context: str = "",
+    collection: str = "",
+) -> dict:
+    """Render the report a maintainer reads, with everything redacted.
+
+    Raises ValueError on an unknown `kind`: a report that cannot be routed is
+    worse than no report, and silently relabelling it would hide the mistake.
+    """
+    if kind not in KINDS:
+        raise ValueError(f"unknown kind {kind!r}; expected one of {sorted(KINDS)}")
+    if not (target or "").strip() or not (symptom or "").strip():
+        raise ValueError("a report needs both a target and a symptom")
+
+    fields = {k: redact(v) for k, v in
+              {"symptom": symptom, "expected": expected, "context": context}.items()}
+    stripped = sorted({c for _, cats in fields.values() for c in cats})
+    fid = fingerprint(kind, target, symptom)
+
+    body = [
+        f"**Kind:** `{kind}` — {KINDS[kind]}",
+        f"**Target:** `{target}`" + (f"  ·  **Collection:** `{collection}`" if collection else ""),
+        f"**Fingerprint:** `{fid}`  <!-- corroborate this issue rather than opening a new one -->",
+        "",
+        "### What happened",
+        fields["symptom"][0].strip(),
+    ]
+    if fields["expected"][0].strip():
+        body += ["", "### What the skill led me to expect", fields["expected"][0].strip()]
+    if fields["context"][0].strip():
+        body += ["", "### Context", fields["context"][0].strip()]
+    if stripped:
+        body += ["", f"*Redacted before posting: {', '.join(stripped)}.*"]
+
+    return {
+        "title": f"{kind}: {target} — {' '.join(symptom.split())[:80]}",
+        "body": "\n".join(body).rstrip() + "\n",
+        "labels": labels_for(kind),
+        "fingerprint": fid,
+        "redacted": stripped,
+    }
+
+
+def corroboration(fid: str, symptom: str, context: str = "") -> str:
+    """The comment that strengthens an existing issue instead of duplicating it."""
+    detail, _ = redact(symptom)
+    extra, _ = redact(context)
+    lines = [f"Hit this too (`{fid}`).", "", detail.strip()]
+    if extra.strip():
+        lines += ["", extra.strip()]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--kind", required=True, choices=sorted(KINDS))
+    parser.add_argument("--target", required=True, help="skill slug, or the capability that is missing")
+    parser.add_argument("--symptom", required=True)
+    parser.add_argument("--expected", default="")
+    parser.add_argument("--context", default="")
+    parser.add_argument("--collection", default="")
+    args = parser.parse_args(argv)
+    try:
+        print(json.dumps(render_issue(args.kind, args.target, args.symptom,
+                                      args.expected, args.context, args.collection), indent=2))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_feedback.py
+++ b/tests/test_skill_feedback.py
@@ -1,0 +1,133 @@
+"""Usage reports must dedupe across reporters and must not leak the reporter.
+
+Two failure modes, both quiet. Leak: a home path, a token or a clinical
+identifier rides a session transcript into a public issue. Fragmentation: ten
+people hit one problem and open ten issues, because nothing recognised them as
+the same problem — which is the failure that makes crowd-sourced feedback worse
+than no feedback at all.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from scripts import skill_feedback as sf  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Redaction                                                                    #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("secret,category", [
+    ("/Users/someone/lab/samples", "posix_home"),
+    ("/home/someone/lab/samples", "posix_home"),
+    ("sk-abcdefghijklmnop0123", "credential"),
+    ("ghp_abcdefghijklmnop0123", "credential"),
+    ("Authorization: Bearer abc123", "authorization_header"),
+    ("https://user:hunter2@internal.example/api", "url_userinfo"),
+])
+def test_an_outbound_secret_never_reaches_the_body(secret, category):
+    out, removed = sf.redact(f"it failed on {secret} during the run")
+    assert secret not in out
+    assert category in removed
+
+
+def test_a_clinical_identifier_is_caught_by_the_gates_own_patterns():
+    """One canonical pattern set: the release gate's, not a second copy here."""
+    out, removed = sf.redact("crashed on MRN 4820193 in the export")
+    assert "4820193" not in out
+    assert "mrn" in removed
+
+
+def test_ordinary_technical_detail_survives_redaction():
+    """The other side. Over-redacting produces a report nobody can act on."""
+    text = ("mzmine 4.4.3 batch export wrote 0 rows; the skill says --format mgf "
+            "but the CLI wants --export-mgf. Ran on Ubuntu 24.04, Python 3.12.")
+    out, removed = sf.redact(text)
+    assert out == text
+    assert removed == []
+
+
+def test_the_reader_is_told_what_was_removed():
+    issue = sf.render_issue("defect", "spectral-library-match",
+                            symptom="failed reading /Users/me/data/run1.mzML")
+    assert "posix_home" in issue["redacted"]
+    assert "Redacted before posting: posix_home." in issue["body"]
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprinting — the same friction must collide across reporters             #
+# --------------------------------------------------------------------------- #
+
+def test_two_reporters_describing_one_problem_collide():
+    a = sf.fingerprint("defect", "sirius-denovo", "the flag is wrong in the example")
+    b = sf.fingerprint("defect", "sirius-denovo", "The example's flag is WRONG!")
+    assert a == b
+
+
+def test_wording_order_does_not_change_the_fingerprint():
+    assert (sf.fingerprint("defect", "x", "timeout on large files")
+            == sf.fingerprint("defect", "x", "files large on timeout"))
+
+
+@pytest.mark.parametrize("kind,target,symptom", [
+    ("gap", "sirius-denovo", "the flag is wrong in the example"),
+    ("defect", "other-skill", "the flag is wrong in the example"),
+    ("defect", "sirius-denovo", "crashes on empty input"),
+])
+def test_a_different_problem_gets_a_different_fingerprint(kind, target, symptom):
+    """The other side: collapsing distinct reports would hide real problems."""
+    baseline = sf.fingerprint("defect", "sirius-denovo", "the flag is wrong in the example")
+    assert sf.fingerprint(kind, target, symptom) != baseline
+
+
+def test_the_fingerprint_is_in_the_body_so_a_reader_can_match_on_it():
+    issue = sf.render_issue("defect", "x", symptom="y")
+    assert issue["fingerprint"] in issue["body"]
+
+
+# --------------------------------------------------------------------------- #
+# Routing and refusal                                                          #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("kind", sorted(sf.KINDS))
+def test_every_kind_renders_and_carries_triage_labels(kind):
+    issue = sf.render_issue(kind, "some-target", symptom="something went wrong")
+    assert "usage-feedback" in issue["labels"]
+    assert "needs-triage" in issue["labels"]
+    assert sf.KINDS[kind] in issue["body"]
+
+
+@pytest.mark.parametrize("kind,expected", [("gap", "propose"), ("composition", "workflow")])
+def test_a_report_that_asks_for_new_work_is_labelled_as_a_proposal(kind, expected):
+    assert expected in sf.labels_for(kind)
+
+
+def test_a_defect_is_not_labelled_a_proposal():
+    assert "propose" not in sf.labels_for("defect")
+
+
+def test_an_unroutable_kind_is_refused_rather_than_relabelled():
+    with pytest.raises(ValueError, match="unknown kind"):
+        sf.render_issue("vibes", "x", symptom="y")
+
+
+@pytest.mark.parametrize("target,symptom", [("", "something"), ("x", ""), ("x", "   ")])
+def test_a_report_missing_its_substance_is_refused(target, symptom):
+    with pytest.raises(ValueError):
+        sf.render_issue("defect", target, symptom=symptom)
+
+
+def test_corroboration_carries_the_fingerprint_and_is_redacted():
+    text = sf.corroboration("abc123def456", "same crash under /home/me/x")
+    assert "abc123def456" in text
+    assert "/home/me/x" not in text
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Stacked on #30, which restores the contribution rails this uses.

Peer review makes a skill correct *as written*. Only use makes it correct *as run* — a flag that changed in the tool's last minor release, a step that assumes a file layout nobody has, a procedure that works but costs ten times what it needs to. None of that is visible from the paper the skill was derived from, and none of it reaches us today.

The obstacle is not willingness. Writing a good issue costs more than working around the problem once, so the person who finds a defect pays and everyone after them pays again. This moves that cost onto the agent that was already in the session when it happened.

## What lands

- **`asb-contribute`** — an advertised skill that fires on friction rather than on being asked: a skill's steps failed, search found nothing usable, the leaves existed but nothing composed them, the tool has drifted. It classifies, searches for an existing issue, drafts a redacted report, and files only on an explicit yes.
- **`scripts/skill_feedback.py`** — renders the report, strips outbound secrets, computes the fingerprint that merges reports of one problem. 28 tests.
- **`.github/ISSUE_TEMPLATE/skill-feedback.md`** — the manual path, for people not running an agent.
- **`docs/CONTRIBUTION_LOOP.md`** — how the pieces fit, and the maintainer's triage rules.

## The three properties that decide whether this helps or hurts

**Aggregation over volume.** This is the design risk. Crowd-sourced auto-filing at scale produces a hundred separate "this did not work" issues, which is worse for a maintainer than ten issues carrying a hundred corroborations — and worse for the reporter, whose account disappears into the pile. Every report carries a fingerprint keyed on kind, target and the content words of the symptom, so a close restatement lands as a comment on the open issue instead of a new one. The fingerprint catches close restatements, not arbitrary paraphrase; the skill searches open issues as well, and the module docstring says so rather than overclaiming.

**Consent, not automation.** Nothing is posted without an explicit yes in the session, and the user is shown the exact body rather than a summary — they are deciding whether to publish that text, which cannot be judged from a paraphrase. Redaction reuses the release gate's clinical patterns (one canonical set, not a second copy) plus an outbound set the gate never needed: home directories, bearer tokens, `user:pass@host` URLs. It reports what it stripped, and it states plainly that it cannot recognise a sensitive sample name.

**One offer per problem.** A prompt that returns after being declined stops being a contribution channel and becomes a reason to disable the plugin. The skill says so in as many words.

## Reciprocity, and the credit loop

The ask is made once, briefly, and without moralising: the collection is grounded in published work and given away under CC-BY, and it improves only when people who run it say what broke. Where a report carries its own fix, the skill points at `propose-skill` and names what it earns — `governance/AUTHORSHIP.md` records an authored skill as credit toward the reviewer tier.

The citation half is folded into the same skill rather than shipped separately: at the end of a session it offers the collection DOI plus the source DOIs of the skills actually applied. Reciprocity is easier to ask for after the user has seen the credit machinery work in their favour.

## Companion skills considered but not shipped

Every advertised description is paid for in the session prompt of every user, so only one skill is advertised (`asb-contribute`, ~96 tokens; all nine plugins together now advertise ~614). Reasoning for the rest is in `docs/CONTRIBUTION_LOOP.md`: **claim-authorship** is deferred because `claim-skill.md` and `tier_update --credit-author` already cover it; a **session provenance report** is the strongest remaining candidate but wants a session-log surface that does not exist yet; a **pre-flight grounding check** is already step 4 of `asb-metabolomics` and duplicating it would split the protocol.

923 tests pass, 2 skipped. `release_gate --strict` exits 0 on all four collections.
