### PR TITLE
Ground the MetabolomicsHub and Workflow4Metabolomics skills in their sources

### DIFF
--- a/collections/metabolomics/v2/proposals/skills/galaxy-workflow4metabolomics-reproducible-processing/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/galaxy-workflow4metabolomics-reproducible-processing/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: galaxy-workflow4metabolomics-reproducible-processing
-description: Use when running an LC-MS or GC-MS preprocessing and statistics workflow
-  on the Galaxy Workflow4Metabolomics instance, or when a collaborator needs to re-execute
-  an analysis without installing the toolchain locally.
+description: Use when running an LC-MS or GC-MS preprocessing and statistics pipeline
+  on a Galaxy Workflow4Metabolomics instance, or when a collaborator must re-execute
+  the analysis without installing the toolchain — the stage order is fixed by the
+  wrappers' own datatypes, not by convention.
 license: CC-BY-4.0
 status: hold
 metadata:
@@ -13,65 +14,118 @@ metadata:
   - LC-MS
   - GC-MS
   repo_url: https://github.com/workflow4metabolomics/tools-metabolomics
-  related_skills: []
+  related_skills:
+  - w4m-three-table-format-conformance
   license_tier: open
   provenance_tier: repository
   tool_license:
     tier: open
     requires_ack: false
     ref: GPL-3.0
-    url: https://github.com/workflow4metabolomics/tools-metabolomics/blob/main/LICENSE
+    url: https://github.com/workflow4metabolomics/tools-metabolomics/blob/master/LICENSE.txt
+  verified_against:
+    repo_ref: master
+    observed: '2026-08-21'
 schema_version: 0.2.0
 ---
 
 # galaxy-workflow4metabolomics-reproducible-processing
 
-Run a metabolomics workflow on a shared Galaxy instance so that the analysis can
-be re-executed by someone who has neither the software nor the compute.
+Run a metabolomics workflow on a shared Galaxy instance so the analysis can be
+re-executed by someone who has neither the software nor the compute.
 
 ## When this applies
 
 The barrier to reproducing a metabolomics analysis is rarely the method; it is
-the environment. Workflow4Metabolomics packages the common LC-MS and GC-MS
-pipeline — preprocessing, normalisation, annotation, univariate and multivariate
-statistics — as Galaxy tools on a public instance, so a workflow can be shared as
-a document that others execute rather than as instructions they reimplement.
+the environment. Workflow4Metabolomics packages the LC-MS, GC-MS and NMR
+pipelines — preprocessing, annotation, normalisation, univariate and
+multivariate statistics — as Galaxy tools, so a workflow is shared as a document
+others execute rather than as instructions they reimplement.
 
-Reach for it when the analysis must outlive the machine it was written on, when a
-collaborator cannot install the toolchain, or when a submission requires an
+Reach for it when the analysis must outlive the machine it was written on, when
+a collaborator cannot install the toolchain, or when a submission requires an
 executable record of what was run.
+
+## The stage order is enforced, not conventional
+
+The LC-MS wrappers declare intermediate Galaxy datatypes, and each stage accepts
+only the datatype the previous one emits. The chain is therefore readable off
+the tool definitions:
+
+```
+mzML / mzXML / netCDF / mzData
+  → MSnbase readMSData          → rdata.msnbase.raw
+  → xcms findChromPeaks         → rdata.xcms.findchrompeaks
+  → xcms refineChromPeaks       → rdata.xcms.findchrompeaks     (optional)
+  → xcms findChromPeaks Merger  → rdata.xcms.findchrompeaks     (multi-sample)
+  → xcms groupChromPeaks        → rdata.xcms.group
+  → xcms adjustRtime            → rdata.xcms.retcor
+  → xcms groupChromPeaks        → rdata.xcms.group              (second pass)
+  → xcms fillChromPeaks         → rdata.xcms.fillpeaks
+  → CAMERA annotate             → rdata.camera.* + the three tables
+```
+
+Two consequences follow from the datatypes themselves. `adjustRtime` consumes a
+grouped object, so correspondence precedes alignment and is then repeated
+against the corrected retention times — the second grouping pass is required,
+not a refinement. And `fillChromPeaks` accepts only `rdata.xcms.group`, so gap
+filling cannot be moved after annotation.
+
+Parameter optimisation sits beside the chain rather than in it: `IPO for
+xcmsSet` reads raw files and `IPO for group and retcor` reads the xcms objects,
+and both emit parameter tables you feed back into the corresponding step.
+
+Downstream of CAMERA the pipeline works on the three-table format, and
+`Check Format` is the entry point to it. Polarity modes are processed separately
+and joined with `CAMERA combinexsAnnos`. `Mz(X)ML Shaper` reshapes open formats
+into XCMS-readable mz(X)ML — it accepts mzML, mzXML and netCDF only, so vendor
+conversion still happens before upload and outside the platform.
 
 ## Procedure
 
-1. **Upload the raw data in an open format.** Convert vendor files to mzML first.
+1. **Upload raw data in an open format.** Convert vendor files to mzML first.
    Uploading vendor formats defers the conversion problem to whoever reruns the
    workflow, which defeats the purpose.
-2. **Build the sample metadata table before processing**, with one row per file
-   and explicit columns for class, batch and injection order. Most downstream
-   failures in this pipeline are metadata failures, and they surface late.
-3. **Assemble the workflow from the instance's tool set**, keeping preprocessing,
-   normalisation and statistics as separate steps rather than one composite. A
-   step you cannot inspect is a step you cannot defend.
-4. **Record every non-default parameter.** The workflow document stores them, but
-   a reader needs to know which ones were chosen deliberately and why.
-5. **Export the workflow and the invocation**, not only the results. The workflow
-   is the method; the invocation ties it to this dataset and these parameters.
+
+2. **Build the sample metadata table before processing**, one row per file, with
+   explicit columns for class, batch and injection order. Most downstream
+   failures in this pipeline are metadata failures and they surface late. The
+   `xcms get a sampleMetadata file` tool emits the skeleton to fill in.
+
+3. **Keep the stages separate.** Preprocessing, annotation, normalisation and
+   statistics stay distinct steps rather than one composite. A step you cannot
+   inspect is a step you cannot defend, and the datatypes above give you the
+   inspection points for free.
+
+4. **Record every non-default parameter.** The workflow document stores them,
+   but a reader needs to know which were chosen deliberately and why. Where a
+   parameter came from IPO, say so and keep the IPO output.
+
+5. **Export the workflow and the invocation**, not only the results. The
+   workflow is the method; the invocation ties it to this dataset, these
+   parameters and the tool versions that actually ran.
 
 ## Verification
 
+- `xcms process history` summarises what ran; read it rather than trusting the
+  workflow diagram, which shows what was requested.
 - The exported workflow re-runs on the same inputs and yields the same feature
   count. A difference means a parameter was not captured or a tool version moved.
 - The sample metadata row count matches the uploaded file count.
-- The feature table's sample columns match the metadata's sample identifiers
-  exactly — a silent mismatch here produces statistics on mislabelled groups.
+- The three tables agree on identifiers and order before any statistics step.
+- Both polarities, if processed, were combined once and not double-counted.
 
 ## Limitations
 
-- Public instances impose quotas on storage and runtime; a large study may need a
-  local or institutional Galaxy rather than the shared one.
-- Tool versions on the instance change over time. A workflow exported today may
-  resolve to different tool versions later, so the invocation record — which pins
-  versions — matters more than the workflow alone.
+- Public instances impose quotas on storage and runtime; a large study may need
+  an institutional Galaxy rather than the shared one.
+- Tool versions on the instance change over time, and most wrappers version
+  themselves against the underlying R package. A workflow exported today may
+  resolve to different versions later, so the invocation record matters more
+  than the workflow alone.
 - The available tools bound the method. A step the instance does not provide
   cannot be inserted without deploying a tool, which is an administrative task
   rather than an analytical one.
+- The datatype chain above is the LC-MS line. The NMR tools and the
+  isotope-labelling and flux tools in the same repository form separate chains
+  that share only the three-table format.

