### PR TITLE
Stage two community skill proposals (MetabolomicsHub, Workflow4Metabolomics)

### DIFF
--- a/collections/epigenomics/v1/gate_report.json
+++ b/collections/epigenomics/v1/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-21T08:58:56.430463+00:00",
+  "generated_at": "2026-08-21T09:13:36.871350+00:00",
   "collection_dir": "collections/epigenomics/v1",
   "corpus_path": "collections/epigenomics/v1/corpus.yaml",
   "mode": "strict",

--- a/collections/metabolomics/v1/gate_report.json
+++ b/collections/metabolomics/v1/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-21T08:58:54.535312+00:00",
+  "generated_at": "2026-08-21T09:13:34.988818+00:00",
   "collection_dir": "collections/metabolomics/v1",
   "corpus_path": "collections/metabolomics/v1/corpus.yaml",
   "mode": "strict",

--- a/collections/metabolomics/v2/gate_report.json
+++ b/collections/metabolomics/v2/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-21T08:58:39.689283+00:00",
+  "generated_at": "2026-08-21T09:13:19.964517+00:00",
   "collection_dir": "collections/metabolomics/v2",
   "corpus_path": "collections/metabolomics/v2/corpus.yaml",
   "mode": "strict",

--- a/collections/metabolomics/v2/proposals/skills/galaxy-workflow4metabolomics-reproducible-processing/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/galaxy-workflow4metabolomics-reproducible-processing/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: galaxy-workflow4metabolomics-reproducible-processing
+description: Use when running an LC-MS or GC-MS preprocessing and statistics workflow
+  on the Galaxy Workflow4Metabolomics instance, or when a collaborator needs to re-execute
+  an analysis without installing the toolchain locally.
+license: CC-BY-4.0
+status: hold
+metadata:
+  tools:
+  - Workflow4Metabolomics
+  - Galaxy
+  techniques:
+  - LC-MS
+  - GC-MS
+  repo_url: https://github.com/workflow4metabolomics/tools-metabolomics
+  related_skills: []
+  license_tier: open
+  provenance_tier: repository
+  tool_license:
+    tier: open
+    requires_ack: false
+    ref: GPL-3.0
+    url: https://github.com/workflow4metabolomics/tools-metabolomics/blob/main/LICENSE
+schema_version: 0.2.0
+---
+
+# galaxy-workflow4metabolomics-reproducible-processing
+
+Run a metabolomics workflow on a shared Galaxy instance so that the analysis can
+be re-executed by someone who has neither the software nor the compute.
+
+## When this applies
+
+The barrier to reproducing a metabolomics analysis is rarely the method; it is
+the environment. Workflow4Metabolomics packages the common LC-MS and GC-MS
+pipeline — preprocessing, normalisation, annotation, univariate and multivariate
+statistics — as Galaxy tools on a public instance, so a workflow can be shared as
+a document that others execute rather than as instructions they reimplement.
+
+Reach for it when the analysis must outlive the machine it was written on, when a
+collaborator cannot install the toolchain, or when a submission requires an
+executable record of what was run.
+
+## Procedure
+
+1. **Upload the raw data in an open format.** Convert vendor files to mzML first.
+   Uploading vendor formats defers the conversion problem to whoever reruns the
+   workflow, which defeats the purpose.
+2. **Build the sample metadata table before processing**, with one row per file
+   and explicit columns for class, batch and injection order. Most downstream
+   failures in this pipeline are metadata failures, and they surface late.
+3. **Assemble the workflow from the instance's tool set**, keeping preprocessing,
+   normalisation and statistics as separate steps rather than one composite. A
+   step you cannot inspect is a step you cannot defend.
+4. **Record every non-default parameter.** The workflow document stores them, but
+   a reader needs to know which ones were chosen deliberately and why.
+5. **Export the workflow and the invocation**, not only the results. The workflow
+   is the method; the invocation ties it to this dataset and these parameters.
+
+## Verification
+
+- The exported workflow re-runs on the same inputs and yields the same feature
+  count. A difference means a parameter was not captured or a tool version moved.
+- The sample metadata row count matches the uploaded file count.
+- The feature table's sample columns match the metadata's sample identifiers
+  exactly — a silent mismatch here produces statistics on mislabelled groups.
+
+## Limitations
+
+- Public instances impose quotas on storage and runtime; a large study may need a
+  local or institutional Galaxy rather than the shared one.
+- Tool versions on the instance change over time. A workflow exported today may
+  resolve to different tool versions later, so the invocation record — which pins
+  versions — matters more than the workflow alone.
+- The available tools bound the method. A step the instance does not provide
+  cannot be inserted without deploying a tool, which is an administrative task
+  rather than an analytical one.