--- a/collections/metabolomics/v2/proposals/skills/metabolomicshub-announcement-authoring/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/metabolomicshub-announcement-authoring/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: metabolomicshub-announcement-authoring
+description: Use when publishing a metabolomics dataset into the MetabolomicsHub index
+  — building the common-model file, deriving and validating the announcement against
+  the right profile, minting an identifier, and submitting a revision whose outcome
+  only a polled task reports.
+license: CC-BY-4.0
+status: hold
+metadata:
+  tools:
+  - MetabolomicsHub
+  - mhd-cli
+  techniques:
+  - LC-MS
+  - GC-MS
+  repo_url: https://github.com/MetabolomicsHub/mhd-model
+  service_url: https://www.metabolomicshub.org/api/submission
+  related_skills:
+  - metabolomicshub-cross-repository-dataset-search
+  license_tier: open
+  provenance_tier: repository
+  tool_license:
+    tier: open
+    requires_ack: false
+    ref: Apache-2.0
+    url: https://github.com/MetabolomicsHub/mhd-model/blob/main/LICENSE
+  verified_against:
+    package: mhd-model
+    api_version: v0.0.1
+    observed: '2026-08-21'
+schema_version: 0.2.0
+---
+
+# metabolomicshub-announcement-authoring
+
+Turn a dataset's metadata into an MHD announcement that the hub will accept, and
+find out that it will not before submitting rather than after.
+
+## When this applies
+
+A repository, a consortium partner or a submitter with a large deposit needs a
+study to appear in the MetabolomicsHub index. The route is not a web form: it is
+a common-model file, an announcement derived from it, a validation pass, an
+identifier, and a submitted revision. Each of those has a failure mode of its
+own, and two of them are asynchronous.
+
+This is the depositor's side of the hub. Reading the index is a different job.
+
+## The two artefacts, in the order they exist
+
+1. **The MHD common data model file** — the full description of the study:
+   samples, assays, protocols, parameters, instruments, publications.
+2. **The announcement file** — derived from the model file, and the thing the
+   hub actually ingests. It references the model file by URL.
+
+Deriving the second from the first is a command, not an editing task. Writing an
+announcement by hand and keeping it consistent with a model file is the mistake
+this ordering exists to prevent.
+
+## Procedure
+
+1. **Choose the profile before writing anything.** Two model versions (v0.1,
+   v1.0) each carry two profiles: `ms-profile` and `legacy-profile`. The MS
+   profile expects structured acquisition metadata; the legacy profile is the
+   reduced shape for studies migrated from an existing repository. Both the
+   announcement file and the common-model file have their own schema per
+   profile, so there are four schemas in play and picking the wrong one produces
+   validation errors that read as missing data.
+   `GET /v0_1/schemas` returns the profiles the server currently enforces, and
+   `GET /v0_1/server-info` reports which is the default. Ask the server; the
+   defaults move with releases.
+
+2. **Validate the model file first.**
+
+   ```
+   mhd-cli validate mhd <mhd_study_id> <mhd_model_file_path>
+   ```
+
+   Fixing the model file after deriving an announcement means deriving again.
+
+3. **Derive the announcement.**
+
+   ```
+   mhd-cli create announcement [--output-dir DIR] [--output-filename NAME] \
+       <mhd_study_id> <mhd_model_file_path> <target_mhd_model_file_url>
+   ```
+
+   The third argument is where the model file *will be* publicly readable. The
+   hub checks that URL for accessibility when the announcement is shared, so a
+   placeholder or a private link fails at submission rather than at derivation.
+   Publish the model file before you submit, not before you derive.
+
+4. **Validate the announcement.**
+
+   ```
+   mhd-cli validate announcement [--output-path FILE] <mhd_study_id> \
+       <announcement_file_path>
+   ```
+
+   Use `--output-path` in any automated pipeline: it writes the result where a
+   later step can read it, instead of leaving it in a log.
+
+5. **Mint an identifier in the test lane first.** `POST /v0_1/identifiers`,
+   or `MhdClient.get_new_mhd_accession(dataset_repository_identifier, accession_type)`.
+   The accepted accession types are `mhd`, `legacy`, `test-mhd`, `test-legacy`
+   and `dev`. Do a full dry run on a test accession before requesting a real
+   one; identifiers are the part of this process you cannot take back.
+
+6. **Submit the revision, then poll.** `POST /v0_1/datasets/{accession}/announcements`
+   is a multipart upload authenticated with an `x-api-token` header, and it
+   returns a `taskId` rather than a verdict. The outcome is read from
+   `GET /v0_1/datasets/{accession}/tasks/{task_id}`. The shipped client polls it
+   for you (ten attempts, five seconds apart); anything you write yourself must
+   poll too. A 200 on the upload means the file was accepted for validation, not
+   that the dataset was announced.
+
+7. **Record the revision.** Announcements are versioned: every submission takes
+   an `announcement_reason` and `GET /v0_1/datasets/{accession}/announcements`
+   lists the revisions. The reason string is the only human-readable account of
+   why a dataset's public record changed, so write it for someone reading it in
+   two years.
+
+## Related outputs from the same model file
+
+`mhd-cli create sdrf` and `mhd-cli create neo4j-input` emit an SDRF table and a
+graph-import form of the same study. Both take the model file, so they stay
+consistent with the announcement by construction — worth preferring over
+exporting from the announcement or from a repository's own metadata.
+
+## Verification
+
+- The model file validates under the same profile the announcement declares.
+- `target_mhd_model_file_url` resolves publicly and returns the model file that
+  was used to derive the announcement, not a later edit of it.
+- The submission task reached a terminal state and was read; the upload's own
+  status code was not treated as the result.
+- The study appears in the search index under the expected repository, and the
+  fields you care about are populated rather than merely present.
+
+## Limitations
+
+- The announcement carries what the model file carried. Fields the source
+  repository never recorded stay empty, and the hub cannot infer them; this is
+  the origin of the uneven field coverage seen from the search side.
+- Identifier minting and submission need an API token issued to a repository.
+  A submitter without one goes through their repository, not directly.
+- The client and the schemas move together. Pin the `mhd-model` version used for
+  a deposit, and re-validate rather than assuming an older announcement still
+  conforms.
+- The accession types accepted by the client are the five listed above. The
+  package README's example passes `test`, which is not among them.

--- a/collections/metabolomics/v2/proposals/skills/metabolomicshub-cross-repository-dataset-search/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/metabolomicshub-cross-repository-dataset-search/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: metabolomicshub-cross-repository-dataset-search
-description: Use when locating public metabolomics datasets across MetaboLights, Metabolomics
-  Workbench and GNPS/MassIVE in one query, or when filtering candidate studies by
-  instrument, ionisation mode or the availability of open raw formats before committing
-  to a reanalysis.
+description: Use when assembling a reanalysis or meta-analysis cohort from public
+  metabolomics studies held in MetaboLights, Metabolomics Workbench and GNPS/MassIVE,
+  and the instrument, polarity or open-format filters have to be honest about which
+  repositories they silently exclude.
 license: CC-BY-4.0
 status: hold
 metadata:
@@ -13,6 +13,7 @@ metadata:
   - LC-MS
   - GC-MS
   repo_url: https://github.com/MetabolomicsHub/mhd-model
+  service_url: https://www.metabolomicshub.org/api/submission
   related_skills: []
   license_tier: open
   provenance_tier: repository
@@ -21,62 +22,136 @@ metadata:
     requires_ack: false
     ref: Apache-2.0
     url: https://github.com/MetabolomicsHub/mhd-model/blob/main/LICENSE
+  verified_against:
+    api_version: v0.0.1
+    observed: '2026-08-21'
 schema_version: 0.2.0
 ---
 
 # metabolomicshub-cross-repository-dataset-search
 
 Find public metabolomics studies across repositories that do not share a search
-interface, and filter them down to the ones a reanalysis can actually use.
+interface, and know which studies your filters threw away for want of metadata
+rather than for want of a match.
 
 ## When this applies
 
 A reanalysis, a benchmark or a meta-analysis needs studies matching some
-combination of organism, instrument, ionisation mode and file format. Those
-studies are spread across MetaboLights (EBI), Metabolomics Workbench (NIH) and
-GNPS/MassIVE, each with its own accession scheme, metadata vocabulary and API.
-Searching them one at a time misses cross-repository duplicates and makes the
-instrument and format filters — the ones that decide whether the data is usable —
-impossible to apply uniformly.
+combination of organism, instrument, polarity and file format. Those studies sit
+in MetaboLights (EBI), Metabolomics Workbench (NIH) and GNPS/MassIVE, each with
+its own accession scheme, metadata vocabulary and API. MetabolomicsHub indexes
+all three behind one query.
 
-MetabolomicsHub publishes a common model (MHD) over those repositories and an
-API that answers a single query across all of them.
+The index is not uniform, and that is the thing this skill exists to handle. Each
+repository populates a different subset of the searchable fields, so a filter can
+exclude an entire repository for having no value in a field rather than the wrong
+value. The result still looks like a search result.
+
+## The service
+
+Base URL `https://www.metabolomicshub.org/api/submission/v0_1`. The bare
+`/api/` path is not a route. The endpoints below need no credentials; the
+submission and identifier endpoints on the same base do.
+
+| endpoint | method | use |
+| --- | --- | --- |
+| `/search/fields` | GET | the searchable field list and, per field, the operators it accepts |
+| `/search/datasets` | POST | keyword search |
+| `/search/advanced/datasets` | POST | clause-based search, returns facets |
+| `/search/advanced/datasets/example` | GET | a worked request body for every clause kind |
+| `/search/advanced/datasets/export` | POST | the result set as a file |
+| `/server-info` | GET | index version and the schema profiles in force |
 
 ## Procedure
 
 1. **State the selection criteria before searching.** Organism, sample matrix,
    instrument or instrument family, polarity, and the file formats the downstream
-   pipeline can read. Write them down; they are the inclusion criteria of
-   whatever you are building, and deciding them after seeing the hits is how a
-   convenience sample becomes a claim.
-2. **Query the announcement API** at `https://www.metabolomicshub.org/api/` for
-   the criteria that the common model expresses directly. Consult
-   `https://metabolomicshub.github.io/mhd-model/` for the field names — the model
-   is versioned, and a field that existed in one release may be renamed in the
-   next.
-3. **Filter on open raw formats.** A study whose raw data is vendor-only cannot
-   be reprocessed without the vendor's converter, and on some platforms not at
-   all. Prefer mzML; treat the presence of vendor-only formats as a study-level
+   pipeline can read. They are the inclusion criteria of whatever you are
+   building; deciding them after seeing the hits is how a convenience sample
+   becomes a claim.
+
+2. **Read `/search/fields` rather than guessing field names.** It returns each
+   field's target (`DATASET` or `METABOLITE`), value type and permitted
+   operators. The list is versioned with the index and is the only authority on
+   what is filterable today.
+
+3. **Express the query as clauses.** `POST /search/advanced/datasets` takes
+   `{version, query_text, inter_field_combiner, clauses, where, page, sort}`,
+   with `page` shaped `{current, size}`. The clause kinds are `terms`,
+   `compare`, `parameter_pair`, `characteristic_pair` and `descriptor`.
+   Polarity is not a top-level field: it arrives as a `parameter_pair` with
+   `type_name: "scan polarity"`. `GET /search/advanced/datasets/example`
+   returns a body exercising each kind, which is quicker to adapt than the
+   schema.
+
+4. **Filter on open raw formats after the query, not inside it.** No field
+   indexes file format, so no clause can express it. Each returned study instead
+   carries a `files` block with `extensions` — a list of `{extension, count}`
+   pairs — and you filter on that client-side. A study whose raw data is
+   vendor-only cannot be reprocessed without the vendor's converter, and on some
+   platforms not at all; prefer `.mzml` and treat vendor-only as a study-level
    exclusion unless conversion has been verified.
-4. **Resolve duplicates across repositories.** One study can be deposited in more
-   than one repository, sometimes under different accessions. Match on title,
-   submitter and sample count before treating two hits as independent.
-5. **Record the accession and the repository for every retained study**, not just
-   the count. A dataset list without accessions cannot be re-run by anyone else.
+
+5. **Measure what each filter excluded before trusting it.** Re-run the query
+   with the filter removed, facet both runs by `dataset_repository`, and compare
+   per repository. A filter that takes one repository to zero has selected on
+   metadata availability, not on science. Record the comparison; it is part of
+   the cohort's description.
+
+6. **Record the accession, the repository and the MetabolomicsHub id for every
+   retained study**, not just the count. A dataset list without accessions
+   cannot be re-run by anyone else.
+
+## Field coverage is repository-dependent
+
+Facet totals for the whole index, observed 2026-08-21 against index v0.0.1
+(6,796 datasets). Re-measure before relying on them; the index is growing.
+
+| repository | datasets | MS instrument | chromatography | parameters | omics type |
+| --- | --- | --- | --- | --- | --- |
+| Metabolomics Workbench | 3,703 | populated | populated | populated | **none** |
+| MetaboLights | 2,593 | populated | populated | populated | populated |
+| GNPS/MassIVE | 500 | **none** | **none** | **none** | **none** |
+
+Two consequences worth stating plainly, because both are silent:
+
+- Any instrument or polarity filter drops all 500 GNPS/MassIVE studies, which
+  carry no structured instrument or parameter metadata in this index.
+- `facet_omics_types` is populated only by MetaboLights: filtering
+  `facet_omics_types = Metabolomics` returned 2,331 studies, and adding
+  `dataset_repository = metabolights` returned the same 2,331. The filter is a
+  repository filter wearing an omics label.
+
+Every dataset in the index is currently `legacy` profile, so the fields the MS
+profile adds — `dataset_mhd_identifier`, `sample_runs_count`, `subjects_count` —
+are not yet usable as filters.
+
+## Metabolite-level search
+
+Four fields target `METABOLITE` rather than `DATASET`: `metabolite_name`,
+`metabolite_accession`, `metabolite_identifier_accession` and
+`metabolite_identifier_source`. They answer "which public studies report this
+compound", which is a different question from "which studies used this
+instrument" and is not reachable from the repositories' own search interfaces.
+The same coverage caveat applies: a study that reported no metabolite table is
+absent from the answer.
 
 ## Verification
 
 - Every retained study resolves at its home repository by accession.
 - The instrument and polarity recorded by the hub agree with the study's own
-  metadata; where they disagree, the repository is authoritative.
-- The declared file formats are actually present in the study's file listing.
+  record; where they disagree, the repository is authoritative.
+- The extensions counted in `files.extensions` are actually present in the
+  study's file listing.
+- Each filter's per-repository exclusion has been measured, not assumed.
 
 ## Limitations
 
-- Coverage is bounded by what the participating repositories announce; a study
-  that was never announced through the hub will not appear, so a negative result
-  is not evidence of absence.
+- Coverage is bounded by what the participating repositories have submitted, so
+  a negative result is not evidence of absence.
 - The common model normalises heterogeneous metadata, and normalisation loses
   detail. For anything the analysis depends on, read the study's own record.
-- Instrument strings are free text in the source repositories, so instrument
-  filtering is best-effort and should be confirmed per study.
+- Instrument strings originate as free text in the source repositories. The
+  facet groups them, but two spellings of one instrument can remain two buckets.
+- The index version is reported by `/server-info` and the field list moves with
+  it. Pin both in the methods section of anything you publish from this.

--- a/collections/metabolomics/v2/proposals/skills/w4m-three-table-format-conformance/SKILL.md
+++ b/collections/metabolomics/v2/proposals/skills/w4m-three-table-format-conformance/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: w4m-three-table-format-conformance
+description: Use when moving a feature table between Workflow4Metabolomics tools and
+  the dataMatrix, sampleMetadata and variableMetadata files must agree on identifiers,
+  order and R-name validity before a statistics step silently analyses mislabelled
+  samples.
+license: CC-BY-4.0
+status: hold
+metadata:
+  tools:
+  - Workflow4Metabolomics
+  - Galaxy
+  techniques:
+  - LC-MS
+  - GC-MS
+  - NMR
+  repo_url: https://github.com/workflow4metabolomics/tools-metabolomics
+  related_skills:
+  - galaxy-workflow4metabolomics-reproducible-processing
+  license_tier: open
+  provenance_tier: repository
+  tool_license:
+    tier: open
+    requires_ack: false
+    ref: GPL-3.0
+    url: https://github.com/workflow4metabolomics/tools-metabolomics/blob/master/LICENSE.txt
+  verified_against:
+    repo_ref: master
+    observed: '2026-08-21'
+schema_version: 0.2.0
+---
+
+# w4m-three-table-format-conformance
+
+Keep the three tables that Workflow4Metabolomics passes between its tools
+mutually consistent, and catch the mismatch that produces statistics on the
+wrong groups.
+
+## When this applies
+
+Workflow4Metabolomics does not pass a single feature table between steps. It
+passes three tabular files, and 17 of the platform's 46 tool wrappers — across
+LC-MS, NMR and the statistics suite — read or write them. Anything entering the
+platform from outside, or leaving it for a local analysis, crosses this contract.
+
+The failure it guards against is quiet. If the data matrix columns and the
+sample metadata rows hold the same identifiers in a different order, every tool
+still runs. The statistics are computed on samples assigned to the wrong class,
+and nothing in the output says so.
+
+## The contract
+
+| file | shape | holds |
+| --- | --- | --- |
+| `dataMatrix` | variable × sample | the numeric matrix, nothing else |
+| `sampleMetadata` | sample × metadata | class, batch, injection order, covariates |
+| `variableMetadata` | variable × metadata | m/z, retention time, annotations |
+
+All three are tab-separated, use `.` as the decimal mark and `NA` for missing
+values. The binding rules:
+
+- `dataMatrix` column names are exactly the `sampleMetadata` row names.
+- `dataMatrix` row names are exactly the `variableMetadata` row names.
+- `dataMatrix` carries no metadata columns. A retention-time column left in the
+  matrix is read as a sample.
+
+Identifiers must also be syntactically valid R names, because the tools are R.
+A name beginning with a digit gains an `X`; a space becomes a `.`. If that
+conversion happens in one table and not another, identical identifiers stop
+matching.
+
+## Procedure
+
+1. **Run `Check Format` first, on every entry into the platform.** It compares
+   the row and column names across the three tables and, where the sets agree
+   but the orders differ, permutes the `dataMatrix` to match the metadata. It
+   also performs the `make.names` conversion when asked. Running it costs one
+   step and converts a silent mismatch into a reported one.
+
+2. **Let the conversion happen in one place.** Enable the syntactic-validity
+   option at the point of entry rather than letting individual tools rename as
+   they go. Two tools applying `make.names` to differently-spelled originals is
+   how the sets diverge.
+
+3. **Build `sampleMetadata` before processing, not after.** One row per file,
+   with explicit columns for class, batch and injection order. Batch correction
+   and repeated-measures models need these columns and cannot reconstruct them.
+
+4. **Use the platform's own join tools to attach metadata.** `Table Merge`
+   merges a metadata table into the `dataMatrix`, and `W4M concatenate` merges
+   two metadata tables. Joining in a spreadsheet reorders rows without
+   announcing it, which is the mismatch this skill exists to prevent.
+
+5. **Re-check after any step that changes dimensions.** Filtering variables,
+   dropping a sample, or splitting by polarity all break the correspondence, and
+   the tools that follow assume it holds.
+
+## Verification
+
+- Row and column counts: `dataMatrix` columns equal `sampleMetadata` rows;
+  `dataMatrix` rows equal `variableMetadata` rows.
+- Set equality *and* order equality of the identifiers, checked in both
+  directions. Equal sets in different orders is the failure case, and a
+  set-membership test passes it.
+- The matrix is numeric throughout. A column that reads as character is usually
+  a metadata column that was never removed.
+- A known sample's class label, traced by hand from the raw file name through
+  `sampleMetadata` to the statistics output, still says what it should.
+
+## Limitations
+
+- The check is structural. It cannot tell that a correctly-formatted
+  `sampleMetadata` assigns a sample to the wrong group; only the file-name trace
+  in the verification step catches that.
+- Permutation only helps when the identifier sets are equal. A genuinely missing
+  or extra sample is an error to fix upstream, not a formatting problem.
+- The three-table shape is the platform's own interchange format, not a
+  community standard. Exporting it for use elsewhere usually means flattening
+  the three files back into one, and that conversion is not covered here.