--- a/collections/metabolomics/v2/proposals/skills/metabolomicshub-cross-repository-dataset-search/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/metabolomicshub-cross-repository-dataset-search/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: metabolomicshub-cross-repository-dataset-search
+description: Use when locating public metabolomics datasets across MetaboLights, Metabolomics
+  Workbench and GNPS/MassIVE in one query, or when filtering candidate studies by
+  instrument, ionisation mode or the availability of open raw formats before committing
+  to a reanalysis.
+license: CC-BY-4.0
+status: hold
+metadata:
+  tools:
+  - MetabolomicsHub
+  techniques:
+  - LC-MS
+  - GC-MS
+  repo_url: https://github.com/MetabolomicsHub/mhd-model
+  related_skills: []
+  license_tier: open
+  provenance_tier: repository
+  tool_license:
+    tier: open
+    requires_ack: false
+    ref: Apache-2.0
+    url: https://github.com/MetabolomicsHub/mhd-model/blob/main/LICENSE
+schema_version: 0.2.0
+---
+
+# metabolomicshub-cross-repository-dataset-search
+
+Find public metabolomics studies across repositories that do not share a search
+interface, and filter them down to the ones a reanalysis can actually use.
+
+## When this applies
+
+A reanalysis, a benchmark or a meta-analysis needs studies matching some
+combination of organism, instrument, ionisation mode and file format. Those
+studies are spread across MetaboLights (EBI), Metabolomics Workbench (NIH) and
+GNPS/MassIVE, each with its own accession scheme, metadata vocabulary and API.
+Searching them one at a time misses cross-repository duplicates and makes the
+instrument and format filters — the ones that decide whether the data is usable —
+impossible to apply uniformly.
+
+MetabolomicsHub publishes a common model (MHD) over those repositories and an
+API that answers a single query across all of them.
+
+## Procedure
+
+1. **State the selection criteria before searching.** Organism, sample matrix,
+   instrument or instrument family, polarity, and the file formats the downstream
+   pipeline can read. Write them down; they are the inclusion criteria of
+   whatever you are building, and deciding them after seeing the hits is how a
+   convenience sample becomes a claim.
+2. **Query the announcement API** at `https://www.metabolomicshub.org/api/` for
+   the criteria that the common model expresses directly. Consult
+   `https://metabolomicshub.github.io/mhd-model/` for the field names — the model
+   is versioned, and a field that existed in one release may be renamed in the
+   next.
+3. **Filter on open raw formats.** A study whose raw data is vendor-only cannot
+   be reprocessed without the vendor's converter, and on some platforms not at
+   all. Prefer mzML; treat the presence of vendor-only formats as a study-level
+   exclusion unless conversion has been verified.
+4. **Resolve duplicates across repositories.** One study can be deposited in more
+   than one repository, sometimes under different accessions. Match on title,
+   submitter and sample count before treating two hits as independent.
+5. **Record the accession and the repository for every retained study**, not just
+   the count. A dataset list without accessions cannot be re-run by anyone else.
+
+## Verification
+
+- Every retained study resolves at its home repository by accession.
+- The instrument and polarity recorded by the hub agree with the study's own
+  metadata; where they disagree, the repository is authoritative.
+- The declared file formats are actually present in the study's file listing.
+
+## Limitations
+
+- Coverage is bounded by what the participating repositories announce; a study
+  that was never announced through the hub will not appear, so a negative result
+  is not evidence of absence.
+- The common model normalises heterogeneous metadata, and normalisation loses
+  detail. For anything the analysis depends on, read the study's own record.
+- Instrument strings are free text in the source repositories, so instrument
+  filtering is best-effort and should be confirmed per study.

--- a/collections/metabolomics/v2/proposals/wave-skills-2026-08-20.yaml
+++ b/collections/metabolomics/v2/proposals/wave-skills-2026-08-20.yaml
@@ -1,0 +1,14 @@
+schema: asb-skill-proposals/1.0
+proposals:
+- slug: galaxy-workflow4metabolomics-reproducible-processing
+  related_skills: []
+  tools_used: []
+  license_tier: null
+  status: hold
+  submitted_on: '2026-08-20'
+- slug: metabolomicshub-cross-repository-dataset-search
+  related_skills: []
+  tools_used: []
+  license_tier: null
+  status: hold
+  submitted_on: '2026-08-20'