--- a/collections/metabolomics/v2/proposals/wave-skills-2026-08-20.yaml
+++ b/collections/metabolomics/v2/proposals/wave-skills-2026-08-20.yaml
@@ -1,14 +1,15 @@
 schema: asb-skill-proposals/1.0
 proposals:
 - slug: galaxy-workflow4metabolomics-reproducible-processing
-  related_skills: []
+  related_skills:
+  - w4m-three-table-format-conformance
   tools_used: []
-  license_tier: null
+  license_tier: open
   status: hold
   submitted_on: '2026-08-20'
 - slug: metabolomicshub-cross-repository-dataset-search
   related_skills: []
   tools_used: []
-  license_tier: null
+  license_tier: open
   status: hold
   submitted_on: '2026-08-20'

--- a/collections/metabolomics/v2/proposals/wave-skills-2026-08-21.yaml
+++ b/collections/metabolomics/v2/proposals/wave-skills-2026-08-21.yaml
@@ -1,0 +1,16 @@
+schema: asb-skill-proposals/1.0
+proposals:
+- slug: metabolomicshub-announcement-authoring
+  related_skills:
+  - metabolomicshub-cross-repository-dataset-search
+  tools_used: []
+  license_tier: open
+  status: hold
+  submitted_on: '2026-08-21'
+- slug: w4m-three-table-format-conformance
+  related_skills:
+  - galaxy-workflow4metabolomics-reproducible-processing
+  tools_used: []
+  license_tier: open
+  status: hold
+  submitted_on: '2026-08-21'

--- a/scripts/check_proposals.py
+++ b/scripts/check_proposals.py
@@ -48,7 +48,11 @@ if __package__ in (None, ""):
     _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
 
 
-from scripts.normalize_skill import contributor_violations, frontmatter_violations
+from scripts.normalize_skill import (
+    contributor_violations,
+    frontmatter_violations,
+    skill_field,
+)
 from scripts.provenance_tier import validate_entry as validate_provenance
 
 # A super-skill orchestrates other skills; a plain skill stands alone.
@@ -111,8 +115,7 @@ def check_collection(collection_dir) -> list:
             prov,
             dois=meta.get("dois"),
             synthesized_from=meta.get("synthesized_from"),
-            related_skills=(fm.get("related_skills") if "related_skills" in fm
-                            else meta.get("related_skills")),
+            related_skills=skill_field(fm, "related_skills"),
             repo_url=meta.get("repo_url"),
         )
         for msg in prov_violations:

--- a/scripts/normalize_skill.py
+++ b/scripts/normalize_skill.py
@@ -96,6 +96,22 @@ def parse_skill_md(text: str) -> tuple[dict | None, str | None]:
     return (yaml.safe_load(fm_raw) or {}), body
 
 
+def skill_field(fm: dict, key: str):
+    """Read a field that skills may declare at top level or under ``metadata``.
+
+    ``related_skills`` is written both ways across the corpus, so a reader that
+    checks only one place drops it silently: the proposal gate looked in both and
+    the stager looked only at the top level, which is why every staged skill's
+    ledger entry recorded an empty ``related_skills`` while its SKILL.md declared
+    them. One accessor, used by both, is the fix.
+    """
+    fm = fm or {}
+    if key in fm:
+        return fm.get(key)
+    meta = fm.get("metadata")
+    return (meta or {}).get(key) if isinstance(meta, dict) else None
+
+
 def frontmatter_violations(fm: dict) -> list[str]:
     """Validate description + EDAM IRIs + license_tier against the CI gates."""
     violations: list[str] = []

--- a/scripts/propose_skill.py
+++ b/scripts/propose_skill.py
@@ -37,7 +37,7 @@ if __package__ in (None, ""):
 
 
 from asb_skill_collections import layout
-from scripts.normalize_skill import slugify
+from scripts.normalize_skill import skill_field, slugify
 
 LEDGER_SCHEMA = "asb-skill-proposals/1.0"
 
@@ -202,8 +202,8 @@ def main(argv=None) -> int:
     meta = fm.get("metadata") or {}
     ledger_meta = {
         "slug": slugify(fm.get("name") or ""),
-        "related_skills": list(fm.get("related_skills") or []),
-        "tools_used": list(meta.get("tools_used") or []),
+        "related_skills": list(skill_field(fm, "related_skills") or []),
+        "tools_used": list(skill_field(fm, "tools_used") or []),
         "license_tier": meta.get("license_tier"),
         "status": fm.get("status", "hold"),
     }

--- a/staged-collections/metabolomics/workflows/galaxy-w4m-lcms-processing/SKILL.md
+++ b/staged-collections/metabolomics/workflows/galaxy-w4m-lcms-processing/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: galaxy-w4m-lcms-processing-workflow
+description: Use when running the Workflow4Metabolomics LC-MS pipeline end to end
+  on a Galaxy instance — MSnbase import, xcms peak detection, correspondence, alignment
+  and gap filling, CAMERA annotation, three-table conformance, batch correction, statistics
+  — in the stage order the wrappers' datatypes enforce.
+license: CC-BY-4.0
+metadata:
+  kind: composite-workflow
+  collection: https://w3id.org/holobiomicslab/asb-skill/collection/metabolomics/v2
+  techniques:
+  - LC-MS
+  - GC-MS
+  stage_count: 10
+  member_skills:
+  - xcms-data-import-preprocessing
+  - mzml-file-import-xcms
+  - mass-spectrometry-data-format-import
+  - parameter-tuning-metabolomics
+  - peak-picking-parameter-configuration
+  - chromatographic-alignment-parameter-selection
+  - lc-ms-profile-data-segmentation
+  - chromatographic-peak-detection-wavelet
+  - chromatographic-profile-quality-assessment
+  - lc-ms-feature-grouping-by-retention-time
+  - mass-chromatogram-alignment
+  - retention-time-correction-and-alignment
+  - retention-time-alignment-correction
+  - missing-peak-imputation-fillpeaks
+  - spectral-feature-clustering-by-intensity-correlation
+  - metabolite-mass-to-charge-ratio-matching
+  - adduct-fragment-table-construction
+  - feature-metadata-parsing-and-integration
+  - metadata-structure-checking
+  - cross-table-metadata-harmonization
+  - batch-effect-correction-qc-reference
+  - batch-effect-correction-and-adjustment
+  - compound-reliability-rsd-filtering
+  - pls-pls-da-classification-modeling
+  - metabolomic-biomarker-pathway-association
+  member_tools:
+  - MSnbase readMSData
+  - Mz(X)ML Shaper
+  - IPO for xcmsSet
+  - IPO for group and retcor
+  - xcms findChromPeaks
+  - xcms refineChromPeaks
+  - xcms findChromPeaks Merger
+  - xcms groupChromPeaks
+  - xcms adjustRtime
+  - xcms fillChromPeaks
+  - CAMERA.annotate
+  - CAMERA.groupFWHM
+  - CAMERA.groupCorr
+  - CAMERA.findIsotopes
+  - CAMERA.findAdducts
+  - CAMERA.combinexsAnnos
+  - Check Format
+  - Table Merge
+  - W4M concatenate
+  - xcms get a sampleMetadata file
+  - Normalization
+  - Parsec batch correction
+  - Batch Dispersion
+  - Intensity Check
+  - Biosigner
+  - mixmodel
+  - Metabolites Correlation Analysis
+  - Heatmap
+  edam_operations:
+  - http://edamontology.org/operation_3214
+  - http://edamontology.org/operation_3215
+  - http://edamontology.org/operation_3432
+  - http://edamontology.org/operation_3434
+  - http://edamontology.org/operation_3435
+  - http://edamontology.org/operation_3441
+  - http://edamontology.org/operation_3632
+  - http://edamontology.org/operation_3695
+  - http://edamontology.org/operation_3891
+  coverage_gaps:
+  - 'parameter_optimisation: no leaf in the collection declares IPO; the stage is
+    bound to generic parameter-tuning leaves'
+  - 'statistics: no leaf declares Biosigner or the other W4M statistics wrappers'
+  - no leaf in the collection declares Workflow4Metabolomics or Galaxy as the execution
+    platform; the platform itself is unrepresented in the corpus
+  derived_from_workflows: []
+  bound_by: index
+  provenance_tier: repository
+  repo_url: https://github.com/workflow4metabolomics/tools-metabolomics
+  license_tier: open
+  tool_license:
+    tier: open
+    requires_ack: false
+    ref: GPL-3.0
+    url: https://github.com/workflow4metabolomics/tools-metabolomics/blob/master/LICENSE.txt
+  verified_against:
+    repo_ref: master
+    observed: '2026-08-21'
+schema_version: 0.3.0
+---
+
+# galaxy-w4m-lcms-processing-workflow
+
+The Workflow4Metabolomics LC-MS line as one pipeline: ten stages, each bound to
+leaf skills already in this collection and to the Galaxy tool that performs it.
+
+## When to use
+
+You are running, reviewing or reproducing a metabolomics analysis on a
+Workflow4Metabolomics Galaxy instance, and you want the whole route from raw
+open-format files to statistics rather than one step of it.
+
+## When not to use
+
+- The analysis is MS/MS annotation-led — molecular networking, spectral library
+  matching, SIRIUS. That is `untargeted-lcmsms-annotation`, a different pipeline
+  with different tools.
+- You are working locally with xcms in R. The stage order still holds, but the
+  Galaxy datatypes and the three-table interchange format do not apply.
+- The data are NMR, or isotope-labelling and flux data. The same repository ships
+  those tools, but they form separate chains that share only the three-table
+  format.
+
+## Why this stage order
+
+It is not a convention. Each Galaxy wrapper declares the datatype it accepts and
+the datatype it emits, and the chain below is the only order those declarations
+permit. Two consequences are worth naming because they surprise people:
+`adjustRtime` consumes a *grouped* object, so correspondence runs before
+alignment and is then repeated against the corrected retention times; and
+`fillChromPeaks` accepts only `rdata.xcms.group`, so gap filling cannot be moved
+after annotation.
+
+| stage | W4M tools | emits |
+| --- | --- | --- |
+| `import_raw` | `MSnbase readMSData`, `Mz(X)ML Shaper` | rdata.msnbase.raw |
+| `parameter_optimisation` | `IPO for xcmsSet`, `IPO for group and retcor` | ipo-parameters |
+| `peak_detection` | `xcms findChromPeaks`, `xcms refineChromPeaks`, `xcms findChromPeaks Merger` | rdata.xcms.findchrompeaks |
+| `correspondence` | `xcms groupChromPeaks` | rdata.xcms.group |
+| `rt_alignment` | `xcms adjustRtime`, `xcms groupChromPeaks` | rdata.xcms.group |
+| `gap_filling` | `xcms fillChromPeaks` | rdata.xcms.fillpeaks |
+| `annotation` | `CAMERA.annotate`, `CAMERA.groupFWHM`, `CAMERA.groupCorr`, `CAMERA.findIsotopes`, `CAMERA.findAdducts`, `CAMERA.combinexsAnnos` | rdata.camera, three-table |
+| `table_conformance` | `Check Format`, `Table Merge`, `W4M concatenate`, `xcms get a sampleMetadata file` | three-table |
+| `normalisation` | `Normalization`, `Parsec batch correction`, `Batch Dispersion`, `Intensity Check` | three-table |
+| `statistics` | `Biosigner`, `mixmodel`, `Metabolites Correlation Analysis`, `Heatmap` | statistics, pdf |
+
+## Stages
+
+### `import_raw`
+
+Raw open-format files -> an MSnbase object the xcms chain accepts.
+
+- **after:** —
+- **in → out:** mzML, mzXML, netCDF → rdata.msnbase.raw
+- **W4M tools:** `MSnbase readMSData`, `Mz(X)ML Shaper`
+- **EDAM:** `operation_3215`
+- **leaf skills:**
+  - `xcms-data-import-preprocessing` *(primary)*
+  - `mzml-file-import-xcms`
+  - `mass-spectrometry-data-format-import`
+- **grounding:** 2 source DOI(s)
+
+### `parameter_optimisation`
+
+Design-of-experiments search for peak-picking, grouping and alignment parameters.
+
+- **after:** —
+- **in → out:** mzML → ipo-parameters
+- **W4M tools:** `IPO for xcmsSet`, `IPO for group and retcor`
+- **EDAM:** `operation_3435`
+- **leaf skills:**
+  - `parameter-tuning-metabolomics` *(primary)*
+  - `peak-picking-parameter-configuration`
+  - `chromatographic-alignment-parameter-selection`
+- **grounding:** 3 source DOI(s)
+
+### `peak_detection`
+
+Detect chromatographic peaks per sample and merge the per-sample objects.
+
+- **after:** `import_raw`, `parameter_optimisation`
+- **in → out:** rdata.msnbase.raw → rdata.xcms.findchrompeaks
+- **W4M tools:** `xcms findChromPeaks`, `xcms refineChromPeaks`, `xcms findChromPeaks Merger`
+- **EDAM:** `operation_3441`
+- **leaf skills:**
+  - `lc-ms-profile-data-segmentation` *(primary)*
+  - `chromatographic-peak-detection-wavelet`
+  - `chromatographic-profile-quality-assessment`
+- **grounding:** 3 source DOI(s)
+
+### `correspondence`
+
+Group peaks across samples into features.
+
+- **after:** `peak_detection`
+- **in → out:** rdata.xcms.findchrompeaks → rdata.xcms.group
+- **W4M tools:** `xcms groupChromPeaks`
+- **EDAM:** `operation_3632`
+- **leaf skills:**
+  - `lc-ms-feature-grouping-by-retention-time` *(primary)*
+  - `mass-chromatogram-alignment`
+- **grounding:** 1 source DOI(s)
+
+### `rt_alignment`
+
+Correct retention-time drift, then repeat correspondence against the corrected times.
+
+- **after:** `correspondence`
+- **in → out:** rdata.xcms.group → rdata.xcms.group
+- **W4M tools:** `xcms adjustRtime`, `xcms groupChromPeaks`
+- **EDAM:** `operation_3632`
+- **leaf skills:**
+  - `retention-time-correction-and-alignment` *(primary)*
+  - `retention-time-alignment-correction`
+- **grounding:** 2 source DOI(s)
+
+### `gap_filling`
+
+Integrate the areas of peaks missing from the feature matrix.
+
+- **after:** `rt_alignment`
+- **in → out:** rdata.xcms.group → rdata.xcms.fillpeaks
+- **W4M tools:** `xcms fillChromPeaks`
+- **EDAM:** `operation_3214`
+- **leaf skills:**
+  - `missing-peak-imputation-fillpeaks` *(primary)*
+- **grounding:** 1 source DOI(s)
+
+### `annotation`
+
+Group features into pseudospectra and annotate isotopes and adducts.
+
+- **after:** `gap_filling`
+- **in → out:** rdata.xcms.fillpeaks → rdata.camera, three-table
+- **W4M tools:** `CAMERA.annotate`, `CAMERA.groupFWHM`, `CAMERA.groupCorr`, `CAMERA.findIsotopes`, `CAMERA.findAdducts`, `CAMERA.combinexsAnnos`
+- **EDAM:** `operation_3432`
+- **leaf skills:**
+  - `spectral-feature-clustering-by-intensity-correlation` *(primary)*
+  - `metabolite-mass-to-charge-ratio-matching`
+  - `adduct-fragment-table-construction`
+- **grounding:** 1 source DOI(s)
+
+### `table_conformance`
+
+Make the dataMatrix, sampleMetadata and variableMetadata agree before any statistics.
+
+- **after:** `annotation`
+- **in → out:** three-table → three-table
+- **W4M tools:** `Check Format`, `Table Merge`, `W4M concatenate`, `xcms get a sampleMetadata file`
+- **EDAM:** `operation_3891`
+- **leaf skills:**
+  - `feature-metadata-parsing-and-integration` *(primary)*
+  - `metadata-structure-checking`
+  - `cross-table-metadata-harmonization`
+- **grounding:** 3 source DOI(s)
+
+### `normalisation`
+
+Normalise intensities and correct batch and drift effects using the pooled QC samples.
+
+- **after:** `table_conformance`
+- **in → out:** three-table → three-table
+- **W4M tools:** `Normalization`, `Parsec batch correction`, `Batch Dispersion`, `Intensity Check`
+- **EDAM:** `operation_3434`
+- **leaf skills:**
+  - `batch-effect-correction-qc-reference` *(primary)*
+  - `batch-effect-correction-and-adjustment`
+  - `compound-reliability-rsd-filtering`
+- **grounding:** 3 source DOI(s)
+
+### `statistics`
+
+Univariate, multivariate and signature analysis on the corrected matrix.
+
+- **after:** `normalisation`
+- **in → out:** three-table → statistics, pdf
+- **W4M tools:** `Biosigner`, `mixmodel`, `Metabolites Correlation Analysis`, `Heatmap`
+- **EDAM:** `operation_3695`
+- **leaf skills:**
+  - `pls-pls-da-classification-modeling` *(primary)*
+  - `metabolomic-biomarker-pathway-association`
+- **grounding:** 2 source DOI(s)
+
+## Grounding
+
+Every stage carries the DOIs and KB slugs of the leaves bound to it; ground a
+stage with the collection's `/ground` recipe against those slugs.
+
+The pipeline *structure* is grounded differently from the leaves: it was read off
+the tool wrappers in `workflow4metabolomics/tools-metabolomics` at `master` on
+2026-08-21, not distilled from a paper. `provenance.structure_source` in
+`workflow.yaml` records that.
+
+## Verification contract
+
+- Each stage's output datatype is the one the next stage declares as its input.
+  A Galaxy invocation that type-checks has already verified most of this.
+- The second correspondence pass ran after alignment; a workflow with one
+  grouping step is missing it.
+- The three tables agree on identifiers and order before `normalisation`. See
+  `w4m-three-table-format-conformance`.
+- `xcms process history` matches the exported workflow.
+- Feature counts are reported after gap filling, not after correspondence; the
+  two differ and only the first describes the matrix the statistics saw.
+
+## Coverage gaps
+
+The corpus does not cover this pipeline evenly, and the bindings say where:
+
+- **Parameter optimisation** — no leaf declares IPO. The stage is bound to
+  generic parameter-tuning leaves, which describe the activity but not the tool.
+- **Statistics** — no leaf declares Biosigner or the other W4M statistics
+  wrappers. The bound leaves cover PLS-DA and biomarker association generically.
+- **The platform** — no leaf declares Workflow4Metabolomics or Galaxy. The
+  collection knows the methods this pipeline runs and not the platform that runs
+  them.
+
+Of the 16 DOIs the wrappers cite, 2 are already in the collection's corpus. The
+other 14 are candidates for corpus expansion, which would close the gaps above
+at their source rather than by rebinding.
+
+## Provenance
+
+Structure from the tool wrappers; leaf bindings by lexical retrieval over
+`skills_index.json` constrained to leaves that declare the relevant tool, then
+checked by hand. `bound_by: index`. No ASB rerun; no per-paper workflow DAG
+contributed structure, so `derived_from_workflows` is empty and no benchmark
+ablation is required.