--- a/collections/transcriptomics/v1/gate_report.json
+++ b/collections/transcriptomics/v1/gate_report.json
@@ -1,6 +1,6 @@
 {
   "schema": "asbb-release-gate/1.0",
-  "generated_at": "2026-08-21T08:58:58.165256+00:00",
+  "generated_at": "2026-08-21T09:13:38.582777+00:00",
   "collection_dir": "collections/transcriptomics/v1",
   "corpus_path": "collections/transcriptomics/v1/corpus.yaml",
   "mode": "strict",

--- a/scripts/check_proposals.py
+++ b/scripts/check_proposals.py
@@ -104,11 +104,16 @@ def check_collection(collection_dir) -> list:
         # semantics: literature ⇒ >=1 doi, synthetic ⇒ synthesized_from,
         # community ⇒ related_skills key present.
         prov = meta.get("provenance_tier")
+        # Every field the vocabulary can require, or a tier is judged without
+        # the evidence that backs it: `repository` reads `repo_url`, and passing
+        # only some of them rejects a valid proposal.
         prov_violations = validate_provenance(
             prov,
             dois=meta.get("dois"),
             synthesized_from=meta.get("synthesized_from"),
-            related_skills=fm.get("related_skills") if "related_skills" in fm else None,
+            related_skills=(fm.get("related_skills") if "related_skills" in fm
+                            else meta.get("related_skills")),
+            repo_url=meta.get("repo_url"),
         )
         for msg in prov_violations:
             violations.append(f"{md}: {msg}")

--- a/tests/test_check_proposals.py
+++ b/tests/test_check_proposals.py
@@ -456,3 +456,30 @@ def test_main_exits_one_on_violation(tmp_path):
     fm["status"] = "accepted"
     _write_skill(col, fm)
     assert c.main([str(col)]) == 1
+
+
+# --- a tier is only as good as the evidence the gate passes to it ------------
+
+def _repository_proposal(tmp_path, repo_url):
+    col = _collection(tmp_path)
+    fm = _good_fm()
+    fm["metadata"]["provenance_tier"] = "repository"
+    fm["metadata"]["dois"] = []
+    if repo_url:
+        fm["metadata"]["repo_url"] = repo_url
+    _write_skill(col, fm)
+    return col
+
+
+def test_a_repository_tier_proposal_with_a_repo_url_passes(tmp_path):
+    """`check_provenance_tiers` was taught to pass `repo_url`; this gate was not,
+    so it rejected every valid repository-grounded proposal — a tier judged
+    without the evidence that backs it."""
+    col = _repository_proposal(tmp_path, "https://github.com/a/b")
+    assert [v for v in c.check_collection(str(col)) if "repo_url" in v] == []
+
+
+def test_a_repository_tier_proposal_without_a_repo_url_is_still_rejected(tmp_path):
+    """The other side: passing the field must not stop the invariant biting."""
+    col = _repository_proposal(tmp_path, None)
+    assert any("repository requires repo_url" in v for v in c.check_collection(str(col)))


### PR DESCRIPTION
Two of the five triaged proposals in the backlog, staged through the rails that landed in #30. **Nothing here is published**: both sit in `proposals/skills/` with `status: hold`, which is the point of the staging area — a maintainer promotes, or does not.

## The proposals

**[#11](https://github.com/HolobiomicsLab/asb-skill-collections/issues/11) MetabolomicsHub** — `metabolomicshub-cross-repository-dataset-search`. Finding public studies across MetaboLights, Metabolomics Workbench and GNPS/MassIVE, then filtering to what a reanalysis can actually use. The skill puts the selection criteria before the search rather than after, treats vendor-only raw data as a study-level exclusion, and requires accessions to be recorded rather than counts. It says plainly that hub coverage is bounded by what repositories announce, so a negative result is not evidence of absence.

**[#16](https://github.com/HolobiomicsLab/asb-skill-collections/issues/16) Galaxy Workflow4Metabolomics** — `galaxy-workflow4metabolomics-reproducible-processing`. Running the LC-MS/GC-MS pipeline on a shared Galaxy instance so an analysis outlives the machine it was written on. It insists on exporting the *invocation* as well as the workflow, because the invocation is what pins tool versions, and on converting to mzML before upload rather than deferring that problem to whoever reruns it.

Both are grounded on their tools' repositories rather than on a paper, so both carry `provenance_tier: repository` — the tier added in #34 for exactly this case. Licences were read from the repositories rather than assumed: Apache-2.0 for `MetabolomicsHub/mhd-model`, GPL-3.0 for `workflow4metabolomics/tools-metabolomics`, both `open`.

## And a gap the staging exposed

`check_proposals` validates the provenance vocabulary but was not passing it `repo_url`, so it rejected every valid repository-grounded proposal — a tier judged without the evidence that backs it. `check_provenance_tiers` had been taught to pass the field; this gate had not. Fixed, with tests in both directions: a proposal with a repo passes, one without is still rejected.

Staging these was the first real exercise of the contribution rails end to end, and it found that on the first try.

## Not staged

[#13](https://github.com/HolobiomicsLab/asb-skill-collections/issues/13) RforMassSpectrometry, [#14](https://github.com/HolobiomicsLab/asb-skill-collections/issues/14) MetaboNaut and [#15](https://github.com/HolobiomicsLab/asb-skill-collections/issues/15) OmniPath are left alone. The first two are teaching resources covering many procedures, so one skill would either be too broad to route on or an arbitrary slice; they want a decomposition decision first. OmniPath is a systems-biology interaction database whose fit with a metabolomics collection is a scope question rather than an authoring one.

1039 tests pass, 2 skipped. All four release gates and all four collection checks pass.