--- a/staged-collections/metabolomics/workflows/galaxy-w4m-lcms-processing/workflow.yaml
+++ b/staged-collections/metabolomics/workflows/galaxy-w4m-lcms-processing/workflow.yaml
@@ -1,0 +1,421 @@
+schema_version: 0.3.0
+workflow_id: galaxy_w4m_lcms_processing
+kind: composite-workflow
+techniques:
+- LC-MS
+- GC-MS
+steps:
+- id: import_raw
+  goal: raw open-format files -> an MSnbase object the xcms chain accepts
+  edam_operation: http://edamontology.org/operation_3215
+  primary_skill: xcms-data-import-preprocessing
+  skills:
+  - xcms-data-import-preprocessing
+  - mzml-file-import-xcms
+  - mass-spectrometry-data-format-import
+  tools:
+  - MSnbase readMSData
+  - Mz(X)ML Shaper
+  inputs:
+  - type: mzML
+  - type: mzXML
+  - type: netCDF
+  outputs:
+  - type: rdata
+    flavour: rdata.msnbase.raw
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-ac051437y
+    - asb-paper-10-1186-s13321-024-00878-1
+    dois:
+    - 10.1021/ac051437y
+    - 10.1186/s13321-024-00878-1
+  after: []
+  candidate_tools:
+  - BiocParallel
+  - MSnbase
+  - MassSpecWavelet
+  - MsDataHub
+  - MsExperiment
+  - Python
+  - Spectra
+  - matchms
+  - xcms
+- id: parameter_optimisation
+  goal: design-of-experiments search for peak-picking, grouping and alignment parameters
+  edam_operation: http://edamontology.org/operation_3435
+  primary_skill: parameter-tuning-metabolomics
+  skills:
+  - parameter-tuning-metabolomics
+  - peak-picking-parameter-configuration
+  - chromatographic-alignment-parameter-selection
+  tools:
+  - IPO for xcmsSet
+  - IPO for group and retcor
+  inputs:
+  - type: mzML
+  outputs:
+  - type: tabular
+    flavour: ipo-parameters
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-ac051437y
+    - asb-paper-10-1021-acs-analchem-1c03032
+    - asb-paper-10-1101-812370
+    dois:
+    - 10.1021/ac051437y
+    - 10.1021/acs.analchem.1c03032
+    - 10.1101/812370
+  after: []
+  candidate_tools:
+  - MSconvert
+  - MZmine2
+  - MassBank
+  - MetaboAnnotatoR
+  - MsExperiment
+  - MsFeatures
+  - R
+  - R (version or higher)
+  - XCMS
+  - mtbls2
+  - xcms
+- id: peak_detection
+  goal: detect chromatographic peaks per sample and merge the per-sample objects
+  edam_operation: http://edamontology.org/operation_3441
+  primary_skill: lc-ms-profile-data-segmentation
+  skills:
+  - lc-ms-profile-data-segmentation
+  - chromatographic-peak-detection-wavelet
+  - chromatographic-profile-quality-assessment
+  tools:
+  - xcms findChromPeaks
+  - xcms refineChromPeaks
+  - xcms findChromPeaks Merger
+  inputs:
+  - type: rdata
+    flavour: rdata.msnbase.raw
+  outputs:
+  - type: rdata
+    flavour: rdata.xcms.findchrompeaks
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-ac051437y
+    - asb-paper-10-1021-acs-analchem-4c04531
+    - asb-paper-10-1021-acs-analchem-5c00567
+    dois:
+    - 10.1021/ac051437y
+    - 10.1021/acs.analchem.4c04531
+    - 10.1021/acs.analchem.5c00567
+  after:
+  - import_raw
+  - parameter_optimisation
+  candidate_tools:
+  - MassSpecWavelet
+  - MsDataHub
+  - ProteoWizard/MSConvert
+  - PyTorch
+  - Python
+  - QuanFormer
+  - R
+  - Spectra
+  - TARDIS
+  - knitr
+  - xcms
+  - xcms (R package) with centWave algorithm
+  inputs_from:
+    import_raw:
+    - rdata:rdata.msnbase.raw
+    parameter_optimisation:
+    - tabular:ipo-parameters
+- id: correspondence
+  goal: group peaks across samples into features
+  edam_operation: http://edamontology.org/operation_3632
+  primary_skill: lc-ms-feature-grouping-by-retention-time
+  skills:
+  - lc-ms-feature-grouping-by-retention-time
+  - mass-chromatogram-alignment
+  tools:
+  - xcms groupChromPeaks
+  inputs:
+  - type: rdata
+    flavour: rdata.xcms.findchrompeaks
+  outputs:
+  - type: rdata
+    flavour: rdata.xcms.group
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-ac051437y
+    dois:
+    - 10.1021/ac051437y
+  after:
+  - peak_detection
+  candidate_tools:
+  - MsExperiment
+  - MsFeatures
+  - Spectra
+  - xcms
+  inputs_from:
+    peak_detection:
+    - rdata:rdata.xcms.findchrompeaks
+- id: rt_alignment
+  goal: correct retention-time drift, then repeat correspondence against the corrected
+    times
+  edam_operation: http://edamontology.org/operation_3632
+  primary_skill: retention-time-correction-and-alignment
+  skills:
+  - retention-time-correction-and-alignment
+  - retention-time-alignment-correction
+  tools:
+  - xcms adjustRtime
+  - xcms groupChromPeaks
+  inputs:
+  - type: rdata
+    flavour: rdata.xcms.group
+  outputs:
+  - type: rdata
+    flavour: rdata.xcms.group
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-acs-analchem-4c04906
+    - asb-paper-10-1021-acs-analchem-5c00567
+    dois:
+    - 10.1021/acs.analchem.4c04906
+    - 10.1021/acs.analchem.5c00567
+  after:
+  - correspondence
+  candidate_tools:
+  - MetCohort
+  - R
+  - Spectra
+  - TARDIS
+  - kableExtra
+  - knitr
+  - xcms
+  inputs_from:
+    correspondence:
+    - rdata:rdata.xcms.group
+- id: gap_filling
+  goal: integrate the areas of peaks missing from the feature matrix
+  edam_operation: http://edamontology.org/operation_3214
+  primary_skill: missing-peak-imputation-fillpeaks
+  skills:
+  - missing-peak-imputation-fillpeaks
+  tools:
+  - xcms fillChromPeaks
+  inputs:
+  - type: rdata
+    flavour: rdata.xcms.group
+  outputs:
+  - type: rdata
+    flavour: rdata.xcms.fillpeaks
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1093-bioinformatics-btaa037
+    dois:
+    - 10.1093/bioinformatics/btaa037
+  after:
+  - rt_alignment
+  candidate_tools:
+  - R
+  - compCV
+  - ncGTW
+  - xcms
+  inputs_from:
+    rt_alignment:
+    - rdata:rdata.xcms.group
+- id: annotation
+  goal: group features into pseudospectra and annotate isotopes and adducts
+  edam_operation: http://edamontology.org/operation_3432
+  primary_skill: spectral-feature-clustering-by-intensity-correlation
+  skills:
+  - spectral-feature-clustering-by-intensity-correlation
+  - metabolite-mass-to-charge-ratio-matching
+  - adduct-fragment-table-construction
+  tools:
+  - CAMERA.annotate
+  - CAMERA.groupFWHM
+  - CAMERA.groupCorr
+  - CAMERA.findIsotopes
+  - CAMERA.findAdducts
+  - CAMERA.combinexsAnnos
+  inputs:
+  - type: rdata
+    flavour: rdata.xcms.fillpeaks
+  outputs:
+  - type: rdata
+    flavour: rdata.camera
+  - type: tabular
+    flavour: three-table
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-acs-analchem-1c00238
+    dois:
+    - 10.1021/acs.analchem.1c00238
+  after:
+  - gap_filling
+  candidate_tools:
+  - CAMERA
+  - FELLA
+  - KEGG database
+  - R
+  - cliqueMS
+  - igraph
+  - mWISE
+  inputs_from:
+    gap_filling:
+    - rdata:rdata.xcms.fillpeaks
+- id: table_conformance
+  goal: make the dataMatrix, sampleMetadata and variableMetadata agree before any
+    statistics
+  edam_operation: http://edamontology.org/operation_3891
+  primary_skill: feature-metadata-parsing-and-integration
+  skills:
+  - feature-metadata-parsing-and-integration
+  - metadata-structure-checking
+  - cross-table-metadata-harmonization
+  tools:
+  - Check Format
+  - Table Merge
+  - W4M concatenate
+  - xcms get a sampleMetadata file
+  inputs:
+  - type: tabular
+    flavour: three-table
+  outputs:
+  - type: tabular
+    flavour: three-table
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1007-s11306-020-01717-8
+    - asb-paper-10-1093-bioinformatics-btac059-6522114
+    - asb-paper-10-3390-metabo12030212
+    dois:
+    - 10.1007/s11306-020-01717-8
+    - 10.1093/bioinformatics/btac059
+    - 10.3390/metabo12030212
+  after:
+  - annotation
+  candidate_tools:
+  - CAMERA
+  - JPA
+  - MSnbase
+  - MetaboShiny
+  - R
+  - XCMS
+  - metaboprep
+  inputs_from:
+    annotation:
+    - tabular:three-table
+- id: normalisation
+  goal: normalise intensities and correct batch and drift effects using the pooled
+    QC samples
+  edam_operation: http://edamontology.org/operation_3434
+  primary_skill: batch-effect-correction-qc-reference
+  skills:
+  - batch-effect-correction-qc-reference
+  - batch-effect-correction-and-adjustment
+  - compound-reliability-rsd-filtering
+  tools:
+  - Normalization
+  - Parsec batch correction
+  - Batch Dispersion
+  - Intensity Check
+  inputs:
+  - type: tabular
+    flavour: three-table
+  outputs:
+  - type: tabular
+    flavour: three-table
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1007-s11306-020-01717-8
+    - asb-paper-10-1021-acs-analchem-5c01213
+    - asb-paper-10-1021-jasms-5c00073
+    dois:
+    - 10.1007/s11306-020-01717-8
+    - 10.1021/acs.analchem.5c01213
+    - 10.1021/jasms.5c00073
+  after:
+  - table_conformance
+  candidate_tools:
+  - BiocManager
+  - MetaboShiny
+  - R
+  - SummarizedExperiment
+  - XCMS
+  - mzQuality
+  - mzQualityDashboard
+  - mzrtsim
+  - xcms
+  inputs_from:
+    table_conformance:
+    - tabular:three-table
+- id: statistics
+  goal: univariate, multivariate and signature analysis on the corrected matrix
+  edam_operation: http://edamontology.org/operation_3695
+  primary_skill: pls-pls-da-classification-modeling
+  skills:
+  - pls-pls-da-classification-modeling
+  - metabolomic-biomarker-pathway-association
+  tools:
+  - Biosigner
+  - mixmodel
+  - Metabolites Correlation Analysis
+  - Heatmap
+  inputs:
+  - type: tabular
+    flavour: three-table
+  outputs:
+  - type: tabular
+    flavour: statistics
+  - type: pdf
+  grounding:
+    kb_slugs:
+    - asb-paper-10-1021-acs-analchem-5c03225
+    - asb-paper-10-1093-bib-bbac455
+    dois:
+    - 10.1021/acs.analchem.5c03225
+    - 10.1093/bib/bbac455
+  after:
+  - normalisation
+  candidate_tools:
+  - Enrichment
+  - KEGG_Enrich_Plot
+  - KEGG_Enrich_PlotPanel
+  - R
+  - SMART Statistical Analysis module
+  - ggplot2
+  - igraph
+  inputs_from:
+    normalisation:
+    - tabular:three-table
+verification:
+  per_step_outputs:
+  - 'import_raw: rdata.msnbase.raw'
+  - 'parameter_optimisation: ipo-parameters'
+  - 'peak_detection: rdata.xcms.findchrompeaks'
+  - 'correspondence: rdata.xcms.group'
+  - 'rt_alignment: rdata.xcms.group'
+  - 'gap_filling: rdata.xcms.fillpeaks'
+  - 'annotation: rdata.camera'
+  - 'table_conformance: three-table'
+  - 'normalisation: three-table'
+  - 'statistics: statistics'
+  final_outputs:
+  - path: dataMatrix.tsv
+    type: file
+  - path: sampleMetadata.tsv
+    type: file
+  - path: variableMetadata.tsv
+    type: file
+  - path: workflow-invocation.json
+    type: file
+provenance:
+  derived_from_workflows: []
+  bound_by: index
+  structure_source:
+    kind: repository
+    repo_url: https://github.com/workflow4metabolomics/tools-metabolomics
+    repo_ref: master
+    observed: '2026-08-21'
+    method: stage order read from the Galaxy wrappers' declared input/output datatypes

--- a/tests/test_propose_skill.py
+++ b/tests/test_propose_skill.py
@@ -186,3 +186,53 @@ def test_main_stages_files(tmp_path):
     assert rc == 0
     assert (col / "proposals" / "skills" / "my-new-skill" / "SKILL.md").is_file()
     assert (col / "proposals" / "wave-skills-2026-06-26.yaml").is_file()
+
+
+class TestLedgerReadsBothDeclarationSites:
+    """`related_skills` is written at top level by some skills and under
+    `metadata` by others. The stager read only the top level, so every skill
+    following the `metadata` convention -- which is all of the staged corpus --
+    got an empty `related_skills` in its ledger entry while its SKILL.md
+    declared them. Both sites, one accessor."""
+
+    def _stage(self, tmp_path, fm):
+        from scripts.propose_skill import stage_proposal
+        from scripts.normalize_skill import skill_field
+
+        ledger_meta = {
+            "slug": "s",
+            "related_skills": list(skill_field(fm, "related_skills") or []),
+            "tools_used": list(skill_field(fm, "tools_used") or []),
+        }
+        stage_proposal(tmp_path, fm, "body\n", ledger_meta, date="2026-08-21")
+        ledger = yaml.safe_load(
+            (tmp_path / "proposals" / "wave-skills-2026-08-21.yaml").read_text()
+        )
+        return ledger["proposals"][0]
+
+    def test_related_skills_under_metadata_reach_the_ledger(self, tmp_path):
+        entry = self._stage(
+            tmp_path,
+            {"name": "s", "metadata": {"related_skills": ["other-skill"]}},
+        )
+        assert entry["related_skills"] == ["other-skill"]
+
+    def test_related_skills_at_top_level_still_reach_the_ledger(self, tmp_path):
+        entry = self._stage(tmp_path, {"name": "s", "related_skills": ["other-skill"]})
+        assert entry["related_skills"] == ["other-skill"]
+
+    def test_absent_everywhere_is_an_empty_list_not_a_crash(self, tmp_path):
+        assert self._stage(tmp_path, {"name": "s"})["related_skills"] == []
+
+
+class TestSkillFieldAccessor:
+    def test_top_level_wins_over_metadata(self):
+        from scripts.normalize_skill import skill_field
+
+        fm = {"related_skills": ["top"], "metadata": {"related_skills": ["meta"]}}
+        assert skill_field(fm, "related_skills") == ["top"]
+
+    def test_a_non_mapping_metadata_does_not_raise(self):
+        from scripts.normalize_skill import skill_field
+
+        assert skill_field({"metadata": "not-a-mapping"}, "related_skills") is None

--- a/tests/test_workflow_manifests.py
+++ b/tests/test_workflow_manifests.py
@@ -1,0 +1,70 @@
+"""Every composite workflow in the repo validates -- released or staged.
+
+`validate_workflows.py` is run by `release_gate.check_workflows` over
+`collections/*/v*/workflows`, and the CI job that walks staged content globs
+`staged-collections/*/v*`. A workflow staged at `staged-collections/<domain>/
+workflows/<slug>/` matches neither, so a broken manifest there reaches a
+promotion PR unchecked -- the silent-clean-pass this suite exists to prevent.
+
+The discovery below keys on structure (a directory holding both `SKILL.md` and
+`workflow.yaml`) rather than on a list of paths, so a workflow staged somewhere
+new is covered the day it is written instead of the day someone remembers to add
+its path here.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import validate_workflows  # noqa: E402
+
+# The released collection is the slug authority: a workflow's leaves must resolve
+# there whether the workflow itself is released or still staged.
+SKILLS_INDEX = ROOT / "collections" / "metabolomics" / "v2" / "skills_index.json"
+
+
+def workflow_dirs() -> list[pathlib.Path]:
+    """Every workflow directory in the repo, found by shape."""
+    found = []
+    for root in ("collections", "staged-collections"):
+        base = ROOT / root
+        if not base.is_dir():
+            continue
+        for skill_md in base.rglob("workflows/*/SKILL.md"):
+            d = skill_md.parent
+            if d.name.startswith("_") or d.name == "bin":
+                continue
+            if (d / "workflow.yaml").is_file():
+                found.append(d)
+    return sorted(found)
+
+
+@pytest.fixture(scope="module")
+def slugs() -> set:
+    return {r["slug"] for r in json.loads(SKILLS_INDEX.read_text())}
+
+
+def test_discovery_finds_both_trees():
+    """Guards the guard: if discovery silently matched nothing, every test below
+    would pass without validating anything."""
+    dirs = workflow_dirs()
+    roots = {p.relative_to(ROOT).parts[0] for p in dirs}
+    assert len(dirs) >= 21, f"expected the released workflows at least, found {len(dirs)}"
+    assert "collections" in roots
+    assert "staged-collections" in roots, (
+        "no staged workflow discovered -- if staging was emptied on purpose, "
+        "relax this; otherwise discovery has drifted"
+    )
+
+
+@pytest.mark.parametrize("wf_dir", workflow_dirs(), ids=lambda p: p.name)
+def test_workflow_manifest_is_valid(wf_dir, slugs):
+    errors = validate_workflows.validate_one(str(wf_dir), slugs)
+    assert not errors, "\n".join(errors)


### PR DESCRIPTION
Both projects were already represented by staged proposals (#11, #16) written from
general knowledge. This reads the actual sources — the live MetabolomicsHub API and
the Workflow4Metabolomics Galaxy wrappers — and rewrites the two skills against what
they do, adds two more, and stages the W4M pipeline as a composite workflow.

## What the ground truth changed

**MetabolomicsHub.** The staged skill directed users to
`https://www.metabolomicshub.org/api/`, which returns 404, and listed open-format
filtering as a search criterion. The live service is
`/api/submission/v0_1`; it indexes 6,796 datasets and does expose search, through a
clause DSL (`terms`, `compare`, `parameter_pair`, `characteristic_pair`,
`descriptor`) over 40 fields. Three corrections follow:

- Polarity is filterable, but as a `parameter_pair` with `type_name: "scan polarity"`,
  not a top-level field.
- File format is not indexed at all. It is filtered client-side from the `files.extensions`
  block each result carries.
- Field coverage is repository-dependent, and the gaps are silent. GNPS/MassIVE (500
  datasets) carries no structured instrument or parameter metadata, so any instrument or
  polarity filter drops it entirely. `facet_omics_types` is populated only by MetaboLights:
  filtering on it returned 2,331 datasets, and adding `dataset_repository = metabolights`
  returned the same 2,331 — a repository filter wearing an omics label.

The skill now carries the coverage table and a procedure step that measures each
filter's per-repository exclusion instead of assuming it.

**Workflow4Metabolomics.** The 46 tool wrappers declare their Galaxy datatypes, so the
LC-MS stage order is not conventional but enforced: `rdata.msnbase.raw` →
`rdata.xcms.findchrompeaks` → `group` → `retcor` → `fillpeaks` → `camera`. Two
consequences that the prose draft could not have stated: `adjustRtime` consumes a
grouped object, so correspondence precedes alignment and is then repeated; and
`fillChromPeaks` accepts only `rdata.xcms.group`, so gap filling cannot move after
annotation. One claim in the draft was also wrong — `Mz(X)ML Shaper` accepts mzML,
mzXML and netCDF only, so it is not the vendor converter.

## Contents

Four skills on the proposal rail, all `status: hold`, all `provenance_tier: repository`:

| skill | wave |
| --- | --- |
| `metabolomicshub-cross-repository-dataset-search` | rewritten |
| `metabolomicshub-announcement-authoring` | new |
| `galaxy-workflow4metabolomics-reproducible-processing` | rewritten |
| `w4m-three-table-format-conformance` | new |

One composite workflow, staged rather than released, per the super-skill spec:
`staged-collections/metabolomics/workflows/galaxy-w4m-lcms-processing` — 10 stages, 25
leaf skills all resolving in `skills_index.json`, stage tools taken from the real W4M
tool ids rather than unioned from the bound leaves.

The workflow declares its coverage gaps instead of hiding them: no leaf in the
collection declares IPO, Biosigner, or Workflow4Metabolomics/Galaxy as a platform. Of
the 16 DOIs the wrappers cite, 2 are already in the corpus; the other 14 are corpus
expansion candidates that would close those gaps at the source.

## Two harness fixes

`propose_skill` read `related_skills` only at the top level of the frontmatter while
`check_proposals` looked in both places, and the whole staged corpus declares it under
`metadata`. Every ledger entry therefore recorded an empty `related_skills` while its
SKILL.md declared them. Both now route through one `skill_field` accessor.

Nothing validated staged workflows: `release_gate` covers `collections/*/v*/workflows`
and the staged CI job globs `staged-collections/*/v*`, so a workflow staged at
`staged-collections/<domain>/workflows/` matched neither. `tests/test_workflow_manifests.py`
discovers workflow directories by shape across both trees and validates each; it was
confirmed red on an unresolvable leaf slug before being committed green.

## Verification

`check_proposals`, `check_provenance_tiers`, `check_tools_index`, `check_license_tiers`
and `release_gate --strict` all pass on the released collection; `validate_workflows`
reports 21/21 released and 1/1 staged; 1,067 tests pass, 2 skipped.

API observations are dated 2026-08-21 against index v0.0.1 and recorded in each
skill's `verified_against` block, since both the index and the field list move.
