### PR TITLE
Resolve tool licences from the tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ collections/*/v*/curation_report.json
 # Resolved per-machine; the CI install pins its own dependencies explicitly.
 # Committed by accident in 59d470915 (a data commit) and untracked again here.
 uv.lock
+.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,9 @@ the indexes plus the few skills you need. Full steps:
 
 - `skills_index.json` — `slug, name, description, edam_operation, edam_topics, tools, dois`
 - `tools_index.json` — `slug, name, edam_topics, dois, license_tier, license_subject,
-  source_paper_repos` (`source_paper_repos` = repositories of the papers that cite the
-  tool, not the tool's own home)
+  repo_url, source_paper_repos` (`repo_url` = the tool's own repository, recorded only
+  where a licence was resolved from it; `source_paper_repos` = repositories of the
+  papers that cite the tool, which are not the tool's home)
 
 ```bash
 # skills that use a given tool

--- a/collections/metabolomics/v2/USAGE.md
+++ b/collections/metabolomics/v2/USAGE.md
@@ -77,7 +77,7 @@ the machine indexes directly:
 | File | What it is |
 |---|---|
 | `skills_index.json` | one row/skill: `slug, name, description, edam_operation, edam_topics, tools, dois` |
-| `tools_index.json` | one row/tool: `slug, name, edam_topics, dois, license_tier, license_subject, source_paper_repos` |
+| `tools_index.json` | one row/tool: `slug, name, edam_topics, dois, license_tier, license_subject, repo_url, source_paper_repos` |
 | `kb_bundle.json` | skill → source DOIs + tools + `asb-paper-<doi>` KB slugs (grounding map) |
 | `collection.yaml` | the SkillCollection record (counts, curators, license) |
 | `corpus.yaml` | per-paper access basis (`repo-oa`) |

--- a/collections/metabolomics/v2/skills/_router/SKILL.md
+++ b/collections/metabolomics/v2/skills/_router/SKILL.md
@@ -100,10 +100,10 @@ Three machine indexes back both scripts, and are worth querying directly with
   `edam_operation`, `edam_topics`, `tools`, `dois`, `techniques`,
   `license_tier`.
 - **`tools_index.json`** — one row per tool: `slug`, `name`, `edam_topics`,
-  `dois`, `license_tier`, `license_subject`, `source_paper_repos`.
-  `source_paper_repos` holds the repositories of the papers that *cite* the tool.
-  It is not the tool's own home and must never be offered as one: no field yet
-  records that (issue #43).
+  `dois`, `license_tier`, `license_subject`, `repo_url`, `source_paper_repos`.
+  `repo_url` is the tool's own repository, present only where a licence was
+  resolved from it. `source_paper_repos` holds the repositories of the papers
+  that *cite* the tool — not the tool's home, and never to be offered as one.
 - **`workflows/workflows_index.json`** — one row per composite workflow: `slug`,
   `name`, `description`, `techniques`, `stages`, `member_tools`.
 
@@ -166,7 +166,8 @@ routing logic:
   *"no tool-level licence evidence — verify before redistributing"* (non-blocking).
   This is an open question, not a verdict: do not present it as a restriction on
   using the tool, and do not treat it as permission to redistribute the tool's
-  code. Every tool in this collection is currently `unknown` (issue #42).
+  code. 713 of the 909 tools in this collection are `unknown`: no registry or
+  source repository has been found for them yet (issue #43).
 
 All other routing behavior (technique, EDAM, tool name, keyword matching) is
 unchanged; tier-awareness is an additional layer applied after candidate

--- a/collections/metabolomics/v2/tool_licenses.json
+++ b/collections/metabolomics/v2/tool_licenses.json
@@ -1,0 +1,1402 @@
+{
+  "adviselipidomics": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "ShinyFabio/ADViSELipidomics",
+    "route": "self_published",
+    "matched": "ADViSELipidomics"
+  },
+  "aerith": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/xyz1396/Aerith",
+    "route": "registry:bioconductor",
+    "matched": "Aerith",
+    "superseded": {
+      "license": "GPL-3.0",
+      "license_detection": "github-api"
+    }
+  },
+  "alphatims": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/MannLabs/alphatims",
+    "route": "registry:bioconda",
+    "matched": "alphatims"
+  },
+  "ann-solo": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "bittremieux-lab/ANN-SoLo",
+    "route": "self_published",
+    "matched": "ANN-SoLo"
+  },
+  "annome": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "chrboku/AnnoMe",
+    "route": "self_published",
+    "matched": "AnnoMe"
+  },
+  "antismash": {
+    "license": "AGPL-3.0-or-later",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/antismash/antismash",
+    "route": "registry:bioconda",
+    "matched": "antismash"
+  },
+  "asics": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/ASICS",
+    "route": "registry:bioconductor",
+    "matched": "ASICS"
+  },
+  "autoccs": {
+    "license": "BSD-2-Clause",
+    "license_detection": "github-api",
+    "repo_url": "PNNL-Comp-Mass-Spec/AutoCCS",
+    "route": "self_published",
+    "matched": "AutoCCS"
+  },
+  "aws-cli": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": null,
+    "route": "registry:bioconda",
+    "matched": "awscli"
+  },
+  "big-scape": {
+    "license": "AGPL-3.0-or-later",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/medema-group/BiG-SCAPE",
+    "route": "registry:bioconda",
+    "matched": "bigscape"
+  },
+  "big-slice": {
+    "license": "AGPL-3.0-or-later",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/satriaphd/bigslice",
+    "route": "registry:bioconda",
+    "matched": "bigslice",
+    "superseded": {
+      "license": "AGPL-3.0",
+      "license_detection": "github-api"
+    }
+  },
+  "bigscape": {
+    "license": "AGPL-3.0-or-later",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/medema-group/BiG-SCAPE",
+    "route": "registry:bioconda",
+    "matched": "bigscape"
+  },
+  "biobase": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Bioconductor/Biobase",
+    "route": "registry:bioconductor",
+    "matched": "Biobase"
+  },
+  "biosynfoni": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "lucinamay/biosynfoni",
+    "route": "self_published",
+    "matched": "biosynfoni"
+  },
+  "camera": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/sneumann/CAMERA",
+    "route": "registry:bioconductor",
+    "matched": "CAMERA"
+  },
+  "cardinal": {
+    "license": "Artistic-2.0",
+    "license_detection": "github-api",
+    "repo_url": "kuwisdelu/Cardinal",
+    "route": "self_published",
+    "matched": "Cardinal"
+  },
+  "chemminer": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/girke-lab/ChemmineR",
+    "route": "registry:bioconductor",
+    "matched": "ChemmineR"
+  },
+  "chemprop-ir": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/gfm-collab/chemprop-IR",
+    "route": "self_published",
+    "matched": "Chemprop-IR"
+  },
+  "cliquems": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/osenan/cliqueMS",
+    "route": "registry:bioconductor",
+    "matched": "cliqueMS"
+  },
+  "clumsid": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/tdepke/CluMSID",
+    "route": "registry:bioconductor",
+    "matched": "CluMSID"
+  },
+  "clusterprofiler": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/YuLab-SMU/clusterProfiler",
+    "route": "registry:bioconductor",
+    "matched": "clusterProfiler"
+  },
+  "commit": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/pwendering/COMMIT",
+    "route": "self_published",
+    "matched": "COMMIT"
+  },
+  "complexheatmap": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/jokergoo/ComplexHeatmap",
+    "route": "registry:bioconductor",
+    "matched": "ComplexHeatmap"
+  },
+  "cordbat": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "BorchLab/CordBat",
+    "route": "self_published",
+    "matched": "CordBat"
+  },
+  "corems": {
+    "license": "BSD-2-Clause",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/EMSL-Computing/CoreMS",
+    "route": "self_published",
+    "matched": "corems"
+  },
+  "dbdipy": {
+    "license": "MIT",
+    "license_detection": "readme-llm",
+    "repo_url": "leopold-weidner/DBDIpy",
+    "route": "self_published",
+    "matched": "DBDIpy"
+  },
+  "decometdia": {
+    "license": "GPL-3.0-only",
+    "license_detection": "r-description",
+    "repo_url": "ZhuMSLab/DecoMetDIA",
+    "route": "self_published",
+    "matched": "DecoMetDIA"
+  },
+  "deimos": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/pnnl/deimos",
+    "route": "self_published",
+    "matched": "deimos"
+  },
+  "dereplicator": {
+    "license": "Apache-2.0",
+    "license_detection": "readme-llm",
+    "repo_url": "ablab/npdtools",
+    "route": "self_published",
+    "matched": "dereplicator"
+  },
+  "deseq2": {
+    "license": "LGPL-3.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/thelovelab/DESeq2",
+    "route": "registry:bioconductor",
+    "matched": "DESeq2"
+  },
+  "diffspectra": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "AzureLeon1/DiffSpectra",
+    "route": "self_published",
+    "matched": "DiffSpectra"
+  },
+  "dures": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "BiosystemEngineeringLab-IITB/dures",
+    "route": "self_published",
+    "matched": "DuReS"
+  },
+  "edger": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/edgeR",
+    "route": "registry:bioconductor",
+    "matched": "edgeR"
+  },
+  "elemcor": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "4dsoftware/elemcor",
+    "route": "self_published",
+    "matched": "ElemCor"
+  },
+  "falcon": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/bittremieuxlab/falcon",
+    "route": "self_published",
+    "matched": "falcon"
+  },
+  "fella": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/FELLA",
+    "route": "registry:bioconductor",
+    "matched": "FELLA"
+  },
+  "fgsea": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/alserglab/fgsea",
+    "route": "registry:bioconductor",
+    "matched": "fgsea"
+  },
+  "fiddle": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/JosieHong/FIDDLE",
+    "route": "self_published",
+    "matched": "fiddle"
+  },
+  "fmcsr": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/girke-lab/fmcsR",
+    "route": "registry:bioconductor",
+    "matched": "fmcsR"
+  },
+  "fnicm": {
+    "license": "AFL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "LiQi94/FNICM",
+    "route": "self_published",
+    "matched": "FNICM"
+  },
+  "gcims": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "sipss/GCIMS",
+    "route": "self_published",
+    "matched": "GCIMS"
+  },
+  "george": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "jcapelladesto/geoRge",
+    "route": "self_published",
+    "matched": "geoRge"
+  },
+  "getfeatistics": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "FrigerioGianfranco/GetFeatistics",
+    "route": "self_published",
+    "matched": "GetFeatistics"
+  },
+  "gleams": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "bittremieux-lab/GLEAMS",
+    "route": "self_published",
+    "matched": "GLEAMS"
+  },
+  "hruv": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "SydneyBioX/hRUV",
+    "route": "self_published",
+    "matched": "hRUV"
+  },
+  "hyperspec": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "wh-xu/Hyper-Spec",
+    "route": "self_published",
+    "matched": "HyperSpec"
+  },
+  "idsl-csa": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "idslme/IDSL.CSA",
+    "route": "self_published",
+    "matched": "IDSL.CSA"
+  },
+  "idsl-ufa": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "idslme/IDSL.UFA",
+    "route": "self_published",
+    "matched": "IDSL.UFA"
+  },
+  "impute": {
+    "license": "GPL-2.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/impute",
+    "route": "registry:bioconductor",
+    "matched": "impute"
+  },
+  "imzml-writer": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "VIU-Metabolomics/imzML_Writer",
+    "route": "self_published",
+    "matched": "imzML Writer"
+  },
+  "ipapy2": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/francescodc87/ipaPy2",
+    "route": "registry:bioconda",
+    "matched": "ipapy2"
+  },
+  "isfrag": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "HuanLab/ISFrag",
+    "route": "self_published",
+    "matched": "ISFrag"
+  },
+  "isoformswitchanalyzer": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/kvittingseerup/IsoformSwitchAnalyzeR",
+    "route": "registry:bioconductor",
+    "matched": "IsoformSwitchAnalyzeR"
+  },
+  "isofusion": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "xfcui/IsoFusion",
+    "route": "self_published",
+    "matched": "IsoFusion"
+  },
+  "isoscan": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "jcapelladesto/isoSCAN",
+    "route": "self_published",
+    "matched": "isoSCAN"
+  },
+  "jpa": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "HuanLab/JPA",
+    "route": "self_published",
+    "matched": "JPA"
+  },
+  "keggrest": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Bioconductor/KEGGREST",
+    "route": "registry:bioconductor",
+    "matched": "KEGGREST"
+  },
+  "largemetabo": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "LargeMetabo/LargeMetabo",
+    "route": "self_published",
+    "matched": "LargeMetabo"
+  },
+  "lcmsworld": {
+    "license": "AGPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "PGB-LIV/lcmsWorld",
+    "route": "self_published",
+    "matched": "lcmsWorld"
+  },
+  "lilikoi-v2-0": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "lanagarmire/lilikoi2",
+    "route": "self_published",
+    "matched": "Lilikoi V2.0"
+  },
+  "limma": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/limma",
+    "route": "registry:bioconductor",
+    "matched": "limma"
+  },
+  "lipidlynxx": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "SysMedOs/LipidLynxX",
+    "route": "self_published",
+    "matched": "LipidLynxX"
+  },
+  "lipidmatch": {
+    "license": "CC-BY-4.0",
+    "license_detection": "license-file",
+    "repo_url": "GarrettLab-UF/LipidMatch",
+    "route": "self_published",
+    "matched": "lipidmatch"
+  },
+  "lipidr": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/ahmohamed/lipidr",
+    "route": "registry:bioconductor",
+    "matched": "lipidr"
+  },
+  "lipidspace": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "lifs-tools/lipidspace",
+    "route": "self_published",
+    "matched": "LipidSpace"
+  },
+  "lipoclean": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/stavis1/LipoCLEAN",
+    "route": "self_published",
+    "matched": "lipoclean"
+  },
+  "madbyte": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "liningtonlab/madbyte",
+    "route": "self_published",
+    "matched": "MADByTE"
+  },
+  "magma": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/NLeSC/MAGMa",
+    "route": "self_published",
+    "matched": "magma"
+  },
+  "maplet": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "krumsieklab/maplet",
+    "route": "self_published",
+    "matched": "maplet"
+  },
+  "marr": {
+    "license": "GPL-3.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Ghoshlab/marr",
+    "route": "registry:bioconductor",
+    "matched": "marr"
+  },
+  "mass2adduct": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/kbseah/mass2adduct",
+    "route": "self_published",
+    "matched": "mass2adduct"
+  },
+  "masscube": {
+    "license": "CC-BY-NC-4.0",
+    "license_detection": "license-file",
+    "repo_url": "huaxuyu/masscube",
+    "route": "self_published",
+    "matched": "MassCube"
+  },
+  "massdash": {
+    "license": "BSD-3-Clause",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/Roestlab/massdash",
+    "route": "registry:bioconda",
+    "matched": "massdash"
+  },
+  "massql": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "mwang87/MassQueryLanguage",
+    "route": "self_published",
+    "matched": "MassQL"
+  },
+  "massqlab": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "JohnsonDylan/MassQLab",
+    "route": "self_published",
+    "matched": "MassQLab"
+  },
+  "massspecwavelet": {
+    "license": "LGPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/zeehio/MassSpecWavelet",
+    "route": "registry:bioconductor",
+    "matched": "MassSpecWavelet"
+  },
+  "matchms": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/matchms/matchms",
+    "route": "registry:bioconda",
+    "matched": "matchms"
+  },
+  "mcfnmr": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "GeoMetabolomics-ICBM/mcfNMR",
+    "route": "self_published",
+    "matched": "mcfNMR"
+  },
+  "meister": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "richardxie1119/MEISTER",
+    "route": "self_published",
+    "matched": "MEISTER"
+  },
+  "metabcombiner": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://www.github.com/hhabra/metabCombiner",
+    "route": "registry:bioconductor",
+    "matched": "metabCombiner"
+  },
+  "metaboanalystr": {
+    "license": "GPL-3.0",
+    "license_detection": "license-file",
+    "repo_url": "xia-lab/MetaboAnalystR",
+    "route": "self_published",
+    "matched": "metaboanalystr"
+  },
+  "metaboannotator": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/gggraca/MetaboAnnotatoR",
+    "route": "registry:bioconductor",
+    "matched": "MetaboAnnotatoR",
+    "superseded": {
+      "license": "GPL-3.0",
+      "license_detection": "github-api"
+    }
+  },
+  "metabocoreutils": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/MetaboCoreUtils",
+    "route": "registry:bioconductor",
+    "matched": "MetaboCoreUtils"
+  },
+  "metabodirect": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/Coayala/MetaboDirect",
+    "route": "self_published",
+    "matched": "MetaboDirect"
+  },
+  "metabolabpy": {
+    "license": "GPL-3.0-or-later",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/ludwigc/metabolabpy",
+    "route": "registry:bioconda",
+    "matched": "metabolabpy",
+    "superseded": {
+      "license": "GPL-3.0",
+      "license_detection": "github-api"
+    }
+  },
+  "metaboprep": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "MRCIEU/metaboprep",
+    "route": "self_published",
+    "matched": "Metaboprep"
+  },
+  "metaboshiny": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "joannawolthuis/MetaboShiny",
+    "route": "self_published",
+    "matched": "MetaboShiny"
+  },
+  "metamapr": {
+    "license": "AGPL-3.0",
+    "license_detection": "license-file",
+    "repo_url": "dgrapov/MetaMapR",
+    "route": "self_published",
+    "matched": "MetaMapR"
+  },
+  "metams": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/yguitton/metaMS",
+    "route": "registry:bioconductor",
+    "matched": "metaMS"
+  },
+  "metanet": {
+    "license": "GPL-3.0-only",
+    "license_detection": "r-description",
+    "repo_url": "Asa12138/MetaNet",
+    "route": "self_published",
+    "matched": "MetaNet"
+  },
+  "metaxtract": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "Rappsilber-Laboratory/MetaXtract",
+    "route": "self_published",
+    "matched": "MetaXtract"
+  },
+  "metcohort": {
+    "license": "AGPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "JunYang2021/MetCohort",
+    "route": "self_published",
+    "matched": "MetCohort"
+  },
+  "metdatamodel": {
+    "license": "BSD-3-Clause",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/shuzhao-li/metDataModel",
+    "route": "registry:bioconda",
+    "matched": "metdatamodel"
+  },
+  "metfrag": {
+    "license": "LGPL-3.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "http://c-ruttkies.github.io/MetFrag/",
+    "route": "registry:bioconda",
+    "matched": "metfrag"
+  },
+  "metnet": {
+    "license": "GPL-3.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/MetNet",
+    "route": "registry:bioconductor",
+    "matched": "MetNet",
+    "superseded": {
+      "license": "LGPL-2.1",
+      "license_detection": "github-api"
+    }
+  },
+  "metscriber": {
+    "license": "GPL-2.0",
+    "license_detection": "github-api",
+    "repo_url": "ncats/metScribeR",
+    "route": "self_published",
+    "matched": "metScribeR"
+  },
+  "mimenet": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/YDaiLab/MiMeNet",
+    "route": "self_published",
+    "matched": "MiMeNet"
+  },
+  "minfer": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "cellbiomaths/MInfer",
+    "route": "self_published",
+    "matched": "MInfer"
+  },
+  "mist-cf": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/samgoldman97/mist-cf",
+    "route": "self_published",
+    "matched": "mistcf"
+  },
+  "mixomics": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/mixOmicsTeam/mixOmics",
+    "route": "registry:bioconductor",
+    "matched": "mixOmics"
+  },
+  "mobilitytransformr": {
+    "license": "Artistic-2.0",
+    "license_detection": "r-description",
+    "repo_url": "LiesaSalzer/MobilityTransformR",
+    "route": "self_published",
+    "matched": "MobilityTransformR"
+  },
+  "moccal": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/HinesLab/MOCCal",
+    "route": "self_published",
+    "matched": "moccal"
+  },
+  "moletrans": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "JibaoLiu/MoleTrans",
+    "route": "self_published",
+    "matched": "MoleTrans"
+  },
+  "molnotator": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "ZzakB/MolNotator",
+    "route": "self_published",
+    "matched": "MolNotator"
+  },
+  "ms-cleanr": {
+    "license": "GPL-3.0-only",
+    "license_detection": "r-description",
+    "repo_url": "eMetaboHUB/MS-CleanR",
+    "route": "self_published",
+    "matched": "MS-CleanR"
+  },
+  "ms-entropy": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/YuanyueLi/MSEntropy",
+    "route": "registry:bioconda",
+    "matched": "ms-entropy"
+  },
+  "ms2compound": {
+    "license": "CC-BY-4.0",
+    "license_detection": "github-api",
+    "repo_url": "beherasan/MS2Compound",
+    "route": "self_published",
+    "matched": "MS2Compound"
+  },
+  "ms2deepscore": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/matchms/ms2deepscore",
+    "route": "registry:bioconda",
+    "matched": "ms2deepscore"
+  },
+  "ms2lda": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "vdhooftcompmet/MS2LDA",
+    "route": "self_published",
+    "matched": "MS2LDA"
+  },
+  "ms2query": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/iomega/ms2query",
+    "route": "registry:bioconda",
+    "matched": "ms2query"
+  },
+  "msbackendmgf": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/MsBackendMgf",
+    "route": "registry:bioconductor",
+    "matched": "MsBackendMgf"
+  },
+  "msdatahub": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/MsDataHub",
+    "route": "registry:bioconductor",
+    "matched": "MsDataHub"
+  },
+  "msentropy": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/YuanyueLi/MSEntropy",
+    "route": "registry:bioconda",
+    "matched": "ms-entropy"
+  },
+  "msexperiment": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/MsExperiment",
+    "route": "registry:bioconductor",
+    "matched": "MsExperiment"
+  },
+  "msfeast": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "kevinmildau/msFeaST",
+    "route": "self_published",
+    "matched": "msFeaST"
+  },
+  "msfeatures": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/MsFeatures",
+    "route": "registry:bioconductor",
+    "matched": "MsFeatures"
+  },
+  "mshub": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "bittremieux/GNPS_GC",
+    "route": "self_published",
+    "matched": "mshub"
+  },
+  "msi-explorer": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "MMV-Lab/MSI-Explorer",
+    "route": "self_published",
+    "matched": "MSI-Explorer"
+  },
+  "msigen": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "LabLaskin/MSIGen",
+    "route": "self_published",
+    "matched": "MSIGen"
+  },
+  "msmetaenhancer": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/RECETOX/MSMetaEnhancer",
+    "route": "registry:bioconda",
+    "matched": "msmetaenhancer"
+  },
+  "msnbase": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/lgatto/MSnbase",
+    "route": "registry:bioconductor",
+    "matched": "MSnbase"
+  },
+  "msnovelist": {
+    "license": "AGPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "meowcat/MSNovelist",
+    "route": "self_published",
+    "matched": "MSNovelist"
+  },
+  "mspack": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "fhanau/mspack",
+    "route": "self_published",
+    "matched": "mspack"
+  },
+  "mspcompiler": {
+    "license": "MIT",
+    "license_detection": "r-description",
+    "repo_url": "https://github.com/QizhiSu/mspcompiler",
+    "route": "self_published",
+    "matched": "mspcompiler"
+  },
+  "multiassayexperiment": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/waldronlab/MultiAssayExperiment",
+    "route": "registry:bioconductor",
+    "matched": "MultiAssayExperiment"
+  },
+  "multtest": {
+    "license": "LGPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/multtest",
+    "route": "registry:bioconductor",
+    "matched": "multtest"
+  },
+  "mwise": {
+    "license": "GPL-3.0-only",
+    "license_detection": "r-description",
+    "repo_url": "b2slab/mWISE",
+    "route": "self_published",
+    "matched": "mWISE"
+  },
+  "mza": {
+    "license": "BSD-2-Clause",
+    "license_detection": "github-api",
+    "repo_url": "PNNL-m-q/mza",
+    "route": "self_published",
+    "matched": "MZA"
+  },
+  "mzmine": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/mzmine/mzmine",
+    "route": "registry:bioconda",
+    "matched": "mzmine"
+  },
+  "mzmine-2": {
+    "license": "GPL-2.0",
+    "license_detection": "github-api",
+    "repo_url": "mzmine/mzmine2",
+    "route": "self_published",
+    "matched": "mzmine2"
+  },
+  "mzmine2": {
+    "license": "GPL-2.0",
+    "license_detection": "github-api",
+    "repo_url": "mzmine/mzmine2",
+    "route": "self_published",
+    "matched": "mzmine2"
+  },
+  "mzquality": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/hankemeierlab/mzQuality",
+    "route": "self_published",
+    "matched": "mzquality"
+  },
+  "mzr": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/sneumann/mzR",
+    "route": "registry:bioconductor",
+    "matched": "mzR"
+  },
+  "mzrapp": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "YasinEl/mzRAPP",
+    "route": "self_published",
+    "matched": "mzRAPP"
+  },
+  "mzrtsim": {
+    "license": "GPL-2.0-only",
+    "license_detection": "r-description",
+    "repo_url": "yufree/mzrtsim",
+    "route": "self_published",
+    "matched": "mzrtsim"
+  },
+  "ncgtw": {
+    "license": "GPL-2.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/ChiungTingWu/ncGTW",
+    "route": "registry:bioconductor",
+    "matched": "ncGTW"
+  },
+  "neatms": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/bihealth/NeatMS",
+    "route": "registry:bioconda",
+    "matched": "neatms"
+  },
+  "nextflow": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/nextflow-io/nextflow",
+    "route": "registry:bioconda",
+    "matched": "nextflow"
+  },
+  "noreva": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "idrblab/NOREVA;",
+    "route": "self_published",
+    "matched": "NOREVA"
+  },
+  "normalizemets": {
+    "license": "GPL-3.0-only",
+    "license_detection": "r-description",
+    "repo_url": "metabolomicstats/NormalizeMets",
+    "route": "self_published",
+    "matched": "NormalizeMets"
+  },
+  "notame": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/hanhineva-lab/notame",
+    "route": "registry:bioconductor",
+    "matched": "notame"
+  },
+  "npanalyst": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/liningtonlab/npanalyst",
+    "route": "self_published",
+    "matched": "NP Analyst"
+  },
+  "nplinker": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "NPLinker/nplinker",
+    "route": "self_published",
+    "matched": "NPLinker"
+  },
+  "openms": {
+    "license": "BSD-3-Clause",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/OpenMS/OpenMS",
+    "route": "registry:bioconda",
+    "matched": "openms"
+  },
+  "opennau": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "zjuRong/openNAU",
+    "route": "self_published",
+    "matched": "OpenNAU"
+  },
+  "openpyxl": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "http://openpyxl.readthedocs.org",
+    "route": "registry:bioconda",
+    "matched": "openpyxl"
+  },
+  "pairkat": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Ghoshlab/pairkat",
+    "route": "registry:bioconductor",
+    "matched": "pairkat"
+  },
+  "paramounter": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "HuanLab/Paramounter",
+    "route": "self_published",
+    "matched": "Paramounter"
+  },
+  "patroon": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "rickhelmus/patRoon",
+    "route": "self_published",
+    "matched": "patRoon"
+  },
+  "pcamethods": {
+    "license": "GPL-3.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/hredestig/pcamethods",
+    "route": "registry:bioconductor",
+    "matched": "pcaMethods"
+  },
+  "peakqc": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/loosolab/PEAKQC",
+    "route": "registry:bioconda",
+    "matched": "peakqc",
+    "superseded": {
+      "license": "BSD-2-Clause",
+      "license_detection": "github-api"
+    }
+  },
+  "proteomm": {
+    "license": "MIT",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/ProteoMM",
+    "route": "registry:bioconductor",
+    "matched": "ProteoMM"
+  },
+  "psims": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/mobiusklein/psims",
+    "route": "registry:bioconda",
+    "matched": "psims"
+  },
+  "psm-utils": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/compomics/psm_utils",
+    "route": "registry:bioconda",
+    "matched": "psm-utils"
+  },
+  "pubchempy": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/mcs07/PubChemPy",
+    "route": "registry:bioconda",
+    "matched": "pubchempy"
+  },
+  "punc-data": {
+    "license": "AGPL-3.0",
+    "license_detection": "license-file",
+    "repo_url": "WTVoe/puncdata",
+    "route": "self_published",
+    "matched": "Punc’data"
+  },
+  "puncdata": {
+    "license": "AGPL-3.0",
+    "license_detection": "license-file",
+    "repo_url": "WTVoe/puncdata",
+    "route": "self_published",
+    "matched": "Punc’data"
+  },
+  "pyhmmer": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/althonos/pyhmmer",
+    "route": "registry:bioconda",
+    "matched": "pyhmmer"
+  },
+  "pyineta": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "edisonomics/PyINETA",
+    "route": "self_published",
+    "matched": "PyINETA"
+  },
+  "pymzml": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/pymzml/pymzML",
+    "route": "registry:bioconda",
+    "matched": "pymzml"
+  },
+  "pyopenms": {
+    "license": "BSD-3-Clause",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/OpenMS/OpenMS",
+    "route": "registry:bioconda",
+    "matched": "pyopenms"
+  },
+  "pyopenms-viz": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/OpenMS/pyopenms_viz",
+    "route": "self_published",
+    "matched": "pyopenmsviz"
+  },
+  "pyteomics": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/levitsky/pyteomics",
+    "route": "registry:bioconda",
+    "matched": "pyteomics"
+  },
+  "qcomics": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/ricoderks/QComics",
+    "route": "self_published",
+    "matched": "QComics"
+  },
+  "qcxms2": {
+    "license": "LGPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "grimme-lab/QCxMS2",
+    "route": "self_published",
+    "matched": "QCxMS2"
+  },
+  "rawrr": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/fgcz/rawrr",
+    "route": "registry:bioconductor",
+    "matched": "rawrr"
+  },
+  "rdkit": {
+    "license": "BSD",
+    "license_detection": "bioconda-package",
+    "repo_url": null,
+    "route": "registry:bioconda",
+    "matched": "rdkit"
+  },
+  "retip": {
+    "license": "CC-BY-4.0",
+    "license_detection": "r-description",
+    "repo_url": "oloBion/Retip",
+    "route": "self_published",
+    "matched": "Retip"
+  },
+  "rhdf5": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Huber-group-EMBL/rhdf5",
+    "route": "registry:bioconductor",
+    "matched": "rhdf5"
+  },
+  "roasmi": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "FangYuan717/ROASMI",
+    "route": "self_published",
+    "matched": "ROASMI"
+  },
+  "ruby": {
+    "license": "BSD",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://www.ruby-lang.org",
+    "route": "registry:bioconda",
+    "matched": "ruby"
+  },
+  "s4vectors": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Bioconductor/S4Vectors",
+    "route": "registry:bioconductor",
+    "matched": "S4Vectors"
+  },
+  "salmon": {
+    "license": "BSD-3-Clause",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/COMBINE-lab/salmon",
+    "route": "registry:bioconda",
+    "matched": "salmon"
+  },
+  "sand": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "edisonomics/SAND",
+    "route": "self_published",
+    "matched": "SAND"
+  },
+  "scannotation": {
+    "license": "MIT",
+    "license_detection": "license-file",
+    "repo_url": "scannotation/Scannotation_software",
+    "route": "self_published",
+    "matched": "Scannotation"
+  },
+  "simile": {
+    "license": "BSD-3-Clause",
+    "license_detection": "readme-llm",
+    "repo_url": "biorack/simile",
+    "route": "self_published",
+    "matched": "SIMILE"
+  },
+  "singularity": {
+    "license": "BSD",
+    "license_detection": "bioconda-package",
+    "repo_url": "http://singularity.lbl.gov",
+    "route": "registry:bioconda",
+    "matched": "singularity"
+  },
+  "sirius": {
+    "license": "AGPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "sirius-ms/sirius",
+    "route": "self_published",
+    "matched": "sirius"
+  },
+  "slaw": {
+    "license": "GPL-2.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/zamboni-lab/SLAW",
+    "route": "self_published",
+    "matched": "slaw"
+  },
+  "smartpeak": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "AutoFlowResearch/SmartPeak",
+    "route": "self_published",
+    "matched": "SmartPeak"
+  },
+  "smiter": {
+    "license": "MIT",
+    "license_detection": "github-api",
+    "repo_url": "LeidelLab/SMITER",
+    "route": "self_published",
+    "matched": "SMITER"
+  },
+  "snakemake": {
+    "license": "MIT",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/snakemake/snakemake",
+    "route": "registry:bioconda",
+    "matched": "snakemake"
+  },
+  "spatialmeta": {
+    "license": "BSD-3-Clause",
+    "license_detection": "github-api",
+    "repo_url": "WanluLiuLab/SpatialMETA",
+    "route": "self_published",
+    "matched": "SpatialMETA"
+  },
+  "spec2vec": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/iomega/spec2vec",
+    "route": "registry:bioconda",
+    "matched": "spec2vec"
+  },
+  "spectra": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/Spectra",
+    "route": "registry:bioconductor",
+    "matched": "Spectra"
+  },
+  "spectralentropy": {
+    "license": "Apache-2.0",
+    "license_detection": "github-api",
+    "repo_url": "YuanyueLi/SpectralEntropy",
+    "route": "self_published",
+    "matched": "Spectral entropy"
+  },
+  "spectripy": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/RforMassSpectrometry/SpectriPy",
+    "route": "registry:bioconductor",
+    "matched": "SpectriPy"
+  },
+  "spectrum-utils": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/bittremieux/spectrum_utils",
+    "route": "registry:bioconda",
+    "matched": "spectrum_utils"
+  },
+  "stattarget": {
+    "license": "LGPL-3.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/statTarget",
+    "route": "registry:bioconductor",
+    "matched": "statTarget"
+  },
+  "summarizedexperiment": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/Bioconductor/SummarizedExperiment",
+    "route": "registry:bioconductor",
+    "matched": "SummarizedExperiment"
+  },
+  "sva": {
+    "license": "Artistic-2.0",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/bioc/sva",
+    "route": "registry:bioconductor",
+    "matched": "sva"
+  },
+  "tardis": {
+    "license": "GPL-3.0",
+    "license_detection": "github-api",
+    "repo_url": "https://github.com/UGent-LIMET/TARDIS",
+    "route": "self_published",
+    "matched": "tardis"
+  },
+  "thermorawfileparser": {
+    "license": "Apache-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/compomics/ThermoRawFileParser",
+    "route": "registry:bioconda",
+    "matched": "thermorawfileparser"
+  },
+  "tqdm": {
+    "license": "MPL-2.0",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/tqdm/tqdm",
+    "route": "registry:bioconda",
+    "matched": "tqdm"
+  },
+  "trimgalore": {
+    "license": "GPL-3.0-only",
+    "license_detection": "bioconda-package",
+    "repo_url": "https://github.com/FelixKrueger/TrimGalore",
+    "route": "registry:bioconda",
+    "matched": "trim-galore"
+  },
+  "xcms": {
+    "license": "GPL-2.0-or-later",
+    "license_detection": "bioconductor-package",
+    "repo_url": "https://github.com/sneumann/xcms",
+    "route": "registry:bioconductor",
+    "matched": "xcms",
+    "superseded": {
+      "license": "LGPL-3.0",
+      "license_detection": "license-file"
+    }
+  }
+}

--- a/collections/metabolomics/v2/tools/10-5281-zenodo-4680579.yaml
+++ b/collections/metabolomics/v2/tools/10-5281-zenodo-4680579.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/adam-optimizer.yaml
+++ b/collections/metabolomics/v2/tools/adam-optimizer.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/adap.yaml
+++ b/collections/metabolomics/v2/tools/adap.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/adviselipidomics.yaml
+++ b/collections/metabolomics/v2/tools/adviselipidomics.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - ShinyFabio/ADViSELipidomics
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: ShinyFabio/ADViSELipidomics
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/aer.yaml
+++ b/collections/metabolomics/v2/tools/aer.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/aerith.yaml
+++ b/collections/metabolomics/v2/tools/aerith.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - thepanlab/Aerith
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/xyz1396/Aerith
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/agilent-1290-infinity-uhplc-system.yaml
+++ b/collections/metabolomics/v2/tools/agilent-1290-infinity-uhplc-system.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/agilent-6550-ifunnel-q-tof-mass-spectrometer.yaml
+++ b/collections/metabolomics/v2/tools/agilent-6550-ifunnel-q-tof-mass-spectrometer.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/agilent-masshunter.yaml
+++ b/collections/metabolomics/v2/tools/agilent-masshunter.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/agilent-q-tof-uhplc-hrms-ms.yaml
+++ b/collections/metabolomics/v2/tools/agilent-q-tof-uhplc-hrms-ms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/agilent-unknowns-analysis.yaml
+++ b/collections/metabolomics/v2/tools/agilent-unknowns-analysis.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/airdpro-v5.yaml
+++ b/collections/metabolomics/v2/tools/airdpro-v5.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/airdpro-v6.yaml
+++ b/collections/metabolomics/v2/tools/airdpro-v6.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/alphatims.yaml
+++ b/collections/metabolomics/v2/tools/alphatims.yaml
@@ -7,10 +7,11 @@ derived_from:
 - doi: 10.1021/acs.jproteome.4c00873
   title: pyopenmsviz
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/MannLabs/alphatims
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/alvadesc.yaml
+++ b/collections/metabolomics/v2/tools/alvadesc.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/amanida.yaml
+++ b/collections/metabolomics/v2/tools/amanida.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/anaconda.yaml
+++ b/collections/metabolomics/v2/tools/anaconda.yaml
@@ -29,6 +29,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ann-solo.yaml
+++ b/collections/metabolomics/v2/tools/ann-solo.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - bittremieux-lab/ANN-SoLo
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: bittremieux-lab/ANN-SoLo
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/annome.yaml
+++ b/collections/metabolomics/v2/tools/annome.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - chrboku/AnnoMe
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: chrboku/AnnoMe
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/antismash.yaml
+++ b/collections/metabolomics/v2/tools/antismash.yaml
@@ -21,10 +21,11 @@ source_repos:
 - NPLinker/nplinker
 - ablab/npdtools
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0-or-later
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/antismash/antismash
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/apache-maven-3-8.yaml
+++ b/collections/metabolomics/v2/tools/apache-maven-3-8.yaml
@@ -11,3 +11,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/appveyor.yaml
+++ b/collections/metabolomics/v2/tools/appveyor.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/arrow.yaml
+++ b/collections/metabolomics/v2/tools/arrow.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/asap-ms.yaml
+++ b/collections/metabolomics/v2/tools/asap-ms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/asari-mass-functions-module-nn-cluster-by-mz-seeds.yaml
+++ b/collections/metabolomics/v2/tools/asari-mass-functions-module-nn-cluster-by-mz-seeds.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs.yaml
+++ b/collections/metabolomics/v2/tools/asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/asari-peaks-module.yaml
+++ b/collections/metabolomics/v2/tools/asari-peaks-module.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/asari.yaml
+++ b/collections/metabolomics/v2/tools/asari.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ase-ani.yaml
+++ b/collections/metabolomics/v2/tools/ase-ani.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/asics.yaml
+++ b/collections/metabolomics/v2/tools/asics.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - GaelleLefort/ASICS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/ASICS
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/assign-hierarchy.yaml
+++ b/collections/metabolomics/v2/tools/assign-hierarchy.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/autoccs.yaml
+++ b/collections/metabolomics/v2/tools/autoccs.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - PNNL-Comp-Mass-Spec/AutoCCS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-2-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: PNNL-Comp-Mass-Spec/AutoCCS
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/autotuner.yaml
+++ b/collections/metabolomics/v2/tools/autotuner.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/avir-r.yaml
+++ b/collections/metabolomics/v2/tools/avir-r.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/aws-cli.yaml
+++ b/collections/metabolomics/v2/tools/aws-cli.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - meowcat/MSNovelist
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: null

--- a/collections/metabolomics/v2/tools/bago.yaml
+++ b/collections/metabolomics/v2/tools/bago.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/bam.yaml
+++ b/collections/metabolomics/v2/tools/bam.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/bart.yaml
+++ b/collections/metabolomics/v2/tools/bart.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/base64enc.yaml
+++ b/collections/metabolomics/v2/tools/base64enc.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/basicevaluationengine.yaml
+++ b/collections/metabolomics/v2/tools/basicevaluationengine.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/benjamini-hochberg-fdr-correction.yaml
+++ b/collections/metabolomics/v2/tools/benjamini-hochberg-fdr-correction.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/big-scape.yaml
+++ b/collections/metabolomics/v2/tools/big-scape.yaml
@@ -11,10 +11,11 @@ derived_from:
 source_repos:
 - NPLinker/nplinker
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0-or-later
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/medema-group/BiG-SCAPE
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/big-slice.yaml
+++ b/collections/metabolomics/v2/tools/big-slice.yaml
@@ -9,7 +9,8 @@ derived_from:
 source_repos:
 - medema-group/bigslice
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0-or-later
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/satriaphd/bigslice

--- a/collections/metabolomics/v2/tools/bigscape.yaml
+++ b/collections/metabolomics/v2/tools/bigscape.yaml
@@ -11,9 +11,10 @@ derived_from:
 source_repos:
 - NPLinker/nplinker
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0-or-later
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/medema-group/BiG-SCAPE
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/biobase.yaml
+++ b/collections/metabolomics/v2/tools/biobase.yaml
@@ -12,10 +12,11 @@ source_repos:
 - antonvsdata/notame
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Bioconductor/Biobase
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/biocmanager.yaml
+++ b/collections/metabolomics/v2/tools/biocmanager.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/bioconda.yaml
+++ b/collections/metabolomics/v2/tools/bioconda.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/bioconductor.yaml
+++ b/collections/metabolomics/v2/tools/bioconductor.yaml
@@ -35,6 +35,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/biocparallel.yaml
+++ b/collections/metabolomics/v2/tools/biocparallel.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/bioinformatic-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/bioinformatic-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/biosynfoni.yaml
+++ b/collections/metabolomics/v2/tools/biosynfoni.yaml
@@ -9,7 +9,8 @@ derived_from:
 source_repos:
 - lucinamay/biosynfoni
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: lucinamay/biosynfoni

--- a/collections/metabolomics/v2/tools/biotransformer.yaml
+++ b/collections/metabolomics/v2/tools/biotransformer.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/biotransformerapi.yaml
+++ b/collections/metabolomics/v2/tools/biotransformerapi.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/biotranslator.yaml
+++ b/collections/metabolomics/v2/tools/biotranslator.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/bitterpredict-m.yaml
+++ b/collections/metabolomics/v2/tools/bitterpredict-m.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/bitterpredict.yaml
+++ b/collections/metabolomics/v2/tools/bitterpredict.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/black.yaml
+++ b/collections/metabolomics/v2/tools/black.yaml
@@ -16,5 +16,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/blast.yaml
+++ b/collections/metabolomics/v2/tools/blast.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/bmxp.yaml
+++ b/collections/metabolomics/v2/tools/bmxp.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/bokeh.yaml
+++ b/collections/metabolomics/v2/tools/bokeh.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/bridgedb.yaml
+++ b/collections/metabolomics/v2/tools/bridgedb.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/bruker-q-tof-uhplc-hrms-ms.yaml
+++ b/collections/metabolomics/v2/tools/bruker-q-tof-uhplc-hrms-ms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/bruker-solarix.yaml
+++ b/collections/metabolomics/v2/tools/bruker-solarix.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/c.yaml
+++ b/collections/metabolomics/v2/tools/c.yaml
@@ -8,3 +8,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/calculator.yaml
+++ b/collections/metabolomics/v2/tools/calculator.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/camera.yaml
+++ b/collections/metabolomics/v2/tools/camera.yaml
@@ -12,10 +12,11 @@ source_repos:
 - LinShuhaiLAB/LipidIN
 - b2slab/mWISE
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/sneumann/CAMERA
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/canonical-correlation-analysis-cca.yaml
+++ b/collections/metabolomics/v2/tools/canonical-correlation-analysis-cca.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/canopus.yaml
+++ b/collections/metabolomics/v2/tools/canopus.yaml
@@ -18,6 +18,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cardinal.yaml
+++ b/collections/metabolomics/v2/tools/cardinal.yaml
@@ -20,10 +20,11 @@ source_repos:
 - kuwisdelu/Cardinal
 - swinnenteam/LipidQMap
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: kuwisdelu/Cardinal
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cardinalio.yaml
+++ b/collections/metabolomics/v2/tools/cardinalio.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/caret.yaml
+++ b/collections/metabolomics/v2/tools/caret.yaml
@@ -17,5 +17,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/casanovo.yaml
+++ b/collections/metabolomics/v2/tools/casanovo.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/cca-canonical-correlation-analysis.yaml
+++ b/collections/metabolomics/v2/tools/cca-canonical-correlation-analysis.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/centwave.yaml
+++ b/collections/metabolomics/v2/tools/centwave.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/cfm-id.yaml
+++ b/collections/metabolomics/v2/tools/cfm-id.yaml
@@ -22,6 +22,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/cfmid.yaml
+++ b/collections/metabolomics/v2/tools/cfmid.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/chambm-pwiz-skyline-i-agree-to-the-vendor-licenses.yaml
+++ b/collections/metabolomics/v2/tools/chambm-pwiz-skyline-i-agree-to-the-vendor-licenses.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/chebi.yaml
+++ b/collections/metabolomics/v2/tools/chebi.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/chem-spectra-app.yaml
+++ b/collections/metabolomics/v2/tools/chem-spectra-app.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/chemecho.yaml
+++ b/collections/metabolomics/v2/tools/chemecho.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/chemicalmixturefrommzml.yaml
+++ b/collections/metabolomics/v2/tools/chemicalmixturefrommzml.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/chemistry-development-kit-cdk.yaml
+++ b/collections/metabolomics/v2/tools/chemistry-development-kit-cdk.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/chemminer.yaml
+++ b/collections/metabolomics/v2/tools/chemminer.yaml
@@ -7,10 +7,11 @@ derived_from:
 - doi: 10.1371/journal.pone.0306202
   title: uafr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/girke-lab/ChemmineR
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/chemparse.yaml
+++ b/collections/metabolomics/v2/tools/chemparse.yaml
@@ -14,5 +14,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/chemprop-ir.yaml
+++ b/collections/metabolomics/v2/tools/chemprop-ir.yaml
@@ -6,9 +6,10 @@ derived_from:
 - doi: 10.1021/acs.jcim.1c00055
   title: Chemprop-IR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/gfm-collab/chemprop-IR
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/chemprop.yaml
+++ b/collections/metabolomics/v2/tools/chemprop.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/chemspider.yaml
+++ b/collections/metabolomics/v2/tools/chemspider.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS

--- a/collections/metabolomics/v2/tools/cir.yaml
+++ b/collections/metabolomics/v2/tools/cir.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/classyfire.yaml
+++ b/collections/metabolomics/v2/tools/classyfire.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/cliquems.yaml
+++ b/collections/metabolomics/v2/tools/cliquems.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - b2slab/mWISE
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/osenan/cliqueMS
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/clumsid.yaml
+++ b/collections/metabolomics/v2/tools/clumsid.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - LeaveMeNotTonight/CMDN
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/tdepke/CluMSID
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/clumsiddata.yaml
+++ b/collections/metabolomics/v2/tools/clumsiddata.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/clusterprofiler.yaml
+++ b/collections/metabolomics/v2/tools/clusterprofiler.yaml
@@ -12,10 +12,11 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - emosca-cnr/margheRita
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/YuLab-SMU/clusterProfiler
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cobrapy-for-optgpsampler-uniform-sampling.yaml
+++ b/collections/metabolomics/v2/tools/cobrapy-for-optgpsampler-uniform-sampling.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/cobrapy-optgpsampler-algorithm.yaml
+++ b/collections/metabolomics/v2/tools/cobrapy-optgpsampler-algorithm.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/cobrapy.yaml
+++ b/collections/metabolomics/v2/tools/cobrapy.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/coconut.yaml
+++ b/collections/metabolomics/v2/tools/coconut.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/cohen-s-kappa-metric.yaml
+++ b/collections/metabolomics/v2/tools/cohen-s-kappa-metric.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/color-jitter-augmentation.yaml
+++ b/collections/metabolomics/v2/tools/color-jitter-augmentation.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/combat.yaml
+++ b/collections/metabolomics/v2/tools/combat.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/commit.yaml
+++ b/collections/metabolomics/v2/tools/commit.yaml
@@ -7,7 +7,8 @@ derived_from:
 - doi: 10.1371/journal.pcbi.1009906
   title: COMMIT
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/pwendering/COMMIT

--- a/collections/metabolomics/v2/tools/commons-math3.yaml
+++ b/collections/metabolomics/v2/tools/commons-math3.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/comparador.yaml
+++ b/collections/metabolomics/v2/tools/comparador.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/comparems2.yaml
+++ b/collections/metabolomics/v2/tools/comparems2.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/complexheatmap.yaml
+++ b/collections/metabolomics/v2/tools/complexheatmap.yaml
@@ -14,10 +14,11 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - emosca-cnr/margheRita
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/jokergoo/ComplexHeatmap
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/compound-discoverer.yaml
+++ b/collections/metabolomics/v2/tools/compound-discoverer.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/conda.yaml
+++ b/collections/metabolomics/v2/tools/conda.yaml
@@ -49,6 +49,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/consensus-clustering.yaml
+++ b/collections/metabolomics/v2/tools/consensus-clustering.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/constraint-based-stoichiometric-metabolic-models.yaml
+++ b/collections/metabolomics/v2/tools/constraint-based-stoichiometric-metabolic-models.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/converterbuilder.yaml
+++ b/collections/metabolomics/v2/tools/converterbuilder.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/convolutional-neural-network-cnn.yaml
+++ b/collections/metabolomics/v2/tools/convolutional-neural-network-cnn.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/convolutional-neural-network.yaml
+++ b/collections/metabolomics/v2/tools/convolutional-neural-network.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/cordbat.yaml
+++ b/collections/metabolomics/v2/tools/cordbat.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - BorchLab/CordBat
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: BorchLab/CordBat
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/corems.yaml
+++ b/collections/metabolomics/v2/tools/corems.yaml
@@ -9,10 +9,11 @@ derived_from:
 - doi: 10.5281/zenodo.14009575
   title: corems
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-2-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/EMSL-Computing/CoreMS
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/cosine-neutral-loss-repository.yaml
+++ b/collections/metabolomics/v2/tools/cosine-neutral-loss-repository.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cosine-neutral-loss.yaml
+++ b/collections/metabolomics/v2/tools/cosine-neutral-loss.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cox-nnet.yaml
+++ b/collections/metabolomics/v2/tools/cox-nnet.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/cox-ph.yaml
+++ b/collections/metabolomics/v2/tools/cox-ph.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/cpat.yaml
+++ b/collections/metabolomics/v2/tools/cpat.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/crest.yaml
+++ b/collections/metabolomics/v2/tools/crest.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/csi-fingerid.yaml
+++ b/collections/metabolomics/v2/tools/csi-fingerid.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cts.yaml
+++ b/collections/metabolomics/v2/tools/cts.yaml
@@ -18,6 +18,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/cuda-toolkit.yaml
+++ b/collections/metabolomics/v2/tools/cuda-toolkit.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/cuda.yaml
+++ b/collections/metabolomics/v2/tools/cuda.yaml
@@ -26,6 +26,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cudnn.yaml
+++ b/collections/metabolomics/v2/tools/cudnn.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/curl.yaml
+++ b/collections/metabolomics/v2/tools/curl.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/cyclobranch.yaml
+++ b/collections/metabolomics/v2/tools/cyclobranch.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/cypreact.yaml
+++ b/collections/metabolomics/v2/tools/cypreact.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/cyproduct.yaml
+++ b/collections/metabolomics/v2/tools/cyproduct.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/cytoscape-js.yaml
+++ b/collections/metabolomics/v2/tools/cytoscape-js.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/cytoscape.yaml
+++ b/collections/metabolomics/v2/tools/cytoscape.yaml
@@ -28,6 +28,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/d3-js.yaml
+++ b/collections/metabolomics/v2/tools/d3-js.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/data-table.yaml
+++ b/collections/metabolomics/v2/tools/data-table.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/dbdipy.yaml
+++ b/collections/metabolomics/v2/tools/dbdipy.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - leopold-weidner/DBDIpy
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: readme-llm
+license_subject: tool
+repo_url: leopold-weidner/DBDIpy
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/dbnorm.yaml
+++ b/collections/metabolomics/v2/tools/dbnorm.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework.yaml
+++ b/collections/metabolomics/v2/tools/decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/decometdia.yaml
+++ b/collections/metabolomics/v2/tools/decometdia.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - ZhuMSLab/DecoMetDIA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: ZhuMSLab/DecoMetDIA
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/deepmass2.yaml
+++ b/collections/metabolomics/v2/tools/deepmass2.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/deimos.yaml
+++ b/collections/metabolomics/v2/tools/deimos.yaml
@@ -8,10 +8,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.1c05017
   title: deimos
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/pnnl/deimos
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/deoptim.yaml
+++ b/collections/metabolomics/v2/tools/deoptim.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/depthcharge.yaml
+++ b/collections/metabolomics/v2/tools/depthcharge.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/dereplicator.yaml
+++ b/collections/metabolomics/v2/tools/dereplicator.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - ablab/npdtools
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: readme-llm
+license_subject: tool
+repo_url: ablab/npdtools
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/deseq2.yaml
+++ b/collections/metabolomics/v2/tools/deseq2.yaml
@@ -9,7 +9,8 @@ derived_from:
 source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-3.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/thelovelab/DESeq2

--- a/collections/metabolomics/v2/tools/devtools.yaml
+++ b/collections/metabolomics/v2/tools/devtools.yaml
@@ -34,6 +34,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/dgl.yaml
+++ b/collections/metabolomics/v2/tools/dgl.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/di-ms.yaml
+++ b/collections/metabolomics/v2/tools/di-ms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/dia-nn.yaml
+++ b/collections/metabolomics/v2/tools/dia-nn.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/diffspectra.yaml
+++ b/collections/metabolomics/v2/tools/diffspectra.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - AzureLeon1/DiffSpectra
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: AzureLeon1/DiffSpectra
 techniques:
 - NMR
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/dimorphite-dl.yaml
+++ b/collections/metabolomics/v2/tools/dimorphite-dl.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/django.yaml
+++ b/collections/metabolomics/v2/tools/django.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/docker-compose.yaml
+++ b/collections/metabolomics/v2/tools/docker-compose.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/docker-desktop-for-mac.yaml
+++ b/collections/metabolomics/v2/tools/docker-desktop-for-mac.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/docker-docker-build-docker-inspect-docker-system-df.yaml
+++ b/collections/metabolomics/v2/tools/docker-docker-build-docker-inspect-docker-system-df.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/docker-engine.yaml
+++ b/collections/metabolomics/v2/tools/docker-engine.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/docker.yaml
+++ b/collections/metabolomics/v2/tools/docker.yaml
@@ -66,6 +66,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/dockerfile-multi-stage-build-with-target-flag.yaml
+++ b/collections/metabolomics/v2/tools/dockerfile-multi-stage-build-with-target-flag.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/doparallel.yaml
+++ b/collections/metabolomics/v2/tools/doparallel.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/dplyr.yaml
+++ b/collections/metabolomics/v2/tools/dplyr.yaml
@@ -26,6 +26,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/dropms.yaml
+++ b/collections/metabolomics/v2/tools/dropms.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/drugbank-extraction-py.yaml
+++ b/collections/metabolomics/v2/tools/drugbank-extraction-py.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/drugbank.yaml
+++ b/collections/metabolomics/v2/tools/drugbank.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/dures.yaml
+++ b/collections/metabolomics/v2/tools/dures.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - BiosystemEngineeringLab-IITB/dures
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: BiosystemEngineeringLab-IITB/dures
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/dynaconf.yaml
+++ b/collections/metabolomics/v2/tools/dynaconf.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/dynamic-time-warping-dtw.yaml
+++ b/collections/metabolomics/v2/tools/dynamic-time-warping-dtw.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/dynamictreecut.yaml
+++ b/collections/metabolomics/v2/tools/dynamictreecut.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/edger.yaml
+++ b/collections/metabolomics/v2/tools/edger.yaml
@@ -14,9 +14,10 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - ShinyFabio/ADViSELipidomics
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/edgeR
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/eflux.yaml
+++ b/collections/metabolomics/v2/tools/eflux.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/elastic-net-regression.yaml
+++ b/collections/metabolomics/v2/tools/elastic-net-regression.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/elastic-net.yaml
+++ b/collections/metabolomics/v2/tools/elastic-net.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/elemcor.yaml
+++ b/collections/metabolomics/v2/tools/elemcor.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - 4dsoftware/elemcor
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: 4dsoftware/elemcor
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/elementtree.yaml
+++ b/collections/metabolomics/v2/tools/elementtree.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/email-service.yaml
+++ b/collections/metabolomics/v2/tools/email-service.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/emperor.yaml
+++ b/collections/metabolomics/v2/tools/emperor.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/enpkg.yaml
+++ b/collections/metabolomics/v2/tools/enpkg.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/entropy-search.yaml
+++ b/collections/metabolomics/v2/tools/entropy-search.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/enveda-ccs-prediction-repository-model-code-and-pre-trained-weights.yaml
+++ b/collections/metabolomics/v2/tools/enveda-ccs-prediction-repository-model-code-and-pre-trained-weights.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/envipat.yaml
+++ b/collections/metabolomics/v2/tools/envipat.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/environment.yaml
+++ b/collections/metabolomics/v2/tools/environment.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/excalibur.yaml
+++ b/collections/metabolomics/v2/tools/excalibur.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/expressionset.yaml
+++ b/collections/metabolomics/v2/tools/expressionset.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/factoextra.yaml
+++ b/collections/metabolomics/v2/tools/factoextra.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/falcon.yaml
+++ b/collections/metabolomics/v2/tools/falcon.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1002/rcm.9153
   title: Large‐scale tandem mass spectrum clustering using fast nearest neighbor searching
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/bittremieuxlab/falcon
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/fastqc.yaml
+++ b/collections/metabolomics/v2/tools/fastqc.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/featurefindermetabo.yaml
+++ b/collections/metabolomics/v2/tools/featurefindermetabo.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/fella.yaml
+++ b/collections/metabolomics/v2/tools/fella.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - b2slab/mWISE
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/FELLA
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/fgsea.yaml
+++ b/collections/metabolomics/v2/tools/fgsea.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - biodatalab/enrichmet
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/alserglab/fgsea
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/fiddle.yaml
+++ b/collections/metabolomics/v2/tools/fiddle.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1038/s41467-025-66060-9
   title: fiddle
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/JosieHong/FIDDLE
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/figshare.yaml
+++ b/collections/metabolomics/v2/tools/figshare.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/filtering-augmentation.yaml
+++ b/collections/metabolomics/v2/tools/filtering-augmentation.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/fimo.yaml
+++ b/collections/metabolomics/v2/tools/fimo.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/fisher-s-exact-test.yaml
+++ b/collections/metabolomics/v2/tools/fisher-s-exact-test.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/flake8.yaml
+++ b/collections/metabolomics/v2/tools/flake8.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/flask.yaml
+++ b/collections/metabolomics/v2/tools/flask.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/flux-variability-analysis-fva.yaml
+++ b/collections/metabolomics/v2/tools/flux-variability-analysis-fva.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/flux-variability-analysis.yaml
+++ b/collections/metabolomics/v2/tools/flux-variability-analysis.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/fmcsr.yaml
+++ b/collections/metabolomics/v2/tools/fmcsr.yaml
@@ -7,10 +7,11 @@ derived_from:
 - doi: 10.1371/journal.pone.0306202
   title: uafr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/girke-lab/fmcsR
 techniques:
 - GC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/fnicm.yaml
+++ b/collections/metabolomics/v2/tools/fnicm.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - LiQi94/FNICM
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AFL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: LiQi94/FNICM

--- a/collections/metabolomics/v2/tools/foodmasst.yaml
+++ b/collections/metabolomics/v2/tools/foodmasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/formularity.yaml
+++ b/collections/metabolomics/v2/tools/formularity.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/freda.yaml
+++ b/collections/metabolomics/v2/tools/freda.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/future-apply.yaml
+++ b/collections/metabolomics/v2/tools/future-apply.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/future.yaml
+++ b/collections/metabolomics/v2/tools/future.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/galaxy-genomics-framework.yaml
+++ b/collections/metabolomics/v2/tools/galaxy-genomics-framework.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/galaxy.yaml
+++ b/collections/metabolomics/v2/tools/galaxy.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/gcims.yaml
+++ b/collections/metabolomics/v2/tools/gcims.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - sipss/GCIMS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: sipss/GCIMS
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/gensim.yaml
+++ b/collections/metabolomics/v2/tools/gensim.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/geodesic-interpolate.yaml
+++ b/collections/metabolomics/v2/tools/geodesic-interpolate.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/george.yaml
+++ b/collections/metabolomics/v2/tools/george.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - jcapelladesto/geoRge
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: jcapelladesto/geoRge
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/get-models-sh.yaml
+++ b/collections/metabolomics/v2/tools/get-models-sh.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/get-precmz-prodmz.yaml
+++ b/collections/metabolomics/v2/tools/get-precmz-prodmz.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/getfeatistics.yaml
+++ b/collections/metabolomics/v2/tools/getfeatistics.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - FrigerioGianfranco/GetFeatistics
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: FrigerioGianfranco/GetFeatistics
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ggplot.yaml
+++ b/collections/metabolomics/v2/tools/ggplot.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ggplot2.yaml
+++ b/collections/metabolomics/v2/tools/ggplot2.yaml
@@ -53,6 +53,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/git.yaml
+++ b/collections/metabolomics/v2/tools/git.yaml
@@ -42,6 +42,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/github-actions-workflow-ci-build-yml.yaml
+++ b/collections/metabolomics/v2/tools/github-actions-workflow-ci-build-yml.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/github-actions.yaml
+++ b/collections/metabolomics/v2/tools/github-actions.yaml
@@ -32,6 +32,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/github-com-bittremieux-cosine-neutral-loss.yaml
+++ b/collections/metabolomics/v2/tools/github-com-bittremieux-cosine-neutral-loss.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - CE-MS

--- a/collections/metabolomics/v2/tools/github-com-hassounlab-esp.yaml
+++ b/collections/metabolomics/v2/tools/github-com-hassounlab-esp.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/github-com-jlichtarge-pcaglasso.yaml
+++ b/collections/metabolomics/v2/tools/github-com-jlichtarge-pcaglasso.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/github-com-wanluliulab-spatialmeta.yaml
+++ b/collections/metabolomics/v2/tools/github-com-wanluliulab-spatialmeta.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/github-com-zsspython-lagf.yaml
+++ b/collections/metabolomics/v2/tools/github-com-zsspython-lagf.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/github-kbseah-mass2adduct.yaml
+++ b/collections/metabolomics/v2/tools/github-kbseah-mass2adduct.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/github.yaml
+++ b/collections/metabolomics/v2/tools/github.yaml
@@ -177,6 +177,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/gitlab.yaml
+++ b/collections/metabolomics/v2/tools/gitlab.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/gleams.yaml
+++ b/collections/metabolomics/v2/tools/gleams.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - bittremieux-lab/GLEAMS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: bittremieux-lab/GLEAMS
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/gnps-gc.yaml
+++ b/collections/metabolomics/v2/tools/gnps-gc.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/gnps-lcms-visualization-dashboard.yaml
+++ b/collections/metabolomics/v2/tools/gnps-lcms-visualization-dashboard.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/gnps-masst.yaml
+++ b/collections/metabolomics/v2/tools/gnps-masst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/gnps-molecular-networking.yaml
+++ b/collections/metabolomics/v2/tools/gnps-molecular-networking.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/gnps-spectral-libraries.yaml
+++ b/collections/metabolomics/v2/tools/gnps-spectral-libraries.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/gnps-spectral-networking-molecular-networking.yaml
+++ b/collections/metabolomics/v2/tools/gnps-spectral-networking-molecular-networking.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/gnps.yaml
+++ b/collections/metabolomics/v2/tools/gnps.yaml
@@ -58,6 +58,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/gnps2.yaml
+++ b/collections/metabolomics/v2/tools/gnps2.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/gnuplot.yaml
+++ b/collections/metabolomics/v2/tools/gnuplot.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/google-chrome.yaml
+++ b/collections/metabolomics/v2/tools/google-chrome.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/google-colab.yaml
+++ b/collections/metabolomics/v2/tools/google-colab.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/google-colaboratory.yaml
+++ b/collections/metabolomics/v2/tools/google-colaboratory.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/graph-neural-network-gnn-framework-pytorch-geometric-or-equivalent.yaml
+++ b/collections/metabolomics/v2/tools/graph-neural-network-gnn-framework-pytorch-geometric-or-equivalent.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/graphical-time-warping-gtw.yaml
+++ b/collections/metabolomics/v2/tools/graphical-time-warping-gtw.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/graphormer.yaml
+++ b/collections/metabolomics/v2/tools/graphormer.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/grid.yaml
+++ b/collections/metabolomics/v2/tools/grid.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/gunicorn.yaml
+++ b/collections/metabolomics/v2/tools/gunicorn.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/gx-fba.yaml
+++ b/collections/metabolomics/v2/tools/gx-fba.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/h2o.yaml
+++ b/collections/metabolomics/v2/tools/h2o.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/h5py-2-7-1.yaml
+++ b/collections/metabolomics/v2/tools/h5py-2-7-1.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/h5py.yaml
+++ b/collections/metabolomics/v2/tools/h5py.yaml
@@ -28,6 +28,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/hacca.yaml
+++ b/collections/metabolomics/v2/tools/hacca.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/hassounlab-bam.yaml
+++ b/collections/metabolomics/v2/tools/hassounlab-bam.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent.yaml
+++ b/collections/metabolomics/v2/tools/hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/hdf5.yaml
+++ b/collections/metabolomics/v2/tools/hdf5.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/hdf5plugin.yaml
+++ b/collections/metabolomics/v2/tools/hdf5plugin.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/hierarchical-clustering-euclidean-distance-complete-linkage.yaml
+++ b/collections/metabolomics/v2/tools/hierarchical-clustering-euclidean-distance-complete-linkage.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/hineslab-moccal.yaml
+++ b/collections/metabolomics/v2/tools/hineslab-moccal.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - CE-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/hmdb-4.yaml
+++ b/collections/metabolomics/v2/tools/hmdb-4.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/hmdb.yaml
+++ b/collections/metabolomics/v2/tools/hmdb.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/hnswlib.yaml
+++ b/collections/metabolomics/v2/tools/hnswlib.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/homebrew.yaml
+++ b/collections/metabolomics/v2/tools/homebrew.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/hruv.yaml
+++ b/collections/metabolomics/v2/tools/hruv.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - SydneyBioX/hRUV
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: SydneyBioX/hRUV
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/html.yaml
+++ b/collections/metabolomics/v2/tools/html.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/htseq-v-0-6-1.yaml
+++ b/collections/metabolomics/v2/tools/htseq-v-0-6-1.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/https-doi-org-10-5281-zenodo-11243781.yaml
+++ b/collections/metabolomics/v2/tools/https-doi-org-10-5281-zenodo-11243781.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/https-github-com-emosca-cnr-margherita.yaml
+++ b/collections/metabolomics/v2/tools/https-github-com-emosca-cnr-margherita.yaml
@@ -14,3 +14,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/https-github-com-sdrogers-nplinker.yaml
+++ b/collections/metabolomics/v2/tools/https-github-com-sdrogers-nplinker.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/https-github-com-shuzhao-li-asari.yaml
+++ b/collections/metabolomics/v2/tools/https-github-com-shuzhao-li-asari.yaml
@@ -14,3 +14,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/hugging-face-transformers.yaml
+++ b/collections/metabolomics/v2/tools/hugging-face-transformers.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/human-metabolome-database-hmdb.yaml
+++ b/collections/metabolomics/v2/tools/human-metabolome-database-hmdb.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/hyperspec.yaml
+++ b/collections/metabolomics/v2/tools/hyperspec.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - wh-xu/Hyper-Spec
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: wh-xu/Hyper-Spec
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/i-van-krevelen.yaml
+++ b/collections/metabolomics/v2/tools/i-van-krevelen.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/iceberg-model.yaml
+++ b/collections/metabolomics/v2/tools/iceberg-model.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/iceberg-webui.yaml
+++ b/collections/metabolomics/v2/tools/iceberg-webui.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/iceberg.yaml
+++ b/collections/metabolomics/v2/tools/iceberg.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/idsl-csa.yaml
+++ b/collections/metabolomics/v2/tools/idsl-csa.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - idslme/IDSL.CSA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: idslme/IDSL.CSA
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/idsl-ipa.yaml
+++ b/collections/metabolomics/v2/tools/idsl-ipa.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/idsl-ufa.yaml
+++ b/collections/metabolomics/v2/tools/idsl-ufa.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - idslme/IDSL.UFA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: idslme/IDSL.UFA
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/idsm.yaml
+++ b/collections/metabolomics/v2/tools/idsm.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/igraph.yaml
+++ b/collections/metabolomics/v2/tools/igraph.yaml
@@ -23,6 +23,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/image-processing-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/image-processing-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/impute.yaml
+++ b/collections/metabolomics/v2/tools/impute.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/impute

--- a/collections/metabolomics/v2/tools/imzml-writer.yaml
+++ b/collections/metabolomics/v2/tools/imzml-writer.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - VIU-Metabolomics/imzML_Writer
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: VIU-Metabolomics/imzML_Writer
 techniques:
 - MS-imaging
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/independentmassspectrometer.yaml
+++ b/collections/metabolomics/v2/tools/independentmassspectrometer.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/injectiondesign.yaml
+++ b/collections/metabolomics/v2/tools/injectiondesign.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS

--- a/collections/metabolomics/v2/tools/intensity-dependent-missing-value-augmentation.yaml
+++ b/collections/metabolomics/v2/tools/intensity-dependent-missing-value-augmentation.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/interactiveplotter.yaml
+++ b/collections/metabolomics/v2/tools/interactiveplotter.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/interactivetwodimensionplotter.yaml
+++ b/collections/metabolomics/v2/tools/interactivetwodimensionplotter.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/interpretmsspectrum.yaml
+++ b/collections/metabolomics/v2/tools/interpretmsspectrum.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/iokr.yaml
+++ b/collections/metabolomics/v2/tools/iokr.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ion-identity.yaml
+++ b/collections/metabolomics/v2/tools/ion-identity.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/ionflow.yaml
+++ b/collections/metabolomics/v2/tools/ionflow.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/iontoolpack.yaml
+++ b/collections/metabolomics/v2/tools/iontoolpack.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/ipapy2.yaml
+++ b/collections/metabolomics/v2/tools/ipapy2.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - francescodc87/ipaPy2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/francescodc87/ipaPy2
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ipbhalle-metfragweb.yaml
+++ b/collections/metabolomics/v2/tools/ipbhalle-metfragweb.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/ipresto.yaml
+++ b/collections/metabolomics/v2/tools/ipresto.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/isfrag.yaml
+++ b/collections/metabolomics/v2/tools/isfrag.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - HuanLab/ISFrag
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: HuanLab/ISFrag
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/isoformswitchanalyzer.yaml
+++ b/collections/metabolomics/v2/tools/isoformswitchanalyzer.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/kvittingseerup/IsoformSwitchAnalyzeR

--- a/collections/metabolomics/v2/tools/isofusion.yaml
+++ b/collections/metabolomics/v2/tools/isofusion.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - xfcui/IsoFusion
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: xfcui/IsoFusion
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/isopairfinder.yaml
+++ b/collections/metabolomics/v2/tools/isopairfinder.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/isoscan.yaml
+++ b/collections/metabolomics/v2/tools/isoscan.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - jcapelladesto/isoSCAN
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: jcapelladesto/isoSCAN
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/java-21.yaml
+++ b/collections/metabolomics/v2/tools/java-21.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/java.yaml
+++ b/collections/metabolomics/v2/tools/java.yaml
@@ -16,5 +16,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/javafx-24.yaml
+++ b/collections/metabolomics/v2/tools/javafx-24.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/javascript.yaml
+++ b/collections/metabolomics/v2/tools/javascript.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/javax-faces-2-2-12-jar.yaml
+++ b/collections/metabolomics/v2/tools/javax-faces-2-2-12-jar.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/jdk-25.yaml
+++ b/collections/metabolomics/v2/tools/jdk-25.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/jfreechart.yaml
+++ b/collections/metabolomics/v2/tools/jfreechart.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/jms.yaml
+++ b/collections/metabolomics/v2/tools/jms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/joblib.yaml
+++ b/collections/metabolomics/v2/tools/joblib.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/jopt-simple.yaml
+++ b/collections/metabolomics/v2/tools/jopt-simple.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/jorhelp-docker-image.yaml
+++ b/collections/metabolomics/v2/tools/jorhelp-docker-image.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/jpa-r-package.yaml
+++ b/collections/metabolomics/v2/tools/jpa-r-package.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/jpa.yaml
+++ b/collections/metabolomics/v2/tools/jpa.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - HuanLab/JPA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: HuanLab/JPA
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/jsonschema.yaml
+++ b/collections/metabolomics/v2/tools/jsonschema.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/jupyter-lab.yaml
+++ b/collections/metabolomics/v2/tools/jupyter-lab.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/jupyter-notebook.yaml
+++ b/collections/metabolomics/v2/tools/jupyter-notebook.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/jupyter-notebooks.yaml
+++ b/collections/metabolomics/v2/tools/jupyter-notebooks.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/jupyter.yaml
+++ b/collections/metabolomics/v2/tools/jupyter.yaml
@@ -18,6 +18,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/kableextra.yaml
+++ b/collections/metabolomics/v2/tools/kableextra.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/kaleido.yaml
+++ b/collections/metabolomics/v2/tools/kaleido.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/kegg-database.yaml
+++ b/collections/metabolomics/v2/tools/kegg-database.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/kegg.yaml
+++ b/collections/metabolomics/v2/tools/kegg.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/keggrest.yaml
+++ b/collections/metabolomics/v2/tools/keggrest.yaml
@@ -16,10 +16,11 @@ source_repos:
 - biodatalab/enrichmet
 - connor-reid-tiffany/Omu
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Bioconductor/KEGGREST
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/keras-2-2-0.yaml
+++ b/collections/metabolomics/v2/tools/keras-2-2-0.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/keras.yaml
+++ b/collections/metabolomics/v2/tools/keras.yaml
@@ -30,6 +30,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/khipu.yaml
+++ b/collections/metabolomics/v2/tools/khipu.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/knime.yaml
+++ b/collections/metabolomics/v2/tools/knime.yaml
@@ -18,6 +18,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/knitr.yaml
+++ b/collections/metabolomics/v2/tools/knitr.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/largemetabo.yaml
+++ b/collections/metabolomics/v2/tools/largemetabo.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - LargeMetabo/LargeMetabo
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: LargeMetabo/LargeMetabo
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/latent-dirichlet-allocation-lda.yaml
+++ b/collections/metabolomics/v2/tools/latent-dirichlet-allocation-lda.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lcmsworld.yaml
+++ b/collections/metabolomics/v2/tools/lcmsworld.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - PGB-LIV/lcmsWorld
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: PGB-LIV/lcmsWorld
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/lda-latent-dirichlet-allocation.yaml
+++ b/collections/metabolomics/v2/tools/lda-latent-dirichlet-allocation.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lib2nist.yaml
+++ b/collections/metabolomics/v2/tools/lib2nist.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lilikoi-v2-0.yaml
+++ b/collections/metabolomics/v2/tools/lilikoi-v2-0.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - lanagarmire/lilikoi2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: lanagarmire/lilikoi2
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/limma.yaml
+++ b/collections/metabolomics/v2/tools/limma.yaml
@@ -24,10 +24,11 @@ source_repos:
 - idrblab/NOREVA;
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/limma
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lipid-map.yaml
+++ b/collections/metabolomics/v2/tools/lipid-map.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lipid-maps.yaml
+++ b/collections/metabolomics/v2/tools/lipid-maps.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/lipidlynxx.yaml
+++ b/collections/metabolomics/v2/tools/lipidlynxx.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - SysMedOs/LipidLynxX
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: SysMedOs/LipidLynxX

--- a/collections/metabolomics/v2/tools/lipidmatch.yaml
+++ b/collections/metabolomics/v2/tools/lipidmatch.yaml
@@ -13,10 +13,11 @@ source_repos:
 - GarrettLab-UF/LipidMatch
 - InnovativeOmics/Core-Match
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: CC-BY-4.0
+license_detection: license-file
+license_subject: tool
+repo_url: GarrettLab-UF/LipidMatch
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/lipidqmap.yaml
+++ b/collections/metabolomics/v2/tools/lipidqmap.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/lipidr.yaml
+++ b/collections/metabolomics/v2/tools/lipidr.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - ahmohamed/lipidr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/ahmohamed/lipidr
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/lipidsearch.yaml
+++ b/collections/metabolomics/v2/tools/lipidsearch.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/lipidspace.yaml
+++ b/collections/metabolomics/v2/tools/lipidspace.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - lifs-tools/lipidspace
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: lifs-tools/lipidspace

--- a/collections/metabolomics/v2/tools/lipoclean.yaml
+++ b/collections/metabolomics/v2/tools/lipoclean.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.4c04040
   title: lipoclean
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/stavis1/LipoCLEAN
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/liquid.yaml
+++ b/collections/metabolomics/v2/tools/liquid.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/lme4.yaml
+++ b/collections/metabolomics/v2/tools/lme4.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/local-code-artifact.yaml
+++ b/collections/metabolomics/v2/tools/local-code-artifact.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/lotus-database.yaml
+++ b/collections/metabolomics/v2/tools/lotus-database.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/lowess.yaml
+++ b/collections/metabolomics/v2/tools/lowess.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/lsg-lipid-spectrum-generator.yaml
+++ b/collections/metabolomics/v2/tools/lsg-lipid-spectrum-generator.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/lsg.yaml
+++ b/collections/metabolomics/v2/tools/lsg.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/madbyte.yaml
+++ b/collections/metabolomics/v2/tools/madbyte.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - liningtonlab/madbyte
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: liningtonlab/madbyte
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/mag-mass2motif-annotation-guidance.yaml
+++ b/collections/metabolomics/v2/tools/mag-mass2motif-annotation-guidance.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mag.yaml
+++ b/collections/metabolomics/v2/tools/mag.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/magma.yaml
+++ b/collections/metabolomics/v2/tools/magma.yaml
@@ -7,10 +7,11 @@ derived_from:
 - doi: 10.5702/massspectrometry.S0033
   title: magma
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/NLeSC/MAGMa
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/magrittr.yaml
+++ b/collections/metabolomics/v2/tools/magrittr.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/make.yaml
+++ b/collections/metabolomics/v2/tools/make.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mamsi-mamsistructsearch.yaml
+++ b/collections/metabolomics/v2/tools/mamsi-mamsistructsearch.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mamsistructsearch.yaml
+++ b/collections/metabolomics/v2/tools/mamsistructsearch.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/mann-whitney-u-test.yaml
+++ b/collections/metabolomics/v2/tools/mann-whitney-u-test.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/manual-expert-review.yaml
+++ b/collections/metabolomics/v2/tools/manual-expert-review.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/maplet.yaml
+++ b/collections/metabolomics/v2/tools/maplet.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - krumsieklab/maplet
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: krumsieklab/maplet

--- a/collections/metabolomics/v2/tools/margherita.yaml
+++ b/collections/metabolomics/v2/tools/margherita.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mariadb-10.yaml
+++ b/collections/metabolomics/v2/tools/mariadb-10.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/marr.yaml
+++ b/collections/metabolomics/v2/tools/marr.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - Ghoshlab/marr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Ghoshlab/marr
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mascot-generic-format-mgf.yaml
+++ b/collections/metabolomics/v2/tools/mascot-generic-format-mgf.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/mass-functions-nn-cluster-by-mz-seeds.yaml
+++ b/collections/metabolomics/v2/tools/mass-functions-nn-cluster-by-mz-seeds.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/mass-query-language-massql.yaml
+++ b/collections/metabolomics/v2/tools/mass-query-language-massql.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mass2adduct.yaml
+++ b/collections/metabolomics/v2/tools/mass2adduct.yaml
@@ -10,10 +10,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.0c04720
   title: Determination of Abundant Metabolite Matrix Adducts Illuminates the Dark Metabolome of MALDI-Mass Spectrometry Imaging Datasets
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/kbseah/mass2adduct
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/mass2chem.yaml
+++ b/collections/metabolomics/v2/tools/mass2chem.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/massbank-web-validator.yaml
+++ b/collections/metabolomics/v2/tools/massbank-web-validator.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/massbank-web.yaml
+++ b/collections/metabolomics/v2/tools/massbank-web.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/massbank.yaml
+++ b/collections/metabolomics/v2/tools/massbank.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/masscube.yaml
+++ b/collections/metabolomics/v2/tools/masscube.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - huaxuyu/masscube
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: noncommercial
+license: CC-BY-NC-4.0
+license_detection: license-file
+license_subject: tool
+repo_url: huaxuyu/masscube
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/massdash-loaders-resultsloader.yaml
+++ b/collections/metabolomics/v2/tools/massdash-loaders-resultsloader.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massdash-peakpickers-mrmtransitiongrouppicker.yaml
+++ b/collections/metabolomics/v2/tools/massdash-peakpickers-mrmtransitiongrouppicker.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massdash-peakpickers-pymrmtransitiongrouppicker.yaml
+++ b/collections/metabolomics/v2/tools/massdash-peakpickers-pymrmtransitiongrouppicker.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massdash-plotting-interactiveplotter.yaml
+++ b/collections/metabolomics/v2/tools/massdash-plotting-interactiveplotter.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massdash-structs-featuremap.yaml
+++ b/collections/metabolomics/v2/tools/massdash-structs-featuremap.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massdash.yaml
+++ b/collections/metabolomics/v2/tools/massdash.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - Roestlab/massdash
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/Roestlab/massdash
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/masshunter-profinder.yaml
+++ b/collections/metabolomics/v2/tools/masshunter-profinder.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massive.yaml
+++ b/collections/metabolomics/v2/tools/massive.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/massql.yaml
+++ b/collections/metabolomics/v2/tools/massql.yaml
@@ -16,10 +16,11 @@ source_repos:
 - mwang87/MassQueryLanguage
 - vdhooftcompmet/MS2LDA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: mwang87/MassQueryLanguage
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/massqlab.yaml
+++ b/collections/metabolomics/v2/tools/massqlab.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - JohnsonDylan/MassQLab
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: JohnsonDylan/MassQLab
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/massspecwavelet.yaml
+++ b/collections/metabolomics/v2/tools/massspecwavelet.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/zeehio/MassSpecWavelet
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/masst.yaml
+++ b/collections/metabolomics/v2/tools/masst.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/matchms.yaml
+++ b/collections/metabolomics/v2/tools/matchms.yaml
@@ -28,10 +28,11 @@ source_repos:
 - matchms/matchms
 - tingxiecsu/CSU-MS2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/matchms/matchms
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/math-distance.yaml
+++ b/collections/metabolomics/v2/tools/math-distance.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/matlab-compiler-runtime-8-3.yaml
+++ b/collections/metabolomics/v2/tools/matlab-compiler-runtime-8-3.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/matlab-r2024a.yaml
+++ b/collections/metabolomics/v2/tools/matlab-r2024a.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/matlab.yaml
+++ b/collections/metabolomics/v2/tools/matlab.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/matplotlib-or-seaborn-for-visualization.yaml
+++ b/collections/metabolomics/v2/tools/matplotlib-or-seaborn-for-visualization.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/matplotlib.yaml
+++ b/collections/metabolomics/v2/tools/matplotlib.yaml
@@ -42,6 +42,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/maven-gui.yaml
+++ b/collections/metabolomics/v2/tools/maven-gui.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/maxquant.yaml
+++ b/collections/metabolomics/v2/tools/maxquant.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/mbpls.yaml
+++ b/collections/metabolomics/v2/tools/mbpls.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mcfnmr.yaml
+++ b/collections/metabolomics/v2/tools/mcfnmr.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - GeoMetabolomics-ICBM/mcfNMR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: GeoMetabolomics-ICBM/mcfNMR
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/meister.yaml
+++ b/collections/metabolomics/v2/tools/meister.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - richardxie1119/MEISTER
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: richardxie1119/MEISTER
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/melonnpan-elastic-net-linear-regression.yaml
+++ b/collections/metabolomics/v2/tools/melonnpan-elastic-net-linear-regression.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/melonnpan.yaml
+++ b/collections/metabolomics/v2/tools/melonnpan.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/memo-ms.yaml
+++ b/collections/metabolomics/v2/tools/memo-ms.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/memo.yaml
+++ b/collections/metabolomics/v2/tools/memo.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mergeion2.yaml
+++ b/collections/metabolomics/v2/tools/mergeion2.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/messes.yaml
+++ b/collections/metabolomics/v2/tools/messes.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/metabcombiner.yaml
+++ b/collections/metabolomics/v2/tools/metabcombiner.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - hhabra/metabCombiner
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://www.github.com/hhabra/metabCombiner
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/metaboanalyst.yaml
+++ b/collections/metabolomics/v2/tools/metaboanalyst.yaml
@@ -27,6 +27,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metaboanalystr.yaml
+++ b/collections/metabolomics/v2/tools/metaboanalystr.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - xia-lab/MetaboAnalystR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: license-file
+license_subject: tool
+repo_url: xia-lab/MetaboAnalystR
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/metaboannotator.yaml
+++ b/collections/metabolomics/v2/tools/metaboannotator.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.1c03032
   title: Automated Annotation of Untargeted All-Ion Fragmentation LC–MS Metabolomics Data with MetaboAnnotatoR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/gggraca/MetaboAnnotatoR
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/metabocoreutils.yaml
+++ b/collections/metabolomics/v2/tools/metabocoreutils.yaml
@@ -12,10 +12,11 @@ source_repos:
 - LiesaSalzer/MobilityTransformR
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/MetaboCoreUtils
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metabodiff.yaml
+++ b/collections/metabolomics/v2/tools/metabodiff.yaml
@@ -14,3 +14,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/metabodirect.yaml
+++ b/collections/metabolomics/v2/tools/metabodirect.yaml
@@ -12,10 +12,11 @@ derived_from:
 - doi: 10.1186/s40168-023-01476-3
   title: MetaboDirect
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/Coayala/MetaboDirect
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metabolabpy.yaml
+++ b/collections/metabolomics/v2/tools/metabolabpy.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - ludwigc/metabolabpy
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-or-later
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/ludwigc/metabolabpy
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/metabolights.yaml
+++ b/collections/metabolomics/v2/tools/metabolights.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/metabolomics-workbench-api.yaml
+++ b/collections/metabolomics/v2/tools/metabolomics-workbench-api.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/metabolomics-workbench.yaml
+++ b/collections/metabolomics/v2/tools/metabolomics-workbench.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/metaboprep.yaml
+++ b/collections/metabolomics/v2/tools/metaboprep.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - MRCIEU/metaboprep
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: MRCIEU/metaboprep
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/metaboshiny.yaml
+++ b/collections/metabolomics/v2/tools/metaboshiny.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - joannawolthuis/MetaboShiny
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: joannawolthuis/MetaboShiny
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metaclean.yaml
+++ b/collections/metabolomics/v2/tools/metaclean.yaml
@@ -14,5 +14,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/metadatamasst.yaml
+++ b/collections/metabolomics/v2/tools/metadatamasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/metamapr.yaml
+++ b/collections/metabolomics/v2/tools/metamapr.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - dgrapov/MetaMapR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: license-file
+license_subject: tool
+repo_url: dgrapov/MetaMapR

--- a/collections/metabolomics/v2/tools/metaminer.yaml
+++ b/collections/metabolomics/v2/tools/metaminer.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/metams.yaml
+++ b/collections/metabolomics/v2/tools/metams.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - HuanLab/DaDIA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/yguitton/metaMS
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metanet.yaml
+++ b/collections/metabolomics/v2/tools/metanet.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - Asa12138/MetaNet
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: Asa12138/MetaNet
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/metanorm-r-package.yaml
+++ b/collections/metabolomics/v2/tools/metanorm-r-package.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/metanorm.yaml
+++ b/collections/metabolomics/v2/tools/metanorm.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/metaxtract.yaml
+++ b/collections/metabolomics/v2/tools/metaxtract.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - Rappsilber-Laboratory/MetaXtract
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: Rappsilber-Laboratory/MetaXtract
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/metcohort.yaml
+++ b/collections/metabolomics/v2/tools/metcohort.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - JunYang2021/MetCohort
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: JunYang2021/MetCohort
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/metcorr.yaml
+++ b/collections/metabolomics/v2/tools/metcorr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metdatamodel.yaml
+++ b/collections/metabolomics/v2/tools/metdatamodel.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - shuzhao-li-lab/khipu
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/shuzhao-li/metDataModel
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metdna2-r-package.yaml
+++ b/collections/metabolomics/v2/tools/metdna2-r-package.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/meteor.yaml
+++ b/collections/metabolomics/v2/tools/meteor.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/metfrag.yaml
+++ b/collections/metabolomics/v2/tools/metfrag.yaml
@@ -24,10 +24,11 @@ source_repos:
 - rickhelmus/patRoon
 - zmahnoor14/MAW
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-3.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: http://c-ruttkies.github.io/MetFrag/
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/metnet.yaml
+++ b/collections/metabolomics/v2/tools/metnet.yaml
@@ -9,7 +9,8 @@ derived_from:
 source_repos:
 - simeoni-biolab/MetNet
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/MetNet

--- a/collections/metabolomics/v2/tools/metscriber.yaml
+++ b/collections/metabolomics/v2/tools/metscriber.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - ncats/metScribeR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: ncats/metScribeR
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/mgcv.yaml
+++ b/collections/metabolomics/v2/tools/mgcv.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mibig.yaml
+++ b/collections/metabolomics/v2/tools/mibig.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/microbemasst.yaml
+++ b/collections/metabolomics/v2/tools/microbemasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/microbiomemasst.yaml
+++ b/collections/metabolomics/v2/tools/microbiomemasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/microsoft-visual-c-runtime-x64.yaml
+++ b/collections/metabolomics/v2/tools/microsoft-visual-c-runtime-x64.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mimenet.yaml
+++ b/collections/metabolomics/v2/tools/mimenet.yaml
@@ -9,10 +9,11 @@ derived_from:
 - doi: 10.1371/journal.pcbi.1009021
   title: 'MiMeNet: Exploring microbiome-metabolome relationships using neural networks'
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/YDaiLab/MiMeNet
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mimir.yaml
+++ b/collections/metabolomics/v2/tools/mimir.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/minems2.yaml
+++ b/collections/metabolomics/v2/tools/minems2.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/minfer.yaml
+++ b/collections/metabolomics/v2/tools/minfer.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - cellbiomaths/MInfer
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: cellbiomaths/MInfer

--- a/collections/metabolomics/v2/tools/miniconda.yaml
+++ b/collections/metabolomics/v2/tools/miniconda.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - CE-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/mirador.yaml
+++ b/collections/metabolomics/v2/tools/mirador.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/missforest.yaml
+++ b/collections/metabolomics/v2/tools/missforest.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mist-cf.yaml
+++ b/collections/metabolomics/v2/tools/mist-cf.yaml
@@ -8,10 +8,11 @@ derived_from:
 - doi: 10.1021/acs.jcim.3c01082
   title: 'MIST-CF: Chemical Formula Inference from Tandem Mass Spectra'
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/samgoldman97/mist-cf
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/mist.yaml
+++ b/collections/metabolomics/v2/tools/mist.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/mixomics.yaml
+++ b/collections/metabolomics/v2/tools/mixomics.yaml
@@ -12,10 +12,11 @@ source_repos:
 - DanielQuiroz97/RGCxGC
 - LargeMetabo/LargeMetabo
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/mixOmicsTeam/mixOmics
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mobilipid.yaml
+++ b/collections/metabolomics/v2/tools/mobilipid.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mobilitytransformr.yaml
+++ b/collections/metabolomics/v2/tools/mobilitytransformr.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - LiesaSalzer/MobilityTransformR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: r-description
+license_subject: tool
+repo_url: LiesaSalzer/MobilityTransformR
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/moccal.yaml
+++ b/collections/metabolomics/v2/tools/moccal.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.3c04290
   title: moccal
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/HinesLab/MOCCal
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/mode-shinyapp.yaml
+++ b/collections/metabolomics/v2/tools/mode-shinyapp.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/modifinder.yaml
+++ b/collections/metabolomics/v2/tools/modifinder.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/molbar.yaml
+++ b/collections/metabolomics/v2/tools/molbar.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/moldiscovery.yaml
+++ b/collections/metabolomics/v2/tools/moldiscovery.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/moletrans.yaml
+++ b/collections/metabolomics/v2/tools/moletrans.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - JibaoLiu/MoleTrans
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: JibaoLiu/MoleTrans
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/molmass.yaml
+++ b/collections/metabolomics/v2/tools/molmass.yaml
@@ -14,5 +14,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/molnotator.yaml
+++ b/collections/metabolomics/v2/tools/molnotator.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - ZzakB/MolNotator
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: ZzakB/MolNotator
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mona.yaml
+++ b/collections/metabolomics/v2/tools/mona.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mongodb.yaml
+++ b/collections/metabolomics/v2/tools/mongodb.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/monte-carlo-dropout.yaml
+++ b/collections/metabolomics/v2/tools/monte-carlo-dropout.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mordred.yaml
+++ b/collections/metabolomics/v2/tools/mordred.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/motifdb.yaml
+++ b/collections/metabolomics/v2/tools/motifdb.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mozilla-firefox.yaml
+++ b/collections/metabolomics/v2/tools/mozilla-firefox.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/mpactr.yaml
+++ b/collections/metabolomics/v2/tools/mpactr.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mrmquant.yaml
+++ b/collections/metabolomics/v2/tools/mrmquant.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mrmtransitiongrouppicker.yaml
+++ b/collections/metabolomics/v2/tools/mrmtransitiongrouppicker.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mrnannoalgo3-metdna3.yaml
+++ b/collections/metabolomics/v2/tools/mrnannoalgo3-metdna3.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/ms-cleanr.yaml
+++ b/collections/metabolomics/v2/tools/ms-cleanr.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - eMetaboHUB/MS-CleanR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: eMetaboHUB/MS-CleanR
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/ms-dial-4.yaml
+++ b/collections/metabolomics/v2/tools/ms-dial-4.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ms-dial-5.yaml
+++ b/collections/metabolomics/v2/tools/ms-dial-5.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ms-dial-or-higher.yaml
+++ b/collections/metabolomics/v2/tools/ms-dial-or-higher.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/ms-dial-v4-00-or-higher.yaml
+++ b/collections/metabolomics/v2/tools/ms-dial-v4-00-or-higher.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms-dial.yaml
+++ b/collections/metabolomics/v2/tools/ms-dial.yaml
@@ -41,6 +41,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ms-distance.yaml
+++ b/collections/metabolomics/v2/tools/ms-distance.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms-entropy.yaml
+++ b/collections/metabolomics/v2/tools/ms-entropy.yaml
@@ -10,9 +10,10 @@ derived_from:
 source_repos:
 - FanzhouKong/spectral_denoising
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/YuanyueLi/MSEntropy
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms-finder.yaml
+++ b/collections/metabolomics/v2/tools/ms-finder.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/ms-pred-iceberg.yaml
+++ b/collections/metabolomics/v2/tools/ms-pred-iceberg.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms-pred-scarf-model.yaml
+++ b/collections/metabolomics/v2/tools/ms-pred-scarf-model.yaml
@@ -14,3 +14,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/ms-pred.yaml
+++ b/collections/metabolomics/v2/tools/ms-pred.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ms-rescore.yaml
+++ b/collections/metabolomics/v2/tools/ms-rescore.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/ms-search.yaml
+++ b/collections/metabolomics/v2/tools/ms-search.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ms2compound.yaml
+++ b/collections/metabolomics/v2/tools/ms2compound.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - beherasan/MS2Compound
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: CC-BY-4.0
+license_detection: github-api
+license_subject: tool
+repo_url: beherasan/MS2Compound
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms2deepscore.yaml
+++ b/collections/metabolomics/v2/tools/ms2deepscore.yaml
@@ -17,10 +17,11 @@ derived_from:
 source_repos:
 - matchms/MS2DeepScore
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/matchms/ms2deepscore
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/ms2lda-preprocessing-generate-corpus.yaml
+++ b/collections/metabolomics/v2/tools/ms2lda-preprocessing-generate-corpus.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ms2lda-preprocessing-load-and-clean.yaml
+++ b/collections/metabolomics/v2/tools/ms2lda-preprocessing-load-and-clean.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ms2lda.yaml
+++ b/collections/metabolomics/v2/tools/ms2lda.yaml
@@ -22,10 +22,11 @@ source_repos:
 - mwang87/MetabolomicsSpectrumResolver
 - vdhooftcompmet/MS2LDA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: vdhooftcompmet/MS2LDA
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ms2mp.yaml
+++ b/collections/metabolomics/v2/tools/ms2mp.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ms2query.yaml
+++ b/collections/metabolomics/v2/tools/ms2query.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - iomega/ms2query
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/iomega/ms2query
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/msbackendmgf.yaml
+++ b/collections/metabolomics/v2/tools/msbackendmgf.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/MsBackendMgf
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msbackendmzr.yaml
+++ b/collections/metabolomics/v2/tools/msbackendmzr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/msconvert-proteowizard.yaml
+++ b/collections/metabolomics/v2/tools/msconvert-proteowizard.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/msconvert.yaml
+++ b/collections/metabolomics/v2/tools/msconvert.yaml
@@ -51,6 +51,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msdata.yaml
+++ b/collections/metabolomics/v2/tools/msdata.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/msdatahub.yaml
+++ b/collections/metabolomics/v2/tools/msdatahub.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/MsDataHub
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msentropy.yaml
+++ b/collections/metabolomics/v2/tools/msentropy.yaml
@@ -17,10 +17,11 @@ source_repos:
 - YuanyueLi/FlashEntropySearch
 - YuanyueLi/SpectralEntropy
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/YuanyueLi/MSEntropy
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/msexperiment.yaml
+++ b/collections/metabolomics/v2/tools/msexperiment.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.5c00567
   title: Automated Integration and Quality Assessment of Chromatographic Peaks in LC–MS-Based Metabolomics and Lipidomics Using TARDIS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/MsExperiment
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msfeast.yaml
+++ b/collections/metabolomics/v2/tools/msfeast.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - kevinmildau/msFeaST
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: kevinmildau/msFeaST
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/msfeatures.yaml
+++ b/collections/metabolomics/v2/tools/msfeatures.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/MsFeatures
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msfiddle.yaml
+++ b/collections/metabolomics/v2/tools/msfiddle.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msfinder.yaml
+++ b/collections/metabolomics/v2/tools/msfinder.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msflo.yaml
+++ b/collections/metabolomics/v2/tools/msflo.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/msfragger.yaml
+++ b/collections/metabolomics/v2/tools/msfragger.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/msgo-model.yaml
+++ b/collections/metabolomics/v2/tools/msgo-model.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mshub.yaml
+++ b/collections/metabolomics/v2/tools/mshub.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - bittremieux/GNPS_GC
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: bittremieux/GNPS_GC
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msi-explorer.yaml
+++ b/collections/metabolomics/v2/tools/msi-explorer.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - MMV-Lab/MSI-Explorer
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: MMV-Lab/MSI-Explorer
 techniques:
 - CE-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/msigen.yaml
+++ b/collections/metabolomics/v2/tools/msigen.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - LabLaskin/MSIGen
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: LabLaskin/MSIGen
 techniques:
 - CE-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/msmetaenhancer.yaml
+++ b/collections/metabolomics/v2/tools/msmetaenhancer.yaml
@@ -12,10 +12,11 @@ derived_from:
 source_repos:
 - RECETOX/MSMetaEnhancer
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/RECETOX/MSMetaEnhancer
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/msmssim.yaml
+++ b/collections/metabolomics/v2/tools/msmssim.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/msnbase.yaml
+++ b/collections/metabolomics/v2/tools/msnbase.yaml
@@ -12,10 +12,11 @@ source_repos:
 - LiesaSalzer/MobilityTransformR
 - rformassspectrometry/Spectra
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/lgatto/MSnbase
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msnovelist.yaml
+++ b/collections/metabolomics/v2/tools/msnovelist.yaml
@@ -15,10 +15,11 @@ source_repos:
 - meowcat/MSNovelist
 - sirius-ms/sirius
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: meowcat/MSNovelist
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/mspack.yaml
+++ b/collections/metabolomics/v2/tools/mspack.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - fhanau/mspack
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: fhanau/mspack
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mspcompiler.yaml
+++ b/collections/metabolomics/v2/tools/mspcompiler.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.2c05389
   title: mspcompiler
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: r-description
+license_subject: tool
+repo_url: https://github.com/QizhiSu/mspcompiler
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msprep.yaml
+++ b/collections/metabolomics/v2/tools/msprep.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/msroiaug.yaml
+++ b/collections/metabolomics/v2/tools/msroiaug.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/mssearchr.yaml
+++ b/collections/metabolomics/v2/tools/mssearchr.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/msthunder.yaml
+++ b/collections/metabolomics/v2/tools/msthunder.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/msys2.yaml
+++ b/collections/metabolomics/v2/tools/msys2.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/mtbls2.yaml
+++ b/collections/metabolomics/v2/tools/mtbls2.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/multiabler.yaml
+++ b/collections/metabolomics/v2/tools/multiabler.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/multiassayexperiment.yaml
+++ b/collections/metabolomics/v2/tools/multiassayexperiment.yaml
@@ -9,7 +9,8 @@ derived_from:
 source_repos:
 - andreasmock/MetaboDiff
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/waldronlab/MultiAssayExperiment

--- a/collections/metabolomics/v2/tools/multimodalspectraltransformer.yaml
+++ b/collections/metabolomics/v2/tools/multimodalspectraltransformer.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/multiprocessing.yaml
+++ b/collections/metabolomics/v2/tools/multiprocessing.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/multtest.yaml
+++ b/collections/metabolomics/v2/tools/multtest.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/multtest

--- a/collections/metabolomics/v2/tools/mwastools.yaml
+++ b/collections/metabolomics/v2/tools/mwastools.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/mwise.yaml
+++ b/collections/metabolomics/v2/tools/mwise.yaml
@@ -10,9 +10,10 @@ derived_from:
 source_repos:
 - b2slab/mWISE
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: b2slab/mWISE
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/mwtab.yaml
+++ b/collections/metabolomics/v2/tools/mwtab.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mysql-8.yaml
+++ b/collections/metabolomics/v2/tools/mysql-8.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mza.yaml
+++ b/collections/metabolomics/v2/tools/mza.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - PNNL-m-q/mza
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-2-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: PNNL-m-q/mza
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mzembed.yaml
+++ b/collections/metabolomics/v2/tools/mzembed.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mzexacto.yaml
+++ b/collections/metabolomics/v2/tools/mzexacto.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mzmine-2.yaml
+++ b/collections/metabolomics/v2/tools/mzmine-2.yaml
@@ -17,10 +17,11 @@ source_repos:
 - idslme/IDSL.IPA
 - mzmine/mzmine2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: mzmine/mzmine2
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mzmine-3.yaml
+++ b/collections/metabolomics/v2/tools/mzmine-3.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mzmine.yaml
+++ b/collections/metabolomics/v2/tools/mzmine.yaml
@@ -35,10 +35,11 @@ source_repos:
 - luigiquiros/inventa
 - mzmine/mzmine2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/mzmine/mzmine
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mzmine2.yaml
+++ b/collections/metabolomics/v2/tools/mzmine2.yaml
@@ -16,10 +16,11 @@ source_repos:
 - luigiquiros/inventa
 - mzmine/mzmine2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: mzmine/mzmine2
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/mzmine3.yaml
+++ b/collections/metabolomics/v2/tools/mzmine3.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mzmldataloader.yaml
+++ b/collections/metabolomics/v2/tools/mzmldataloader.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/mzquality.yaml
+++ b/collections/metabolomics/v2/tools/mzquality.yaml
@@ -9,10 +9,11 @@ derived_from:
 - doi: 10.1021/jasms.5c00073
   title: mzquality
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/hankemeierlab/mzQuality
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mzr.yaml
+++ b/collections/metabolomics/v2/tools/mzr.yaml
@@ -12,10 +12,11 @@ source_repos:
 - jcapelladesto/isoSCAN
 - thepanlab/Aerith
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/sneumann/mzR
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/mzrapp.yaml
+++ b/collections/metabolomics/v2/tools/mzrapp.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - YasinEl/mzRAPP
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: YasinEl/mzRAPP
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/mzrtsim.yaml
+++ b/collections/metabolomics/v2/tools/mzrtsim.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - yufree/mzrtsim
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: yufree/mzrtsim
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/nanobind.yaml
+++ b/collections/metabolomics/v2/tools/nanobind.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/napari.yaml
+++ b/collections/metabolomics/v2/tools/napari.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - CE-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/ncbi-e-utilities.yaml
+++ b/collections/metabolomics/v2/tools/ncbi-e-utilities.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/ncgtw.yaml
+++ b/collections/metabolomics/v2/tools/ncgtw.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - ChiungTingWu/ncGTW
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/ChiungTingWu/ncGTW
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/neatms.yaml
+++ b/collections/metabolomics/v2/tools/neatms.yaml
@@ -8,10 +8,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.1c02220
   title: neatms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/bihealth/NeatMS
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/ned.yaml
+++ b/collections/metabolomics/v2/tools/ned.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/net-6.yaml
+++ b/collections/metabolomics/v2/tools/net-6.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/net-8-0.yaml
+++ b/collections/metabolomics/v2/tools/net-8-0.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/net-framework-4-8.yaml
+++ b/collections/metabolomics/v2/tools/net-framework-4-8.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/net-framework.yaml
+++ b/collections/metabolomics/v2/tools/net-framework.yaml
@@ -21,6 +21,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/net-standard.yaml
+++ b/collections/metabolomics/v2/tools/net-standard.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/netgsa-r-package.yaml
+++ b/collections/metabolomics/v2/tools/netgsa-r-package.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/networkx.yaml
+++ b/collections/metabolomics/v2/tools/networkx.yaml
@@ -21,6 +21,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/neural-networks-mlpnn-with-relu-activation.yaml
+++ b/collections/metabolomics/v2/tools/neural-networks-mlpnn-with-relu-activation.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/neural-networks.yaml
+++ b/collections/metabolomics/v2/tools/neural-networks.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/nextflow-22-10-0.yaml
+++ b/collections/metabolomics/v2/tools/nextflow-22-10-0.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/nextflow.yaml
+++ b/collections/metabolomics/v2/tools/nextflow.yaml
@@ -19,10 +19,11 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - Wang-Bioinformatics-Lab/Reverse_metabolomics_library_generation
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/nextflow-io/nextflow
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/nist.yaml
+++ b/collections/metabolomics/v2/tools/nist.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/nmrbox.yaml
+++ b/collections/metabolomics/v2/tools/nmrbox.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/nmrfx.yaml
+++ b/collections/metabolomics/v2/tools/nmrfx.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/nmrpipe.yaml
+++ b/collections/metabolomics/v2/tools/nmrpipe.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/noreva.yaml
+++ b/collections/metabolomics/v2/tools/noreva.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: idrblab/NOREVA;
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/norine.yaml
+++ b/collections/metabolomics/v2/tools/norine.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/normalizemets.yaml
+++ b/collections/metabolomics/v2/tools/normalizemets.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - metabolomicstats/NormalizeMets
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: r-description
+license_subject: tool
+repo_url: metabolomicstats/NormalizeMets
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/norvisualization.yaml
+++ b/collections/metabolomics/v2/tools/norvisualization.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/notame.yaml
+++ b/collections/metabolomics/v2/tools/notame.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - antonvsdata/notame
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/hanhineva-lab/notame
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/np-atlas.yaml
+++ b/collections/metabolomics/v2/tools/np-atlas.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/npanalyst.yaml
+++ b/collections/metabolomics/v2/tools/npanalyst.yaml
@@ -4,10 +4,11 @@ derived_from:
 - doi: 10.1021/acscentsci.1c01108
   title: NP Analyst
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/liningtonlab/npanalyst
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/npclassifier.yaml
+++ b/collections/metabolomics/v2/tools/npclassifier.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/npdtools-2-5-0.yaml
+++ b/collections/metabolomics/v2/tools/npdtools-2-5-0.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/npdtools.yaml
+++ b/collections/metabolomics/v2/tools/npdtools.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/npfimg.yaml
+++ b/collections/metabolomics/v2/tools/npfimg.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/nplinker.yaml
+++ b/collections/metabolomics/v2/tools/nplinker.yaml
@@ -17,10 +17,11 @@ derived_from:
 source_repos:
 - NPLinker/nplinker
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: NPLinker/nplinker
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/npm.yaml
+++ b/collections/metabolomics/v2/tools/npm.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/numba.yaml
+++ b/collections/metabolomics/v2/tools/numba.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/numpy-1-15-4.yaml
+++ b/collections/metabolomics/v2/tools/numpy-1-15-4.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/numpy-or-scipy.yaml
+++ b/collections/metabolomics/v2/tools/numpy-or-scipy.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/numpy.yaml
+++ b/collections/metabolomics/v2/tools/numpy.yaml
@@ -85,6 +85,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/omu-omu-summary-function.yaml
+++ b/collections/metabolomics/v2/tools/omu-omu-summary-function.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/onnxruntime.yaml
+++ b/collections/metabolomics/v2/tools/onnxruntime.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/open-tree-of-life.yaml
+++ b/collections/metabolomics/v2/tools/open-tree-of-life.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/openms-topp-tools.yaml
+++ b/collections/metabolomics/v2/tools/openms-topp-tools.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/openms.yaml
+++ b/collections/metabolomics/v2/tools/openms.yaml
@@ -30,10 +30,11 @@ source_repos:
 - OpenMS/OpenMS
 - fgcz/rawrr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/OpenMS/OpenMS
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/opennau.yaml
+++ b/collections/metabolomics/v2/tools/opennau.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - zjuRong/openNAU
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: zjuRong/openNAU
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/openpyxl.yaml
+++ b/collections/metabolomics/v2/tools/openpyxl.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - Leo-Cheng-Lab/ROIAL-NMR
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: http://openpyxl.readthedocs.org
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/opentims.yaml
+++ b/collections/metabolomics/v2/tools/opentims.yaml
@@ -8,3 +8,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/opentimspy.yaml
+++ b/collections/metabolomics/v2/tools/opentimspy.yaml
@@ -7,3 +7,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/optgpsampler-algorithm.yaml
+++ b/collections/metabolomics/v2/tools/optgpsampler-algorithm.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/optgpsampler.yaml
+++ b/collections/metabolomics/v2/tools/optgpsampler.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/optimus.yaml
+++ b/collections/metabolomics/v2/tools/optimus.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/orca.yaml
+++ b/collections/metabolomics/v2/tools/orca.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/orgmassspecr.yaml
+++ b/collections/metabolomics/v2/tools/orgmassspecr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/oswdataaccess.yaml
+++ b/collections/metabolomics/v2/tools/oswdataaccess.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ouks.yaml
+++ b/collections/metabolomics/v2/tools/ouks.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pacman.yaml
+++ b/collections/metabolomics/v2/tools/pacman.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pairkat.yaml
+++ b/collections/metabolomics/v2/tools/pairkat.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - CharlieCarpenter/PaIRKAT
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Ghoshlab/pairkat

--- a/collections/metabolomics/v2/tools/pals-pathway-activity-level-scoring.yaml
+++ b/collections/metabolomics/v2/tools/pals-pathway-activity-level-scoring.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/pals-viewer.yaml
+++ b/collections/metabolomics/v2/tools/pals-viewer.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/pals.yaml
+++ b/collections/metabolomics/v2/tools/pals.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pandas-1-1-1.yaml
+++ b/collections/metabolomics/v2/tools/pandas-1-1-1.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/pandas-for-tabular-data-manipulation-and-aggregation.yaml
+++ b/collections/metabolomics/v2/tools/pandas-for-tabular-data-manipulation-and-aggregation.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pandas-or-equivalent-tabular-data-library.yaml
+++ b/collections/metabolomics/v2/tools/pandas-or-equivalent-tabular-data-library.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pandas.yaml
+++ b/collections/metabolomics/v2/tools/pandas.yaml
@@ -76,6 +76,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/parallel-computing-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/parallel-computing-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/parallel.yaml
+++ b/collections/metabolomics/v2/tools/parallel.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/paramounter.yaml
+++ b/collections/metabolomics/v2/tools/paramounter.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - HuanLab/Paramounter
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: HuanLab/Paramounter
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/patroon.yaml
+++ b/collections/metabolomics/v2/tools/patroon.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - rickhelmus/patRoon
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: rickhelmus/patRoon
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pbapply.yaml
+++ b/collections/metabolomics/v2/tools/pbapply.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/pcamethods.yaml
+++ b/collections/metabolomics/v2/tools/pcamethods.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/hredestig/pcamethods
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/pcutils.yaml
+++ b/collections/metabolomics/v2/tools/pcutils.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/peakqc.yaml
+++ b/collections/metabolomics/v2/tools/peakqc.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - pnnl/IonToolPack
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/loosolab/PEAKQC
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/peakquant.yaml
+++ b/collections/metabolomics/v2/tools/peakquant.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/perl-prima.yaml
+++ b/collections/metabolomics/v2/tools/perl-prima.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/perl.yaml
+++ b/collections/metabolomics/v2/tools/perl.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pewlib.yaml
+++ b/collections/metabolomics/v2/tools/pewlib.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pewpew.yaml
+++ b/collections/metabolomics/v2/tools/pewpew.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pfam.yaml
+++ b/collections/metabolomics/v2/tools/pfam.yaml
@@ -16,3 +16,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pheatmap.yaml
+++ b/collections/metabolomics/v2/tools/pheatmap.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/php.yaml
+++ b/collections/metabolomics/v2/tools/php.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pillow.yaml
+++ b/collections/metabolomics/v2/tools/pillow.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/pip.yaml
+++ b/collections/metabolomics/v2/tools/pip.yaml
@@ -39,6 +39,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/plage-method-within-pals.yaml
+++ b/collections/metabolomics/v2/tools/plage-method-within-pals.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/plantmasst.yaml
+++ b/collections/metabolomics/v2/tools/plantmasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/plotly-or-equivalent-interactive-plotting-library.yaml
+++ b/collections/metabolomics/v2/tools/plotly-or-equivalent-interactive-plotting-library.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/plotly.yaml
+++ b/collections/metabolomics/v2/tools/plotly.yaml
@@ -19,6 +19,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/pmartr.yaml
+++ b/collections/metabolomics/v2/tools/pmartr.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pnnl-preprocessor.yaml
+++ b/collections/metabolomics/v2/tools/pnnl-preprocessor.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/poetry.yaml
+++ b/collections/metabolomics/v2/tools/poetry.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/poisson-noise-augmentation.yaml
+++ b/collections/metabolomics/v2/tools/poisson-noise-augmentation.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/postgresql.yaml
+++ b/collections/metabolomics/v2/tools/postgresql.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/prcomp.yaml
+++ b/collections/metabolomics/v2/tools/prcomp.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/prepare-wikidata-lotus-prefect-py.yaml
+++ b/collections/metabolomics/v2/tools/prepare-wikidata-lotus-prefect-py.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/prima-panel.yaml
+++ b/collections/metabolomics/v2/tools/prima-panel.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/probability-product-kernel-ppk.yaml
+++ b/collections/metabolomics/v2/tools/probability-product-kernel-ppk.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/proc.yaml
+++ b/collections/metabolomics/v2/tools/proc.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/proforma-2-0.yaml
+++ b/collections/metabolomics/v2/tools/proforma-2-0.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/proteomm.yaml
+++ b/collections/metabolomics/v2/tools/proteomm.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/ProteoMM
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/proteowizard-library-and-tools.yaml
+++ b/collections/metabolomics/v2/tools/proteowizard-library-and-tools.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/proteowizard-msconvert.yaml
+++ b/collections/metabolomics/v2/tools/proteowizard-msconvert.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/proteowizard-pwiz-skyline.yaml
+++ b/collections/metabolomics/v2/tools/proteowizard-pwiz-skyline.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/proteowizard.yaml
+++ b/collections/metabolomics/v2/tools/proteowizard.yaml
@@ -42,6 +42,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/proteoxchange-repository.yaml
+++ b/collections/metabolomics/v2/tools/proteoxchange-repository.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ps2ms.yaml
+++ b/collections/metabolomics/v2/tools/ps2ms.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/psims.yaml
+++ b/collections/metabolomics/v2/tools/psims.yaml
@@ -6,9 +6,10 @@ derived_from:
 - doi: 10.1021/acs.jproteome.8b00717
   title: pyteomics
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/mobiusklein/psims
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/psm-utils.yaml
+++ b/collections/metabolomics/v2/tools/psm-utils.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - compomics/ms2rescore
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/compomics/psm_utils
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pubchem-standardization.yaml
+++ b/collections/metabolomics/v2/tools/pubchem-standardization.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pubchem.yaml
+++ b/collections/metabolomics/v2/tools/pubchem.yaml
@@ -37,6 +37,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pubchempy.yaml
+++ b/collections/metabolomics/v2/tools/pubchempy.yaml
@@ -11,10 +11,11 @@ derived_from:
 source_repos:
 - zmahnoor14/MAW
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/mcs07/PubChemPy
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/punc-data.yaml
+++ b/collections/metabolomics/v2/tools/punc-data.yaml
@@ -9,9 +9,10 @@ derived_from:
 source_repos:
 - WTVoe/puncdata
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: license-file
+license_subject: tool
+repo_url: WTVoe/puncdata
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/puncdata.yaml
+++ b/collections/metabolomics/v2/tools/puncdata.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - WTVoe/puncdata
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: license-file
+license_subject: tool
+repo_url: WTVoe/puncdata
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/purrr.yaml
+++ b/collections/metabolomics/v2/tools/purrr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pwiz-bindings-cli-dll.yaml
+++ b/collections/metabolomics/v2/tools/pwiz-bindings-cli-dll.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pwiz.yaml
+++ b/collections/metabolomics/v2/tools/pwiz.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/py4cytoscape.yaml
+++ b/collections/metabolomics/v2/tools/py4cytoscape.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyarrow.yaml
+++ b/collections/metabolomics/v2/tools/pyarrow.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pybaf2sql.yaml
+++ b/collections/metabolomics/v2/tools/pybaf2sql.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - CE-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/pycharm.yaml
+++ b/collections/metabolomics/v2/tools/pycharm.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pycombat.yaml
+++ b/collections/metabolomics/v2/tools/pycombat.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyeva.yaml
+++ b/collections/metabolomics/v2/tools/pyeva.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyg.yaml
+++ b/collections/metabolomics/v2/tools/pyg.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyhmmer.yaml
+++ b/collections/metabolomics/v2/tools/pyhmmer.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - medema-group/bigslice
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/althonos/pyhmmer

--- a/collections/metabolomics/v2/tools/pyineta.yaml
+++ b/collections/metabolomics/v2/tools/pyineta.yaml
@@ -11,9 +11,10 @@ derived_from:
 source_repos:
 - edisonomics/PyINETA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: edisonomics/PyINETA
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/pymolnetenhancer.yaml
+++ b/collections/metabolomics/v2/tools/pymolnetenhancer.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/pymrmtransitiongrouppicker.yaml
+++ b/collections/metabolomics/v2/tools/pymrmtransitiongrouppicker.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pymzml.yaml
+++ b/collections/metabolomics/v2/tools/pymzml.yaml
@@ -23,10 +23,11 @@ source_repos:
 - shuzhao-li-lab/asari
 - zsspython/LAGF
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/pymzml/pymzML
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyopenms-viz.yaml
+++ b/collections/metabolomics/v2/tools/pyopenms-viz.yaml
@@ -9,10 +9,11 @@ derived_from:
 - doi: 10.1021/acs.jproteome.4c00873
   title: pyopenmsviz
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/OpenMS/pyopenms_viz
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pyopenms.yaml
+++ b/collections/metabolomics/v2/tools/pyopenms.yaml
@@ -23,10 +23,11 @@ source_repos:
 - AutoFlowResearch/SmartPeak
 - huaxuyu/bago
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/OpenMS/OpenMS
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyqt5.yaml
+++ b/collections/metabolomics/v2/tools/pyqt5.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/pyrwr.yaml
+++ b/collections/metabolomics/v2/tools/pyrwr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pyteomics.yaml
+++ b/collections/metabolomics/v2/tools/pyteomics.yaml
@@ -12,10 +12,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.9b04884
   title: "<tt>spectrum_utils</tt>\n                    : A Python Package for Mass Spectrometry Data Processing and Visualization"
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/levitsky/pyteomics
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pytest.yaml
+++ b/collections/metabolomics/v2/tools/pytest.yaml
@@ -35,6 +35,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/python-2-7.yaml
+++ b/collections/metabolomics/v2/tools/python-2-7.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/python-3-11-7.yaml
+++ b/collections/metabolomics/v2/tools/python-3-11-7.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/python-3-6-12.yaml
+++ b/collections/metabolomics/v2/tools/python-3-6-12.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/python-3-6.yaml
+++ b/collections/metabolomics/v2/tools/python-3-6.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/python-3-7.yaml
+++ b/collections/metabolomics/v2/tools/python-3-7.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/python-3-8-1.yaml
+++ b/collections/metabolomics/v2/tools/python-3-8-1.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/python-3-8-2.yaml
+++ b/collections/metabolomics/v2/tools/python-3-8-2.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/python-3-8.yaml
+++ b/collections/metabolomics/v2/tools/python-3-8.yaml
@@ -18,6 +18,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/python-3-9-0.yaml
+++ b/collections/metabolomics/v2/tools/python-3-9-0.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/python-3-9.yaml
+++ b/collections/metabolomics/v2/tools/python-3-9.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/python-3.yaml
+++ b/collections/metabolomics/v2/tools/python-3.yaml
@@ -32,6 +32,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/python-deep-learning-framework-pytorch-or-tensorflow.yaml
+++ b/collections/metabolomics/v2/tools/python-deep-learning-framework-pytorch-or-tensorflow.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/python-json-module-for-parsing-json-files.yaml
+++ b/collections/metabolomics/v2/tools/python-json-module-for-parsing-json-files.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/python-numpy-pandas.yaml
+++ b/collections/metabolomics/v2/tools/python-numpy-pandas.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/python-numpy-scipy-stats-pandas-matplotlib-seaborn.yaml
+++ b/collections/metabolomics/v2/tools/python-numpy-scipy-stats-pandas-matplotlib-seaborn.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/python-pandas-numpy-scipy.yaml
+++ b/collections/metabolomics/v2/tools/python-pandas-numpy-scipy.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/python-scikit-learn-seaborn-or-matplotlib-for-visualization.yaml
+++ b/collections/metabolomics/v2/tools/python-scikit-learn-seaborn-or-matplotlib-for-visualization.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/python-scikit-learn.yaml
+++ b/collections/metabolomics/v2/tools/python-scikit-learn.yaml
@@ -11,3 +11,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/python.yaml
+++ b/collections/metabolomics/v2/tools/python.yaml
@@ -289,6 +289,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pytorch-2-2.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-2-2.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/pytorch-cu118.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-cu118.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/pytorch-geometric-pyg.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-geometric-pyg.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/pytorch-geometric.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-geometric.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/pytorch-or-tensorflow.yaml
+++ b/collections/metabolomics/v2/tools/pytorch-or-tensorflow.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/pytorch.yaml
+++ b/collections/metabolomics/v2/tools/pytorch.yaml
@@ -93,6 +93,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/pyvis.yaml
+++ b/collections/metabolomics/v2/tools/pyvis.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/pyyaml.yaml
+++ b/collections/metabolomics/v2/tools/pyyaml.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/q-exactive-orbitrap.yaml
+++ b/collections/metabolomics/v2/tools/q-exactive-orbitrap.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/q2-qemistree.yaml
+++ b/collections/metabolomics/v2/tools/q2-qemistree.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/qcomics.yaml
+++ b/collections/metabolomics/v2/tools/qcomics.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.3c03660
   title: QComics
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/ricoderks/QComics
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/qcxms2.yaml
+++ b/collections/metabolomics/v2/tools/qcxms2.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - grimme-lab/QCxMS2
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: grimme-lab/QCxMS2
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/qmake.yaml
+++ b/collections/metabolomics/v2/tools/qmake.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/qr-code-generation-library.yaml
+++ b/collections/metabolomics/v2/tools/qr-code-generation-library.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/qt5.yaml
+++ b/collections/metabolomics/v2/tools/qt5.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/quick.yaml
+++ b/collections/metabolomics/v2/tools/quick.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/r-3-0-1.yaml
+++ b/collections/metabolomics/v2/tools/r-3-0-1.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/r-4-0-2.yaml
+++ b/collections/metabolomics/v2/tools/r-4-0-2.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/r-4-1-2.yaml
+++ b/collections/metabolomics/v2/tools/r-4-1-2.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/r-base-stats-tidyverse-or-similar.yaml
+++ b/collections/metabolomics/v2/tools/r-base-stats-tidyverse-or-similar.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/r-gui.yaml
+++ b/collections/metabolomics/v2/tools/r-gui.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/r-or-language-used-by-pairkat-scripts.yaml
+++ b/collections/metabolomics/v2/tools/r-or-language-used-by-pairkat-scripts.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/r-package-amanida.yaml
+++ b/collections/metabolomics/v2/tools/r-package-amanida.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/r-shiny.yaml
+++ b/collections/metabolomics/v2/tools/r-shiny.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/r-vegan-package.yaml
+++ b/collections/metabolomics/v2/tools/r-vegan-package.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/r-version-or-higher.yaml
+++ b/collections/metabolomics/v2/tools/r-version-or-higher.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/r.yaml
+++ b/collections/metabolomics/v2/tools/r.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ramclustr.yaml
+++ b/collections/metabolomics/v2/tools/ramclustr.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/random-forest-regression.yaml
+++ b/collections/metabolomics/v2/tools/random-forest-regression.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/random-forest.yaml
+++ b/collections/metabolomics/v2/tools/random-forest.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/random-missing-value-augmentation.yaml
+++ b/collections/metabolomics/v2/tools/random-missing-value-augmentation.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/randomforest.yaml
+++ b/collections/metabolomics/v2/tools/randomforest.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/rankprod.yaml
+++ b/collections/metabolomics/v2/tools/rankprod.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/rapidmass.yaml
+++ b/collections/metabolomics/v2/tools/rapidmass.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/raw-file-uploader-rtklab-byu-raw-file-uploader.yaml
+++ b/collections/metabolomics/v2/tools/raw-file-uploader-rtklab-byu-raw-file-uploader.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/rawfilereader.yaml
+++ b/collections/metabolomics/v2/tools/rawfilereader.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/rawrr.yaml
+++ b/collections/metabolomics/v2/tools/rawrr.yaml
@@ -13,10 +13,11 @@ derived_from:
 source_repos:
 - fgcz/rawrr
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/fgcz/rawrr
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/raxport.yaml
+++ b/collections/metabolomics/v2/tools/raxport.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/rcdk.yaml
+++ b/collections/metabolomics/v2/tools/rcdk.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/rdkit-2020-03-4.yaml
+++ b/collections/metabolomics/v2/tools/rdkit-2020-03-4.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/rdkit-or-similar-cheminformatics-library-for-molecular-fingerprint-computation.yaml
+++ b/collections/metabolomics/v2/tools/rdkit-or-similar-cheminformatics-library-for-molecular-fingerprint-computation.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/rdkit-pypi.yaml
+++ b/collections/metabolomics/v2/tools/rdkit-pypi.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/rdkit.yaml
+++ b/collections/metabolomics/v2/tools/rdkit.yaml
@@ -93,10 +93,11 @@ source_repos:
 - zhanghailiangcsu/MWFormer
 - zmahnoor14/MAW
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD
+license_detection: bioconda-package
+license_subject: tool
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/reactiveextensions.yaml
+++ b/collections/metabolomics/v2/tools/reactiveextensions.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/reactiveproperty.yaml
+++ b/collections/metabolomics/v2/tools/reactiveproperty.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/readr.yaml
+++ b/collections/metabolomics/v2/tools/readr.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/readxl.yaml
+++ b/collections/metabolomics/v2/tools/readxl.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/redis.yaml
+++ b/collections/metabolomics/v2/tools/redis.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/redu.yaml
+++ b/collections/metabolomics/v2/tools/redu.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/relu-activation.yaml
+++ b/collections/metabolomics/v2/tools/relu-activation.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/reshape2.yaml
+++ b/collections/metabolomics/v2/tools/reshape2.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/resnet18.yaml
+++ b/collections/metabolomics/v2/tools/resnet18.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/rest-client-gem.yaml
+++ b/collections/metabolomics/v2/tools/rest-client-gem.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/rest-client.yaml
+++ b/collections/metabolomics/v2/tools/rest-client.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/resultsloader.yaml
+++ b/collections/metabolomics/v2/tools/resultsloader.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/reticulate.yaml
+++ b/collections/metabolomics/v2/tools/reticulate.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/retip.yaml
+++ b/collections/metabolomics/v2/tools/retip.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - oloBion/Retip
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: CC-BY-4.0
+license_detection: r-description
+license_subject: tool
+repo_url: oloBion/Retip
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/reverse-search.yaml
+++ b/collections/metabolomics/v2/tools/reverse-search.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/rgcxgc.yaml
+++ b/collections/metabolomics/v2/tools/rgcxgc.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/rhdf5.yaml
+++ b/collections/metabolomics/v2/tools/rhdf5.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - PNNL-m-q/mza
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Huber-group-EMBL/rhdf5
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/ricoderks-qcomics.yaml
+++ b/collections/metabolomics/v2/tools/ricoderks-qcomics.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/riken.yaml
+++ b/collections/metabolomics/v2/tools/riken.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/rjson.yaml
+++ b/collections/metabolomics/v2/tools/rjson.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/rmarkdown.yaml
+++ b/collections/metabolomics/v2/tools/rmarkdown.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/rmsi.yaml
+++ b/collections/metabolomics/v2/tools/rmsi.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - NMR

--- a/collections/metabolomics/v2/tools/rmsicleanup.yaml
+++ b/collections/metabolomics/v2/tools/rmsicleanup.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - NMR

--- a/collections/metabolomics/v2/tools/rmsiproc.yaml
+++ b/collections/metabolomics/v2/tools/rmsiproc.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging
 - NMR

--- a/collections/metabolomics/v2/tools/roasmi.yaml
+++ b/collections/metabolomics/v2/tools/roasmi.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - FangYuan717/ROASMI
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: FangYuan717/ROASMI
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/roipeaks.yaml
+++ b/collections/metabolomics/v2/tools/roipeaks.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/rpref.yaml
+++ b/collections/metabolomics/v2/tools/rpref.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/rq-redis-queue.yaml
+++ b/collections/metabolomics/v2/tools/rq-redis-queue.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/rstudio.yaml
+++ b/collections/metabolomics/v2/tools/rstudio.yaml
@@ -20,6 +20,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/rtklab-byu-proteomics-data-processor.yaml
+++ b/collections/metabolomics/v2/tools/rtklab-byu-proteomics-data-processor.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/rtklab-byu-raw-file-uploader.yaml
+++ b/collections/metabolomics/v2/tools/rtklab-byu-raw-file-uploader.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/ruby.yaml
+++ b/collections/metabolomics/v2/tools/ruby.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - https://bitbucket.org/wishartlab/classyfire_api.git
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://www.ruby-lang.org

--- a/collections/metabolomics/v2/tools/rust.yaml
+++ b/collections/metabolomics/v2/tools/rust.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/ruv-iii.yaml
+++ b/collections/metabolomics/v2/tools/ruv-iii.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/s4vectors.yaml
+++ b/collections/metabolomics/v2/tools/s4vectors.yaml
@@ -15,10 +15,11 @@ source_repos:
 - BiosystemEngineeringLab-IITB/dures
 - rformassspectrometry/Spectra
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Bioconductor/S4Vectors
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/safari.yaml
+++ b/collections/metabolomics/v2/tools/safari.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/salmon.yaml
+++ b/collections/metabolomics/v2/tools/salmon.yaml
@@ -9,10 +9,11 @@ derived_from:
 source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/COMBINE-lab/salmon
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/sand.yaml
+++ b/collections/metabolomics/v2/tools/sand.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - edisonomics/SAND
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: edisonomics/SAND
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/scannotation.yaml
+++ b/collections/metabolomics/v2/tools/scannotation.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - scannotation/Scannotation_software
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: license-file
+license_subject: tool
+repo_url: scannotation/Scannotation_software
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/scanpy.yaml
+++ b/collections/metabolomics/v2/tools/scanpy.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/scarf.yaml
+++ b/collections/metabolomics/v2/tools/scarf.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scfba.yaml
+++ b/collections/metabolomics/v2/tools/scfba.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/sciex-multiquant-v3-0-3.yaml
+++ b/collections/metabolomics/v2/tools/sciex-multiquant-v3-0-3.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/sciex-multiquant.yaml
+++ b/collections/metabolomics/v2/tools/sciex-multiquant.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/sciex-q-tof-uhplc-hrms-ms.yaml
+++ b/collections/metabolomics/v2/tools/sciex-q-tof-uhplc-hrms-ms.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/scikit-bio.yaml
+++ b/collections/metabolomics/v2/tools/scikit-bio.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scikit-learn-0-23-2.yaml
+++ b/collections/metabolomics/v2/tools/scikit-learn-0-23-2.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/scikit-learn-mlpregressor.yaml
+++ b/collections/metabolomics/v2/tools/scikit-learn-mlpregressor.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/scikit-learn-nearestneighbors-for-knn-index-construction.yaml
+++ b/collections/metabolomics/v2/tools/scikit-learn-nearestneighbors-for-knn-index-construction.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/scikit-learn-python.yaml
+++ b/collections/metabolomics/v2/tools/scikit-learn-python.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scikit-learn.yaml
+++ b/collections/metabolomics/v2/tools/scikit-learn.yaml
@@ -44,6 +44,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scipy-1-0-0.yaml
+++ b/collections/metabolomics/v2/tools/scipy-1-0-0.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport.yaml
+++ b/collections/metabolomics/v2/tools/scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/scipy-signal-detrend.yaml
+++ b/collections/metabolomics/v2/tools/scipy-signal-detrend.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scipy-signal-find-peaks.yaml
+++ b/collections/metabolomics/v2/tools/scipy-signal-find-peaks.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/scipy-spearman-correlation.yaml
+++ b/collections/metabolomics/v2/tools/scipy-spearman-correlation.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/scipy.yaml
+++ b/collections/metabolomics/v2/tools/scipy.yaml
@@ -34,6 +34,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/sdf-file-parser-molecular-structure-library.yaml
+++ b/collections/metabolomics/v2/tools/sdf-file-parser-molecular-structure-library.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/seaborn-0-9-0.yaml
+++ b/collections/metabolomics/v2/tools/seaborn-0-9-0.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - MS-imaging

--- a/collections/metabolomics/v2/tools/seaborn-clustermap.yaml
+++ b/collections/metabolomics/v2/tools/seaborn-clustermap.yaml
@@ -11,3 +11,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/seaborn.yaml
+++ b/collections/metabolomics/v2/tools/seaborn.yaml
@@ -22,6 +22,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/semantic-release.yaml
+++ b/collections/metabolomics/v2/tools/semantic-release.yaml
@@ -10,3 +10,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/seurat.yaml
+++ b/collections/metabolomics/v2/tools/seurat.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/shiny.yaml
+++ b/collections/metabolomics/v2/tools/shiny.yaml
@@ -28,6 +28,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/shinyscreen.yaml
+++ b/collections/metabolomics/v2/tools/shinyscreen.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/signal-processing-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/signal-processing-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/signalp.yaml
+++ b/collections/metabolomics/v2/tools/signalp.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/simile.yaml
+++ b/collections/metabolomics/v2/tools/simile.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - biorack/simile
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: readme-llm
+license_subject: tool
+repo_url: biorack/simile
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/singularity.yaml
+++ b/collections/metabolomics/v2/tools/singularity.yaml
@@ -18,10 +18,11 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - meowcat/MSNovelist
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD
+license_detection: bioconda-package
+license_subject: tool
+repo_url: http://singularity.lbl.gov
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/sirius.yaml
+++ b/collections/metabolomics/v2/tools/sirius.yaml
@@ -38,10 +38,11 @@ source_repos:
 - zmahnoor14/MAW
 - zquinlan/concise
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: AGPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: sirius-ms/sirius
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/sklearn.yaml
+++ b/collections/metabolomics/v2/tools/sklearn.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/skyline.yaml
+++ b/collections/metabolomics/v2/tools/skyline.yaml
@@ -29,6 +29,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/slack-api.yaml
+++ b/collections/metabolomics/v2/tools/slack-api.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/slaw-grouping-module.yaml
+++ b/collections/metabolomics/v2/tools/slaw-grouping-module.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/slaw.yaml
+++ b/collections/metabolomics/v2/tools/slaw.yaml
@@ -6,9 +6,10 @@ derived_from:
 - doi: 10.1021/acs.analchem.1c02687
   title: 'SLAW: A Scalable and Self-Optimizing Processing Workflow for Untargeted LC-MS'
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/zamboni-lab/SLAW
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/slurm.yaml
+++ b/collections/metabolomics/v2/tools/slurm.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/smart.yaml
+++ b/collections/metabolomics/v2/tools/smart.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/smartpeak.yaml
+++ b/collections/metabolomics/v2/tools/smartpeak.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - AutoFlowResearch/SmartPeak
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: AutoFlowResearch/SmartPeak
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/smartpeakcli.yaml
+++ b/collections/metabolomics/v2/tools/smartpeakcli.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/smartpeakgui.yaml
+++ b/collections/metabolomics/v2/tools/smartpeakgui.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/smiter.yaml
+++ b/collections/metabolomics/v2/tools/smiter.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - LeidelLab/SMITER
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: github-api
+license_subject: tool
+repo_url: LeidelLab/SMITER
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/snakemake.yaml
+++ b/collections/metabolomics/v2/tools/snakemake.yaml
@@ -20,10 +20,11 @@ source_repos:
 - biosustain/snakemake_UmetaFlow
 - skinniderlab/clm
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MIT
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/snakemake/snakemake
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/spamtp.yaml
+++ b/collections/metabolomics/v2/tools/spamtp.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/spatialmeta.yaml
+++ b/collections/metabolomics/v2/tools/spatialmeta.yaml
@@ -10,10 +10,11 @@ derived_from:
 source_repos:
 - WanluLiuLab/SpatialMETA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: BSD-3-Clause
+license_detection: github-api
+license_subject: tool
+repo_url: WanluLiuLab/SpatialMETA
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/spec2vec.yaml
+++ b/collections/metabolomics/v2/tools/spec2vec.yaml
@@ -19,10 +19,11 @@ derived_from:
 source_repos:
 - vdhooftcompmet/MS2LDA
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/iomega/spec2vec
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/spectra-hash.yaml
+++ b/collections/metabolomics/v2/tools/spectra-hash.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/spectra.yaml
+++ b/collections/metabolomics/v2/tools/spectra.yaml
@@ -29,10 +29,11 @@ source_repos:
 - sneumann/xcms
 - zmahnoor14/MAW
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/Spectra
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/spectral-denoising.yaml
+++ b/collections/metabolomics/v2/tools/spectral-denoising.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/spectral-similarity.yaml
+++ b/collections/metabolomics/v2/tools/spectral-similarity.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/spectralentropy.yaml
+++ b/collections/metabolomics/v2/tools/spectralentropy.yaml
@@ -8,9 +8,10 @@ derived_from:
 source_repos:
 - YuanyueLi/SpectralEntropy
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: github-api
+license_subject: tool
+repo_url: YuanyueLi/SpectralEntropy
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/spectraverse-analysis-repository.yaml
+++ b/collections/metabolomics/v2/tools/spectraverse-analysis-repository.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/spectripy.yaml
+++ b/collections/metabolomics/v2/tools/spectripy.yaml
@@ -8,10 +8,11 @@ derived_from:
 - doi: 10.21105/joss.08070
   title: spectripy
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/RforMassSpectrometry/SpectriPy
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/spectrum-utils-0-3-5.yaml
+++ b/collections/metabolomics/v2/tools/spectrum-utils-0-3-5.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/spectrum-utils.yaml
+++ b/collections/metabolomics/v2/tools/spectrum-utils.yaml
@@ -10,10 +10,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.9b04884
   title: "<tt>spectrum_utils</tt>\n                    : A Python Package for Mass Spectrometry Data Processing and Visualization"
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/bittremieux/spectrum_utils
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/sphinx.yaml
+++ b/collections/metabolomics/v2/tools/sphinx.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/spreadout.yaml
+++ b/collections/metabolomics/v2/tools/spreadout.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/sql.yaml
+++ b/collections/metabolomics/v2/tools/sql.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/sqlalchemy.yaml
+++ b/collections/metabolomics/v2/tools/sqlalchemy.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/sqlite.yaml
+++ b/collections/metabolomics/v2/tools/sqlite.yaml
@@ -7,5 +7,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/sqlite3.yaml
+++ b/collections/metabolomics/v2/tools/sqlite3.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/sqmassloader.yaml
+++ b/collections/metabolomics/v2/tools/sqmassloader.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/sra-toolkit.yaml
+++ b/collections/metabolomics/v2/tools/sra-toolkit.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/stagate.yaml
+++ b/collections/metabolomics/v2/tools/stagate.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/star-aligner-v-2-6-1d.yaml
+++ b/collections/metabolomics/v2/tools/star-aligner-v-2-6-1d.yaml
@@ -11,5 +11,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/statistical-analysis-libraries-scipy-stats-for-enrichment-tests.yaml
+++ b/collections/metabolomics/v2/tools/statistical-analysis-libraries-scipy-stats-for-enrichment-tests.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/statistical-total-correlation-spectroscopy-stocsy.yaml
+++ b/collections/metabolomics/v2/tools/statistical-total-correlation-spectroscopy-stocsy.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/statistics-and-machine-learning-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/statistics-and-machine-learning-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/stats.yaml
+++ b/collections/metabolomics/v2/tools/stats.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/stattarget.yaml
+++ b/collections/metabolomics/v2/tools/stattarget.yaml
@@ -8,10 +8,11 @@ derived_from:
 source_repos:
 - idrblab/NOREVA;
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: LGPL-3.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/statTarget
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/streamlit.yaml
+++ b/collections/metabolomics/v2/tools/streamlit.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/stringr.yaml
+++ b/collections/metabolomics/v2/tools/stringr.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/summarizedexperiment.yaml
+++ b/collections/metabolomics/v2/tools/summarizedexperiment.yaml
@@ -21,10 +21,11 @@ source_repos:
 - krumsieklab/maplet
 - yufree/mzrtsim
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/Bioconductor/SummarizedExperiment
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/sva.yaml
+++ b/collections/metabolomics/v2/tools/sva.yaml
@@ -12,7 +12,8 @@ source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 - NBDZ/dbnorm
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Artistic-2.0
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/bioc/sva

--- a/collections/metabolomics/v2/tools/symfony.yaml
+++ b/collections/metabolomics/v2/tools/symfony.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/syncsa.yaml
+++ b/collections/metabolomics/v2/tools/syncsa.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/syrupy.yaml
+++ b/collections/metabolomics/v2/tools/syrupy.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/t-sne-t-distributed-stochastic-neighbor-embedding.yaml
+++ b/collections/metabolomics/v2/tools/t-sne-t-distributed-stochastic-neighbor-embedding.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/t-sne.yaml
+++ b/collections/metabolomics/v2/tools/t-sne.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/tandemmatch.yaml
+++ b/collections/metabolomics/v2/tools/tandemmatch.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/tardis.yaml
+++ b/collections/metabolomics/v2/tools/tardis.yaml
@@ -7,10 +7,11 @@ derived_from:
 - doi: 10.1021/acs.analchem.5c00567
   title: Automated Integration and Quality Assessment of Chromatographic Peaks in LC–MS-Based Metabolomics and Lipidomics Using TARDIS
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0
+license_detection: github-api
+license_subject: tool
+repo_url: https://github.com/UGent-LIMET/TARDIS
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/tensorflow-1-8-0.yaml
+++ b/collections/metabolomics/v2/tools/tensorflow-1-8-0.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/tensorflow-2-3-0.yaml
+++ b/collections/metabolomics/v2/tools/tensorflow-2-3-0.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/tensorflow-or-pytorch.yaml
+++ b/collections/metabolomics/v2/tools/tensorflow-or-pytorch.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/tensorflow-serving.yaml
+++ b/collections/metabolomics/v2/tools/tensorflow-serving.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/tensorflow.yaml
+++ b/collections/metabolomics/v2/tools/tensorflow.yaml
@@ -39,6 +39,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/thermorawfileparser.yaml
+++ b/collections/metabolomics/v2/tools/thermorawfileparser.yaml
@@ -6,10 +6,11 @@ derived_from:
 - doi: 10.1371/journal.pcbi.1011912
   title: Common data models to streamline metabolomics processing and annotation, and implementation in a Python pipeline
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: Apache-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/compomics/ThermoRawFileParser
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/tibble.yaml
+++ b/collections/metabolomics/v2/tools/tibble.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/tidyr.yaml
+++ b/collections/metabolomics/v2/tools/tidyr.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/tidyverse.yaml
+++ b/collections/metabolomics/v2/tools/tidyverse.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/timar.yaml
+++ b/collections/metabolomics/v2/tools/timar.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/tissuemasst.yaml
+++ b/collections/metabolomics/v2/tools/tissuemasst.yaml
@@ -14,6 +14,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - MS-imaging

--- a/collections/metabolomics/v2/tools/tomcat.yaml
+++ b/collections/metabolomics/v2/tools/tomcat.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/topncontroller.yaml
+++ b/collections/metabolomics/v2/tools/topncontroller.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/torch-1-7-1.yaml
+++ b/collections/metabolomics/v2/tools/torch-1-7-1.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/torch-cluster.yaml
+++ b/collections/metabolomics/v2/tools/torch-cluster.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/torch-geometric.yaml
+++ b/collections/metabolomics/v2/tools/torch-geometric.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/torch-scatter.yaml
+++ b/collections/metabolomics/v2/tools/torch-scatter.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/torch-sparse.yaml
+++ b/collections/metabolomics/v2/tools/torch-sparse.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/torch.yaml
+++ b/collections/metabolomics/v2/tools/torch.yaml
@@ -21,6 +21,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/torchmetrics.yaml
+++ b/collections/metabolomics/v2/tools/torchmetrics.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/tqdm-joblib.yaml
+++ b/collections/metabolomics/v2/tools/tqdm-joblib.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/tqdm.yaml
+++ b/collections/metabolomics/v2/tools/tqdm.yaml
@@ -13,9 +13,10 @@ source_repos:
 - 01dadada/RT-Transformer
 - zsspython/LAGF
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: MPL-2.0
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/tqdm/tqdm
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/transformer-architecture.yaml
+++ b/collections/metabolomics/v2/tools/transformer-architecture.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/transformer.yaml
+++ b/collections/metabolomics/v2/tools/transformer.yaml
@@ -23,6 +23,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/treelib.yaml
+++ b/collections/metabolomics/v2/tools/treelib.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/trelliscope.yaml
+++ b/collections/metabolomics/v2/tools/trelliscope.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/trfba.yaml
+++ b/collections/metabolomics/v2/tools/trfba.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/trimgalore.yaml
+++ b/collections/metabolomics/v2/tools/trimgalore.yaml
@@ -8,7 +8,8 @@ derived_from:
 source_repos:
 - ASAGlab/MOI--An-integrated-solution-for-omics-analyses
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-3.0-only
+license_detection: bioconda-package
+license_subject: tool
+repo_url: https://github.com/FelixKrueger/TrimGalore

--- a/collections/metabolomics/v2/tools/trove4j.yaml
+++ b/collections/metabolomics/v2/tools/trove4j.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/ubuntu.yaml
+++ b/collections/metabolomics/v2/tools/ubuntu.yaml
@@ -13,5 +13,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/ultramassexplorer.yaml
+++ b/collections/metabolomics/v2/tools/ultramassexplorer.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/unimod.yaml
+++ b/collections/metabolomics/v2/tools/unimod.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/vegan-r-package.yaml
+++ b/collections/metabolomics/v2/tools/vegan-r-package.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/vegan.yaml
+++ b/collections/metabolomics/v2/tools/vegan.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/vim.yaml
+++ b/collections/metabolomics/v2/tools/vim.yaml
@@ -12,3 +12,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/vimms.yaml
+++ b/collections/metabolomics/v2/tools/vimms.yaml
@@ -15,6 +15,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/visual-studio-code.yaml
+++ b/collections/metabolomics/v2/tools/visual-studio-code.yaml
@@ -16,6 +16,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/visual-studio.yaml
+++ b/collections/metabolomics/v2/tools/visual-studio.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/wavelet-toolbox.yaml
+++ b/collections/metabolomics/v2/tools/wavelet-toolbox.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools/webassembly.yaml
+++ b/collections/metabolomics/v2/tools/webassembly.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/webchem.yaml
+++ b/collections/metabolomics/v2/tools/webchem.yaml
@@ -17,6 +17,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - GC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/webworker.yaml
+++ b/collections/metabolomics/v2/tools/webworker.yaml
@@ -12,5 +12,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - NMR

--- a/collections/metabolomics/v2/tools/wgcna.yaml
+++ b/collections/metabolomics/v2/tools/wgcna.yaml
@@ -17,5 +17,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/windows.yaml
+++ b/collections/metabolomics/v2/tools/windows.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - NMR

--- a/collections/metabolomics/v2/tools/wine.yaml
+++ b/collections/metabolomics/v2/tools/wine.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - direct-infusion-MS

--- a/collections/metabolomics/v2/tools/word2vec.yaml
+++ b/collections/metabolomics/v2/tools/word2vec.yaml
@@ -11,6 +11,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/wpf-windows-presentation-foundation.yaml
+++ b/collections/metabolomics/v2/tools/wpf-windows-presentation-foundation.yaml
@@ -12,6 +12,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - ion-mobility-MS

--- a/collections/metabolomics/v2/tools/xcms-centwave.yaml
+++ b/collections/metabolomics/v2/tools/xcms-centwave.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/xcms.yaml
+++ b/collections/metabolomics/v2/tools/xcms.yaml
@@ -75,10 +75,11 @@ source_repos:
 - poomcj/NPFimg
 - sneumann/xcms
 schema_version: 0.2.0
-license_tier: unknown
-license: null
-license_detection: null
-license_subject: null
+license_tier: open
+license: GPL-2.0-or-later
+license_detection: bioconductor-package
+license_subject: tool
+repo_url: https://github.com/sneumann/xcms
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/xlsxwriter.yaml
+++ b/collections/metabolomics/v2/tools/xlsxwriter.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/xml-etree-elementtree.yaml
+++ b/collections/metabolomics/v2/tools/xml-etree-elementtree.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/xquartz.yaml
+++ b/collections/metabolomics/v2/tools/xquartz.yaml
@@ -10,6 +10,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - ion-mobility-MS
 - mass-spectrometry

--- a/collections/metabolomics/v2/tools/xtb.yaml
+++ b/collections/metabolomics/v2/tools/xtb.yaml
@@ -13,6 +13,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - GC-MS

--- a/collections/metabolomics/v2/tools/ysi2950-bioanalyzer.yaml
+++ b/collections/metabolomics/v2/tools/ysi2950-bioanalyzer.yaml
@@ -10,5 +10,6 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS

--- a/collections/metabolomics/v2/tools/zenodo-org-records-10997887.yaml
+++ b/collections/metabolomics/v2/tools/zenodo-org-records-10997887.yaml
@@ -13,3 +13,4 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null

--- a/collections/metabolomics/v2/tools/zenodo.yaml
+++ b/collections/metabolomics/v2/tools/zenodo.yaml
@@ -27,6 +27,7 @@ license_tier: unknown
 license: null
 license_detection: null
 license_subject: null
+repo_url: null
 techniques:
 - LC-MS
 - CE-MS

--- a/collections/metabolomics/v2/tools_index.json
+++ b/collections/metabolomics/v2/tools_index.json
@@ -68,7 +68,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "adam-optimizer",
@@ -143,7 +144,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "adap",
@@ -186,7 +188,8 @@
    "spectral-metadata-integration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "adviselipidomics",
@@ -199,9 +202,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "batch-effect-correction-in-metabolomics",
    "file-format-standardization",
@@ -220,10 +223,11 @@
    "species-identifier-annotation",
    "structured-data-matrix-construction"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": "ShinyFabio/ADViSELipidomics"
  },
  {
   "slug": "aer",
@@ -268,7 +272,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "FrigerioGianfranco/GetFeatistics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "aerith",
@@ -282,9 +287,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "charge-state-determination-and-assignment",
    "heavy-isotope-labeling-interpretation",
@@ -310,10 +315,11 @@
    "theoretical-to-observed-peak-matching",
    "total-ion-current-calculation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "thepanlab/Aerith"
-  ]
+  ],
+  "repo_url": "https://github.com/xyz1396/Aerith"
  },
  {
   "slug": "agilent-1290-infinity-uhplc-system",
@@ -381,7 +387,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "agilent-6550-ifunnel-q-tof-mass-spectrometer",
@@ -449,7 +456,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "agilent-masshunter",
@@ -494,7 +502,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "agilent-q-tof-uhplc-hrms-ms",
@@ -551,7 +560,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "agilent-unknowns-analysis",
@@ -605,7 +615,8 @@
    "unique-compound-enumeration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "airdpro-v5",
@@ -651,7 +662,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "airdpro-v6",
@@ -697,7 +709,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "alphatims",
@@ -711,9 +724,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "backend-compatibility-verification-visualization-library",
@@ -770,8 +783,9 @@
    "statistical-summary-computation-median-range",
    "visualization-comparative-performance-metrics"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/MannLabs/alphatims"
  },
  {
   "slug": "alvadesc",
@@ -826,7 +840,8 @@
    "uncertainty-quantification-rt-prediction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "amanida",
@@ -869,7 +884,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mariallr/amanida"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "anaconda",
@@ -973,7 +989,8 @@
    "yfWang01/FlavorFormer",
    "zhanghailiangcsu/MSBERT",
    "zhanghailiangcsu/MWFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ann-solo",
@@ -987,9 +1004,9 @@
    "CE-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "approximate-nearest-neighbor-index-construction",
    "approximate-nearest-neighbor-indexing-construction",
@@ -1026,10 +1043,11 @@
    "spectral-vector-representation-and-encoding",
    "spectral-vectorization-for-indexing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "bittremieux-lab/ANN-SoLo"
-  ]
+  ],
+  "repo_url": "bittremieux-lab/ANN-SoLo"
  },
  {
   "slug": "annome",
@@ -1041,9 +1059,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "binary-classification-model-training",
    "machine-learning-performance-metric-evaluation",
@@ -1051,10 +1069,11 @@
    "spectrum-relevance-classification",
    "training-validation-dataset-stratification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "chrboku/AnnoMe"
-  ]
+  ],
+  "repo_url": "chrboku/AnnoMe"
  },
  {
   "slug": "antismash",
@@ -1073,9 +1092,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0-or-later",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "antismash-bgc-directory-organization-and-validation",
    "archive-extraction-and-file-mapping",
@@ -1188,11 +1207,12 @@
    "validated-link-ranking-comparison",
    "z-score-normalization-for-cross-dataset-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "NPLinker/nplinker",
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": "https://github.com/antismash/antismash"
  },
  {
   "slug": "apache-maven-3-8",
@@ -1224,7 +1244,8 @@
    "web-service-health-verification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "appveyor",
@@ -1254,7 +1275,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "arrow",
@@ -1308,7 +1330,8 @@
    "tabular-data-field-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "asap-ms",
@@ -1346,7 +1369,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Katherine00689/RapidMass"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "asari-mass-functions-module-nn-cluster-by-mz-seeds",
@@ -1425,7 +1449,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "asari-massgrid-class-build-grid-sample-wise-add-sample-build-grid-by-centroiding-bin-track-mzs",
@@ -1504,7 +1529,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "asari-peaks-module",
@@ -1585,7 +1611,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "asari",
@@ -1716,7 +1743,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ase-ani",
@@ -1760,7 +1788,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DasSusanta/snakemake_ccs"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "asics",
@@ -1772,18 +1801,19 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "bruker-nmr-spectral-data-import",
    "nmr-spectrum-object-construction",
    "r-package-function-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "GaelleLefort/ASICS"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/ASICS"
  },
  {
   "slug": "assign-hierarchy",
@@ -1829,7 +1859,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "connor-reid-tiffany/Omu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "autoccs",
@@ -1842,18 +1873,19 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-2-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "automated-metabolite-property-computation",
    "ion-mobility-spectrometry-data-interpretation",
    "mass-spectrometry-drift-time-processing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "PNNL-Comp-Mass-Spec/AutoCCS"
-  ]
+  ],
+  "repo_url": "PNNL-Comp-Mass-Spec/AutoCCS"
  },
  {
   "slug": "autotuner",
@@ -1885,7 +1917,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "KujawinskiLaboratory/Autotuner"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "avir-r",
@@ -1912,7 +1945,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HuanLab/AVIR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "aws-cli",
@@ -1922,9 +1956,9 @@
    "10.1038/s41592-022-01486-3"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "deep-learning-model-input-layer-adaptation",
    "deep-learning-model-weight-persistence",
@@ -1938,10 +1972,11 @@
    "singularity-container-image-building-and-execution",
    "slurm-gpu-resource-allocation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "meowcat/MSNovelist"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bago",
@@ -1979,7 +2014,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "huaxuyu/bago"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bam",
@@ -2015,7 +2051,8 @@
    "spectral-similarity-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "bart",
@@ -2046,7 +2083,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenDFM/MS-BART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "base64enc",
@@ -2090,7 +2128,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "yufree/mzrtsim"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "basicevaluationengine",
@@ -2128,7 +2167,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/ModiFinder_base"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "benjamini-hochberg-fdr-correction",
@@ -2194,7 +2234,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "big-scape",
@@ -2209,9 +2250,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0-or-later",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "bgc-mf-link-scoring",
    "bgc-mf-link-scoring-standardisation",
@@ -2267,10 +2308,11 @@
    "validated-link-ranking-comparison",
    "z-score-normalization-for-cross-dataset-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": "https://github.com/medema-group/BiG-SCAPE"
  },
  {
   "slug": "big-slice",
@@ -2280,9 +2322,9 @@
    "10.1093/gigascience/giaa154"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0-or-later",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "bgc-cluster-export",
    "bgc-feature-vector-normalization",
@@ -2298,10 +2340,11 @@
    "pfam-domain-hit-extraction",
    "tsv-file-generation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "medema-group/bigslice"
-  ]
+  ],
+  "repo_url": "https://github.com/satriaphd/bigslice"
  },
  {
   "slug": "bigscape",
@@ -2314,9 +2357,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0-or-later",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "antismash-bgc-directory-organization-and-validation",
    "archive-extraction-and-file-mapping",
@@ -2403,10 +2446,11 @@
    "validated-link-ranking-comparison",
    "z-score-normalization-for-cross-dataset-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": "https://github.com/medema-group/BiG-SCAPE"
  },
  {
   "slug": "biobase",
@@ -2420,9 +2464,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -2466,11 +2510,12 @@
    "sample-label-mapping",
    "sample-metadata-integration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "antonvsdata/notame",
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/Bioconductor/Biobase"
  },
  {
   "slug": "biocmanager",
@@ -2522,7 +2567,8 @@
   "source_paper_repos": [
    "idrblab/NOREVA;",
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bioconda",
@@ -2561,7 +2607,8 @@
    "sequence-to-feature-mapping"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "bioconductor",
@@ -2765,7 +2812,8 @@
    "fgcz/rawrr",
    "sneumann/xcms",
    "xdomingoal/erah-devel"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "biocparallel",
@@ -2814,7 +2862,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kuwisdelu/Cardinal"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bioinformatic-toolbox",
@@ -2843,7 +2892,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "biosynfoni",
@@ -2853,9 +2903,9 @@
    "10.26434/chemrxiv-2025-cwq74"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "biosynformatic-descriptor-computation",
    "biosynformatic-vector-computation",
@@ -2887,10 +2937,11 @@
    "test-suite-execution-and-validation",
    "test-suite-execution-verification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "lucinamay/biosynfoni"
-  ]
+  ],
+  "repo_url": "lucinamay/biosynfoni"
  },
  {
   "slug": "biotransformer",
@@ -2966,7 +3017,8 @@
    "https://bitbucket.org/wishartlab/biotransformer.git",
    "https://bitbucket.org/wishartlab/biotransformer3.0jar.git",
    "rickhelmus/patRoon"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "biotransformerapi",
@@ -2993,7 +3045,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Le0nT1/CyProduct"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "biotranslator",
@@ -3042,7 +3095,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bitterpredict-m",
@@ -3074,7 +3128,8 @@
    "smiles-sdf-parsing-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "bitterpredict",
@@ -3106,7 +3161,8 @@
    "smiles-sdf-parsing-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "black",
@@ -3139,7 +3195,8 @@
   "source_paper_repos": [
    "SysMedOs/LipidLynxX",
    "medema-group/BiG-SCAPE"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "blast",
@@ -3168,7 +3225,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mibig-secmet/mibig-json"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bmxp",
@@ -3211,7 +3269,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "broadinstitute/bmxp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bokeh",
@@ -3316,7 +3375,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bridgedb",
@@ -3382,7 +3442,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bruker-q-tof-uhplc-hrms-ms",
@@ -3439,7 +3500,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "bruker-solarix",
@@ -3501,7 +3563,8 @@
    "transient-window-function-application"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "c",
@@ -3514,7 +3577,8 @@
   "license_detection": null,
   "used_by_skills": [],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "calculator",
@@ -3558,7 +3622,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "djdt/pewpew"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "camera",
@@ -3576,9 +3641,9 @@
    "ion-mobility-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "adduct-and-fragment-neutral-mass-calculation",
    "adduct-fragment-table-construction",
@@ -3625,11 +3690,12 @@
    "untargeted-lcms-peak-annotation",
    "wmy-network-prediction-confidence-scoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LinShuhaiLAB/LipidIN",
    "b2slab/mWISE"
-  ]
+  ],
+  "repo_url": "https://github.com/sneumann/CAMERA"
  },
  {
   "slug": "canonical-correlation-analysis-cca",
@@ -3704,7 +3770,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "canopus",
@@ -3784,7 +3851,8 @@
   "source_paper_repos": [
    "luigiquiros/inventa",
    "sirius-ms/sirius"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cardinal",
@@ -3803,9 +3871,9 @@
    "MS-imaging",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-annotation-against-reference-library",
    "adduct-ion-parent-ion-pairing-analysis",
@@ -3906,12 +3974,13 @@
    "spectral-reference-peak-summarization",
    "spectral-smoothing-method-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "GenomicsMachineLearning/SpaMTP",
    "kuwisdelu/Cardinal",
    "swinnenteam/LipidQMap"
-  ]
+  ],
+  "repo_url": "kuwisdelu/Cardinal"
  },
  {
   "slug": "cardinalio",
@@ -3955,7 +4024,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kuwisdelu/Cardinal"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "caret",
@@ -4000,7 +4070,8 @@
   "source_paper_repos": [
    "KelseyChetnik/MetaClean",
    "slfan2013/SERDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "casanovo",
@@ -4032,7 +4103,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Noble-Lab/casanovo"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cca-canonical-correlation-analysis",
@@ -4103,7 +4175,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "centwave",
@@ -4146,7 +4219,8 @@
    "spectral-metadata-integration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "cfm-id",
@@ -4203,7 +4277,8 @@
    "aaronma2020/MSGO",
    "beherasan/MS2Compound",
    "https://gitlab.com/nexs-metabolomics/projects/dna_adductomics_database.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cfmid",
@@ -4238,7 +4313,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "aaronma2020/MSGO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chambm-pwiz-skyline-i-agree-to-the-vendor-licenses",
@@ -4268,7 +4344,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "VIU-Metabolomics/imzML_Writer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chebi",
@@ -4297,7 +4374,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chem-spectra-app",
@@ -4331,7 +4409,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ComPlat/chem-spectra-app"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chemecho",
@@ -4365,7 +4444,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "biorack/chemecho"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chemicalmixturefrommzml",
@@ -4428,7 +4508,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "chemistry-development-kit-cdk",
@@ -4502,7 +4583,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chemminer",
@@ -4518,9 +4600,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chemical-identifier-unification",
    "chemical-identifier-verification",
@@ -4557,8 +4639,9 @@
    "summary-statistics-table-construction",
    "unique-compound-enumeration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/girke-lab/ChemmineR"
  },
  {
   "slug": "chemparse",
@@ -4607,7 +4690,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "FanzhouKong/spectral_denoising"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "chemprop-ir",
@@ -4619,9 +4703,9 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "deep-learning-module-instantiation-and-validation",
    "infrared-spectral-prediction-task-design",
@@ -4636,8 +4720,9 @@
    "spectral-features-module-integration",
    "transformer-architecture-inference"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/gfm-collab/chemprop-IR"
  },
  {
   "slug": "chemprop",
@@ -4668,7 +4753,8 @@
    "transformer-architecture-inference"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "chemspider",
@@ -4697,7 +4783,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cir",
@@ -4763,7 +4850,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "classyfire",
@@ -4810,7 +4898,8 @@
   "source_paper_repos": [
    "michaelwitting/RepoRT",
    "zquinlan/concise"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cliquems",
@@ -4822,9 +4911,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "adduct-and-fragment-neutral-mass-calculation",
    "adduct-fragment-table-construction",
@@ -4850,10 +4939,11 @@
    "spectral-feature-clustering-by-intensity-correlation",
    "untargeted-lcms-peak-annotation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "b2slab/mWISE"
-  ]
+  ],
+  "repo_url": "https://github.com/osenan/cliqueMS"
  },
  {
   "slug": "clumsid",
@@ -4867,9 +4957,9 @@
    "CE-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "exact-mass-database-matching",
    "fragmentation-pattern-similarity-scoring",
@@ -4879,10 +4969,11 @@
    "spectral-entropy-quality-assessment",
    "xenobiotic-metabolite-annotation-from-ms-ms"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": "https://github.com/tdepke/CluMSID"
  },
  {
   "slug": "clumsiddata",
@@ -4911,7 +5002,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "clusterprofiler",
@@ -4926,9 +5018,9 @@
    "CE-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "anova-feature-significance-filtering",
    "batch-effect-correction-combat-sva",
@@ -4983,11 +5075,12 @@
    "statistical-significance-filtering-q-value",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "emosca-cnr/margheRita"
-  ]
+  ],
+  "repo_url": "https://github.com/YuLab-SMU/clusterProfiler"
  },
  {
   "slug": "cobrapy-for-optgpsampler-uniform-sampling",
@@ -5053,7 +5146,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "cobrapy-optgpsampler-algorithm",
@@ -5121,7 +5215,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "cobrapy",
@@ -5189,7 +5284,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "coconut",
@@ -5219,7 +5315,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cohen-s-kappa-metric",
@@ -5287,7 +5384,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "color-jitter-augmentation",
@@ -5335,7 +5433,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "combat",
@@ -5375,7 +5474,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "commit",
@@ -5385,9 +5485,9 @@
    "10.1371/journal.pcbi.1009906"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "community-constraint-propagation",
    "community-dependent-reaction-inference",
@@ -5407,8 +5507,9 @@
    "sbml-model-manipulation",
    "systems-biology-model-standardization"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/pwendering/COMMIT"
  },
  {
   "slug": "commons-math3",
@@ -5481,7 +5582,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "comparador",
@@ -5529,7 +5631,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "comparems2",
@@ -5552,7 +5655,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "524D/compareMS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "complexheatmap",
@@ -5566,9 +5670,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "anova-feature-significance-filtering",
    "batch-effect-correction-combat-sva",
@@ -5623,11 +5727,12 @@
    "statistical-significance-filtering-q-value",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "emosca-cnr/margheRita"
-  ]
+  ],
+  "repo_url": "https://github.com/jokergoo/ComplexHeatmap"
  },
  {
   "slug": "compound-discoverer",
@@ -5689,7 +5794,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "conda",
@@ -5980,7 +6086,8 @@
    "vdhooftcompmet/MS2LDA",
    "yuxuanliao/PACCS",
    "zxguocsu/GCMSFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "consensus-clustering",
@@ -6051,7 +6158,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "constraint-based-stoichiometric-metabolic-models",
@@ -6119,7 +6227,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "converterbuilder",
@@ -6184,7 +6293,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "convolutional-neural-network-cnn",
@@ -6246,7 +6356,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "massspecdl/ChemEmbed"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "convolutional-neural-network",
@@ -6294,7 +6405,8 @@
    "transformer-based-fragment-assembly"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "cordbat",
@@ -6306,9 +6418,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "batch-effect-correction-reference-based",
    "batch-effect-visualization-pca",
@@ -6318,10 +6430,11 @@
    "metabolomics-batch-correction-evaluation",
    "principal-component-analysis-scaling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "BorchLab/CordBat"
-  ]
+  ],
+  "repo_url": "BorchLab/CordBat"
  },
  {
   "slug": "corems",
@@ -6338,9 +6451,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-2-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "abundance-normalization-and-summary-statistics",
    "algorithm-parameter-comparison-analysis",
@@ -6387,8 +6500,9 @@
    "time-domain-signal-apodization",
    "transient-window-function-application"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/EMSL-Computing/CoreMS"
  },
  {
   "slug": "cosine-neutral-loss-repository",
@@ -6408,7 +6522,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bittremieux/cosine_neutral_loss"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cosine-neutral-loss",
@@ -6429,7 +6544,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bittremieux/cosine_neutral_loss"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cox-nnet",
@@ -6470,7 +6586,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lanagarmire/lilikoi2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cox-ph",
@@ -6511,7 +6628,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lanagarmire/lilikoi2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cpat",
@@ -6560,7 +6678,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "crest",
@@ -6593,7 +6712,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "grimme-lab/QCxMS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "csi-fingerid",
@@ -6638,7 +6758,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "sirius-ms/sirius"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cts",
@@ -6728,7 +6849,8 @@
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer",
    "rickhelmus/patRoon"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cuda-toolkit",
@@ -6759,7 +6881,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Noble-Lab/casanovo"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cuda",
@@ -6842,7 +6965,8 @@
    "chensaian/TransG-Net",
    "sword-nan/SpecEmbedding",
    "wh-xu/Hyper-Spec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cudnn",
@@ -6870,7 +6994,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "chensaian/TransG-Net"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "curl",
@@ -6904,7 +7029,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ComPlat/chem-spectra-app"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cyclobranch",
@@ -6936,7 +7062,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cypreact",
@@ -6965,7 +7092,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://bitbucket.org/Leon_Ti/cypreact.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cyproduct",
@@ -6992,7 +7120,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Le0nT1/CyProduct"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cytoscape-js",
@@ -7014,7 +7143,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "dgrapov/MetaMapR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "cytoscape",
@@ -7222,7 +7352,8 @@
   "source_paper_repos": [
    "Karnovsky-Lab/DNEA",
    "lanagarmire/lilikoi2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "d3-js",
@@ -7253,7 +7384,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "data-table",
@@ -7336,7 +7468,8 @@
   "source_paper_repos": [
    "BalunasLab/mpact",
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dbdipy",
@@ -7352,9 +7485,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "readme-llm",
   "used_by_skills": [
    "adduct-fragment-formula-interpretation",
    "exact-mass-accuracy-calculation",
@@ -7369,10 +7502,11 @@
    "temporal-profile-correlation-analysis",
    "time-resolved-dbdi-data-interpretation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "leopold-weidner/DBDIpy"
-  ]
+  ],
+  "repo_url": "leopold-weidner/DBDIpy"
  },
  {
   "slug": "dbnorm",
@@ -7407,7 +7541,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NBDZ/dbnorm"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "decision-tree-classifier-scikit-learn-or-equivalent-tree-based-ml-framework",
@@ -7441,7 +7576,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "biorack/chemecho"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "decometdia",
@@ -7453,9 +7589,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "data-interchange-format-conversion",
    "metabolite-ms-ms-annotation",
@@ -7463,10 +7599,11 @@
    "precursor-ion-isolation-windowing",
    "swath-ms-spectrum-deconvolution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ZhuMSLab/DecoMetDIA"
-  ]
+  ],
+  "repo_url": "ZhuMSLab/DecoMetDIA"
  },
  {
   "slug": "deepmass2",
@@ -7498,7 +7635,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "hcji/DeepMASS2_Data_Processing"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "deimos",
@@ -7514,9 +7652,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "calibration-coefficient-accuracy-assessment",
    "ccs-calibration-polynomial-fitting",
@@ -7563,8 +7701,9 @@
    "spectral-feature-annotation-and-labeling",
    "tandem-mass-spectrum-deconvolution-isotope-annotation"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/pnnl/deimos"
  },
  {
   "slug": "deoptim",
@@ -7607,7 +7746,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "depthcharge",
@@ -7638,7 +7778,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Noble-Lab/casanovo"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dereplicator",
@@ -7651,9 +7792,9 @@
    "LC-MS",
    "direct-infusion-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "readme-llm",
   "used_by_skills": [
    "bgc-identification-from-genomic-sequence",
    "biosynthetic-gene-cluster-mining-with-genomic-data",
@@ -7682,10 +7823,11 @@
    "spectral-scoring-and-significance-assessment",
    "tandem-mass-spectra-peptide-matching"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": "ablab/npdtools"
  },
  {
   "slug": "deseq2",
@@ -7695,9 +7837,9 @@
    "10.1093/bioadv/vbae175"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-3.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -7731,10 +7873,11 @@
    "sra-data-retrieval-and-ingestion",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": "https://github.com/thelovelab/DESeq2"
  },
  {
   "slug": "devtools",
@@ -7855,7 +7998,8 @@
    "idrblab/NOREVA;",
    "kilgain/MassSpec",
    "komorowskilab/MetaFetcheR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dgl",
@@ -7892,7 +8036,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HopkinsLaboratory/Graphormer-RT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "di-ms",
@@ -7930,7 +8075,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Katherine00689/RapidMass"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dia-nn",
@@ -7979,7 +8125,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "diffspectra",
@@ -7992,9 +8139,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "candidate-structure-ranking",
    "diffusion-model-inference",
@@ -8002,10 +8149,11 @@
    "spectra-to-structure-elucidation",
    "spectroscopic-data-preprocessing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "AzureLeon1/DiffSpectra"
-  ]
+  ],
+  "repo_url": "AzureLeon1/DiffSpectra"
  },
  {
   "slug": "dimorphite-dl",
@@ -8048,7 +8196,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DasSusanta/snakemake_ccs"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "django",
@@ -8078,7 +8227,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "docker-compose",
@@ -8136,7 +8286,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/NP-Classifier"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "docker-desktop-for-mac",
@@ -8181,7 +8332,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "docker-docker-build-docker-inspect-docker-system-df",
@@ -8223,7 +8375,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "docker-engine",
@@ -8268,7 +8421,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "docker",
@@ -8689,7 +8843,8 @@
    "rmallol/clomet",
    "vdhooftcompmet/MS2LDA",
    "volvox292/mass2smiles"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dockerfile-multi-stage-build-with-target-flag",
@@ -8731,7 +8886,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "doparallel",
@@ -8772,7 +8928,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "antonvsdata/notame"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dplyr",
@@ -8871,7 +9028,8 @@
    "GenomicsMachineLearning/SpaMTP",
    "SydneyBioX/hRUV",
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dropms",
@@ -8945,7 +9103,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "drugbank-extraction-py",
@@ -8976,7 +9135,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "corinnabrungs/msn_tree_library"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "drugbank",
@@ -9012,7 +9172,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "daniellyz/meRgeION2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dures",
@@ -9024,9 +9185,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "feature-wise-spectrum-count-aggregation",
    "fragment-frequency-threshold-optimization",
@@ -9051,10 +9212,11 @@
    "spectral-peak-intensity-aggregation",
    "spectral-peak-retention-signal-noise-discrimination"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": "BiosystemEngineeringLab-IITB/dures"
  },
  {
   "slug": "dynaconf",
@@ -9139,7 +9301,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dynamic-time-warping-dtw",
@@ -9176,7 +9339,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ChiungTingWu/ncGTW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "dynamictreecut",
@@ -9223,7 +9387,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "cbroeckl/RAMClustR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "edger",
@@ -9236,9 +9401,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "batch-effect-correction-in-metabolomics",
@@ -9288,11 +9453,12 @@
    "structured-data-matrix-construction",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/edgeR"
  },
  {
   "slug": "eflux",
@@ -9360,7 +9526,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "elastic-net-regression",
@@ -9431,7 +9598,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "elastic-net",
@@ -9506,7 +9674,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "elemcor",
@@ -9519,9 +9688,9 @@
    "LC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "fractional-abundance-transformation",
    "isotope-labeling-data-interpretation",
@@ -9537,10 +9706,11 @@
    "resolution-effect-correction-unlabeled-samples",
    "tracer-impurity-correction-modeling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "4dsoftware/elemcor"
-  ]
+  ],
+  "repo_url": "4dsoftware/elemcor"
  },
  {
   "slug": "elementtree",
@@ -9606,7 +9776,8 @@
    "xml-spectrum-element-deserialization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "email-service",
@@ -9649,7 +9820,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "czbiohub-sf/Rapid-QC-MS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "emperor",
@@ -9694,7 +9866,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/ReDU-MS2-Documentation"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "enpkg",
@@ -9727,7 +9900,8 @@
    "virtual-environment-creation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "entropy-search",
@@ -9777,7 +9951,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "YuanyueLi/FlashEntropySearch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "enveda-ccs-prediction-repository-model-code-and-pre-trained-weights",
@@ -9820,7 +9995,8 @@
    "smiles-canonicalization-rdkit"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "envipat",
@@ -9877,7 +10053,8 @@
   "source_paper_repos": [
    "YasinEl/mzRAPP",
    "jcapelladesto/isoSCAN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "environment",
@@ -9940,7 +10117,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "excalibur",
@@ -9979,7 +10157,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "98104781/LSG"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "expressionset",
@@ -10020,7 +10199,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "antonvsdata/notame"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "factoextra",
@@ -10060,7 +10240,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LargeMetabo/LargeMetabo"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "falcon",
@@ -10073,9 +10254,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "cluster-assignment-mapping",
    "command-line-tool-execution",
@@ -10109,8 +10290,9 @@
    "spectrum-vector-similarity-searching",
    "tandem-mass-spectrum-clustering"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/bittremieuxlab/falcon"
  },
  {
   "slug": "fastqc",
@@ -10159,7 +10341,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "featurefindermetabo",
@@ -10202,7 +10385,8 @@
    "spectral-metadata-integration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "fella",
@@ -10214,9 +10398,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "adduct-and-fragment-neutral-mass-calculation",
    "adduct-fragment-table-construction",
@@ -10242,10 +10426,11 @@
    "spectral-feature-clustering-by-intensity-correlation",
    "untargeted-lcms-peak-annotation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "b2slab/mWISE"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/FELLA"
  },
  {
   "slug": "fgsea",
@@ -10257,9 +10442,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "background-reference-set-construction",
    "betweenness-centrality-computation",
@@ -10282,10 +10467,11 @@
    "pathway-metabolite-mapping-integration",
    "ranked-statistic-list-preparation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "biodatalab/enrichmet"
-  ]
+  ],
+  "repo_url": "https://github.com/alserglab/fgsea"
  },
  {
   "slug": "fiddle",
@@ -10299,9 +10485,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "binary-cross-entropy-loss-optimization",
    "checkpoint-selection-based-on-validation-metric",
@@ -10351,8 +10537,9 @@
    "train-test-split-verification",
    "transfer-learning-encoder-freezing"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/JosieHong/FIDDLE"
  },
  {
   "slug": "figshare",
@@ -10397,7 +10584,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "sword-nan/SpecEmbedding"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "filtering-augmentation",
@@ -10445,7 +10633,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "fimo",
@@ -10494,7 +10683,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "fisher-s-exact-test",
@@ -10534,7 +10724,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "biodatalab/enrichmet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "flake8",
@@ -10559,7 +10750,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "medema-group/BiG-SCAPE"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "flask",
@@ -10597,7 +10789,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ComPlat/chem-spectra-app"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "flux-variability-analysis-fva",
@@ -10665,7 +10858,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "flux-variability-analysis",
@@ -10733,7 +10927,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "fmcsr",
@@ -10747,9 +10942,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chemical-identifier-unification",
    "chemical-identifier-verification",
@@ -10786,8 +10981,9 @@
    "summary-statistics-table-construction",
    "unique-compound-enumeration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/girke-lab/fmcsR"
  },
  {
   "slug": "fnicm",
@@ -10797,19 +10993,20 @@
    "10.1021/acs.analchem.3c04131"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AFL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "core-node-identification-from-perturbation",
    "metabolite-ranking-by-network-centrality",
    "network-topology-edge-parsing",
    "trust-score-propagation-directed-graphs"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LiQi94/FNICM"
-  ]
+  ],
+  "repo_url": "LiQi94/FNICM"
  },
  {
   "slug": "foodmasst",
@@ -10867,7 +11064,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "formularity",
@@ -10941,7 +11139,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "freda",
@@ -11015,7 +11214,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "future-apply",
@@ -11069,7 +11269,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "future",
@@ -11123,7 +11324,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "galaxy-genomics-framework",
@@ -11148,7 +11350,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "secimTools/SECIMTools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "galaxy",
@@ -11185,7 +11388,8 @@
   "source_paper_repos": [
    "Viant-Metabolomics/Galaxy-M",
    "wanchanglin/ionflow"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gcims",
@@ -11199,9 +11403,9 @@
    "GC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "chromatography-data-decimation",
    "cluster-statistics-integration",
@@ -11225,10 +11429,11 @@
    "savitzky-golay-smoothing-application",
    "spectral-peak-clustering-gc-ims"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "sipss/GCIMS"
-  ]
+  ],
+  "repo_url": "sipss/GCIMS"
  },
  {
   "slug": "gensim",
@@ -11352,7 +11557,8 @@
   "source_paper_repos": [
    "Qiong-Yang/FastEI",
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "geodesic-interpolate",
@@ -11385,7 +11591,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "grimme-lab/QCxMS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "george",
@@ -11399,9 +11606,9 @@
    "GC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-mass-shift-calculation",
    "isotope-labelling-feature-interpretation",
@@ -11416,10 +11623,11 @@
    "stable-isotope-labelling-feature-detection",
    "xcms-feature-extraction-and-grouping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "jcapelladesto/geoRge"
-  ]
+  ],
+  "repo_url": "jcapelladesto/geoRge"
  },
  {
   "slug": "get-models-sh",
@@ -11460,7 +11668,8 @@
    "tensorflow-serving-layer-inspection"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "get-precmz-prodmz",
@@ -11483,7 +11692,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kslynn128171/MRMQuant"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "getfeatistics",
@@ -11497,9 +11707,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "blank-contamination-ratio-evaluation",
    "compound-database-lookup-and-curation",
@@ -11527,10 +11737,11 @@
    "regression-accuracy-assessment",
    "targeted-metabolomics-feature-elaboration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "FrigerioGianfranco/GetFeatistics"
-  ]
+  ],
+  "repo_url": "FrigerioGianfranco/GetFeatistics"
  },
  {
   "slug": "ggplot",
@@ -11587,7 +11798,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BalunasLab/mpact"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ggplot2",
@@ -11851,7 +12063,8 @@
    "connor-reid-tiffany/Omu",
    "kilgain/MassSpec",
    "wesleyburr/subMaldi"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "git",
@@ -12068,7 +12281,8 @@
    "mibig-secmet/mibig-json",
    "zhanghailiangcsu/MSBERT",
    "zhanghailiangcsu/MWFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-actions-workflow-ci-build-yml",
@@ -12087,7 +12301,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "fermo-metabolomics/FERMO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-actions",
@@ -12242,7 +12457,8 @@
    "OpenMS/OpenMS",
    "iomega/ms2query",
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-com-bittremieux-cosine-neutral-loss",
@@ -12261,7 +12477,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bittremieux/cosine_neutral_loss"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-com-hassounlab-esp",
@@ -12296,7 +12513,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HassounLab/ESP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-com-jlichtarge-pcaglasso",
@@ -12324,7 +12542,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "jlichtarge/pcaGLASSO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-com-wanluliulab-spatialmeta",
@@ -12362,7 +12581,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "WanluLiuLab/SpatialMETA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-com-zsspython-lagf",
@@ -12384,7 +12604,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "github-kbseah-mass2adduct",
@@ -12432,7 +12653,8 @@
    "spectral-peak-parent-product-pairing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "github",
@@ -12758,7 +12980,8 @@
    "wesleyburr/subMaldi",
    "xdomingoal/erah-devel",
    "zhangxiang1205/CorrDIA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gitlab",
@@ -12782,7 +13005,8 @@
   "source_paper_repos": [
    "hcji/TarMet",
    "tidymass/tidymass"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gleams",
@@ -12794,9 +13018,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "embedding-space-dimensionality-reduction",
    "mass-spectra-encoding-neural-network",
@@ -12806,10 +13030,11 @@
    "spectral-feature-vector-generation",
    "spectrum-embedding-clustering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "bittremieux-lab/GLEAMS"
-  ]
+  ],
+  "repo_url": "bittremieux-lab/GLEAMS"
  },
  {
   "slug": "gnps-gc",
@@ -12853,7 +13078,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bittremieux/GNPS_GC"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps-lcms-visualization-dashboard",
@@ -12890,7 +13116,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/GNPS_LCMSDashboard"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps-masst",
@@ -12950,7 +13177,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps-molecular-networking",
@@ -12983,7 +13211,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps-spectral-libraries",
@@ -13016,7 +13245,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps-spectral-networking-molecular-networking",
@@ -13062,7 +13292,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps",
@@ -13470,7 +13701,8 @@
    "mwang87/ReDU-MS2-Documentation",
    "sneumann/xcms",
    "zquinlan/concise"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnps2",
@@ -13583,7 +13815,8 @@
    "NPLinker/nplinker",
    "Wang-Bioinformatics-Lab/GNPS2_Workflows",
    "mwang87/ReDU-MS2-Documentation"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gnuplot",
@@ -13606,7 +13839,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "matteogiulietti/LipidOne"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "google-chrome",
@@ -13631,7 +13865,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lidawei1975/colmarvista"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "google-colab",
@@ -13656,7 +13891,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "alexandrovteam/SpaceM"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "google-colaboratory",
@@ -13684,7 +13920,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "facundof2016/CCSP2.0"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "graph-neural-network-gnn-framework-pytorch-geometric-or-equivalent",
@@ -13725,7 +13962,8 @@
    "smiles-canonicalization-rdkit"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "graphical-time-warping-gtw",
@@ -13762,7 +14000,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ChiungTingWu/ncGTW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "graphormer",
@@ -13798,7 +14037,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HopkinsLaboratory/Graphormer-RT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "grid",
@@ -13827,7 +14067,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gunicorn",
@@ -13861,7 +14102,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ComPlat/chem-spectra-app"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "gx-fba",
@@ -13929,7 +14171,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "h2o",
@@ -13970,7 +14213,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lanagarmire/lilikoi2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "h5py-2-7-1",
@@ -13999,7 +14243,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "h5py",
@@ -14122,7 +14367,8 @@
    "PNNL-m-q/mzapy",
    "bioinfo-ibms-pumc/SMART",
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hacca",
@@ -14151,7 +14397,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LittleLittleCloud/haCCA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hassounlab-bam",
@@ -14186,7 +14433,8 @@
    "spectral-similarity-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "hdf5-reader-writer-library-h5py-h5netcdf-or-equivalent",
@@ -14226,7 +14474,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "swinnenteam/LipidQMap"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hdf5",
@@ -14284,7 +14533,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "PNNL-m-q/mza"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hdf5plugin",
@@ -14363,7 +14613,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "PNNL-m-q/mzapy"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hierarchical-clustering-euclidean-distance-complete-linkage",
@@ -14434,7 +14685,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "hineslab-moccal",
@@ -14476,7 +14728,8 @@
    "twim-ms-data-processing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "hmdb-4",
@@ -14557,7 +14810,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hmdb",
@@ -14632,7 +14886,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "griquelme/tidyms"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hnswlib",
@@ -14663,7 +14918,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Qiong-Yang/FastEI"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "homebrew",
@@ -14693,7 +14949,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hruv",
@@ -14707,9 +14964,9 @@
    "GC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "batch-effect-preprocessing-with-replicate-structure",
    "batch-effect-visualization",
@@ -14729,10 +14986,11 @@
    "ruv-iii-implementation-in-metabolomics",
    "summarizedexperiment-assay-manipulation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "SydneyBioX/hRUV"
-  ]
+  ],
+  "repo_url": "SydneyBioX/hRUV"
  },
  {
   "slug": "html",
@@ -14761,7 +15019,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "htseq-v-0-6-1",
@@ -14829,7 +15088,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "https-doi-org-10-5281-zenodo-11243781",
@@ -14868,7 +15128,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "emosca-cnr/margheRita"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "https-github-com-emosca-cnr-margherita",
@@ -14907,7 +15168,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "emosca-cnr/margheRita"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "https-github-com-sdrogers-nplinker",
@@ -14978,7 +15240,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "https-github-com-shuzhao-li-asari",
@@ -15054,7 +15317,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hugging-face-transformers",
@@ -15085,7 +15349,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenDFM/MS-BART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "human-metabolome-database-hmdb",
@@ -15118,7 +15383,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Leo-Cheng-Lab/ROIAL-NMR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "hyperspec",
@@ -15132,9 +15398,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "binary-representation-generation",
    "gpu-accelerated-computation",
@@ -15149,10 +15415,11 @@
    "proteome-dataset-handling",
    "runtime-performance-benchmarking"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "wh-xu/Hyper-Spec"
-  ]
+  ],
+  "repo_url": "wh-xu/Hyper-Spec"
  },
  {
   "slug": "i-van-krevelen",
@@ -15226,7 +15493,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "iceberg-model",
@@ -15262,7 +15530,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "iceberg-webui",
@@ -15320,7 +15589,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "iceberg",
@@ -15359,7 +15629,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "idsl-csa",
@@ -15374,9 +15645,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chemical-structure-annotation-preparation",
    "composite-spectra-analysis",
@@ -15391,10 +15662,11 @@
    "r-workflow-implementation",
    "retention-time-based-ion-association"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idslme/IDSL.CSA"
-  ]
+  ],
+  "repo_url": "idslme/IDSL.CSA"
  },
  {
   "slug": "idsl-ipa",
@@ -15446,7 +15718,8 @@
   "source_paper_repos": [
    "idslme/IDSL.IPA",
    "idslme/IDSL.UFA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "idsl-ufa",
@@ -15462,19 +15735,20 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "mass-accuracy-tolerance-filtering",
    "molecular-formula-isotopic-profile-matching",
    "ms1-spectral-annotation-chemical-space",
    "peaklist-metabolite-assignment-prioritization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idslme/IDSL.UFA"
-  ]
+  ],
+  "repo_url": "idslme/IDSL.UFA"
  },
  {
   "slug": "idsm",
@@ -15540,7 +15814,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "igraph",
@@ -15636,7 +15911,8 @@
    "LargeMetabo/LargeMetabo",
    "b2slab/mWISE",
    "biodatalab/enrichmet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "image-processing-toolbox",
@@ -15665,7 +15941,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "impute",
@@ -15675,9 +15952,9 @@
    "10.1038/s41596-021-00636-9"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -15700,10 +15977,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/impute"
  },
  {
   "slug": "imzml-writer",
@@ -15716,9 +15994,9 @@
    "MS-imaging",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "docker-container-orchestration",
    "imaging-parameter-metadata-annotation",
@@ -15731,10 +16009,11 @@
    "spatial-pixel-coordinate-alignment",
    "system-path-environment-configuration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "VIU-Metabolomics/imzML_Writer"
-  ]
+  ],
+  "repo_url": "VIU-Metabolomics/imzML_Writer"
  },
  {
   "slug": "independentmassspectrometer",
@@ -15797,7 +16076,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "injectiondesign",
@@ -15829,7 +16109,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "CSi-Studio/InjectionDesign"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "intensity-dependent-missing-value-augmentation",
@@ -15877,7 +16158,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "interactiveplotter",
@@ -15925,7 +16207,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "interactivetwodimensionplotter",
@@ -15974,7 +16257,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "interpretmsspectrum",
@@ -16021,7 +16305,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "cbroeckl/RAMClustR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "iokr",
@@ -16094,7 +16379,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ion-identity",
@@ -16148,7 +16434,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ionflow",
@@ -16171,7 +16458,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wanchanglin/ionflow"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "iontoolpack",
@@ -16220,7 +16508,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ipapy2",
@@ -16232,9 +16521,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "adduct-formation-prediction-for-metabolites",
    "bayesian-annotation-probability-inference",
@@ -16242,10 +16531,11 @@
    "isotope-pattern-spectral-matching",
    "lcms-feature-probability-scoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "francescodc87/ipaPy2"
-  ]
+  ],
+  "repo_url": "https://github.com/francescodc87/ipaPy2"
  },
  {
   "slug": "ipbhalle-metfragweb",
@@ -16279,7 +16569,8 @@
    "web-service-health-verification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "ipresto",
@@ -16313,7 +16604,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://git.wur.nl/bioinformatics/iPRESTO.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "isfrag",
@@ -16325,9 +16617,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "feature-table-integration-and-normalization",
    "in-source-fragment-identification",
@@ -16345,10 +16637,11 @@
    "parent-ion-fragment-hierarchy-organization",
    "r-data-structure-serialization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "HuanLab/ISFrag"
-  ]
+  ],
+  "repo_url": "HuanLab/ISFrag"
  },
  {
   "slug": "isoformswitchanalyzer",
@@ -16358,9 +16651,9 @@
    "10.1093/bioadv/vbae175"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -16394,10 +16687,11 @@
    "sra-data-retrieval-and-ingestion",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": "https://github.com/kvittingseerup/IsoformSwitchAnalyzeR"
  },
  {
   "slug": "isofusion",
@@ -16411,9 +16705,9 @@
    "CE-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "docker-containerized-pipeline-execution",
    "gradient-flow-backpropagation-validation",
@@ -16428,10 +16722,11 @@
    "retention-time-prediction",
    "tensor-dimension-alignment-and-broadcasting"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "xfcui/IsoFusion"
-  ]
+  ],
+  "repo_url": "xfcui/IsoFusion"
  },
  {
   "slug": "isopairfinder",
@@ -16457,7 +16752,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "isoscan",
@@ -16471,9 +16767,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "gc-ci-ms-data-processing",
    "gc-ms-abundance-preprocessing",
@@ -16489,10 +16785,11 @@
    "r-data-frame-transformation",
    "stable-isotope-labeling-quantification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "jcapelladesto/isoSCAN"
-  ]
+  ],
+  "repo_url": "jcapelladesto/isoSCAN"
  },
  {
   "slug": "java-21",
@@ -16526,7 +16823,8 @@
    "web-service-health-verification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "java",
@@ -16569,7 +16867,8 @@
   "source_paper_repos": [
    "Le0nT1/CyProduct",
    "simeoni-biolab/MetNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "javafx-24",
@@ -16640,7 +16939,8 @@
    "workflow-status-monitoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "javascript",
@@ -16669,7 +16969,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "javax-faces-2-2-12-jar",
@@ -16691,7 +16992,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "albertogilf/ceuMassMediator"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jdk-25",
@@ -16762,7 +17064,8 @@
    "workflow-status-monitoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "jfreechart",
@@ -16835,7 +17138,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jms",
@@ -16916,7 +17220,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "joblib",
@@ -16969,7 +17274,8 @@
   "source_paper_repos": [
    "ablab/npdtools",
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jopt-simple",
@@ -17042,7 +17348,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jorhelp-docker-image",
@@ -17072,7 +17379,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "xfcui/IsoFusion"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jpa-r-package",
@@ -17109,7 +17417,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HuanLab/JPA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jpa",
@@ -17122,9 +17431,9 @@
    "LC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "aligned-feature-table-manipulation",
    "alignment-quality-assessment",
@@ -17146,10 +17455,11 @@
    "target-list-matching-and-alignment",
    "targeted-feature-extraction-from-lcms"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "HuanLab/JPA"
-  ]
+  ],
+  "repo_url": "HuanLab/JPA"
  },
  {
   "slug": "jsonschema",
@@ -17222,7 +17532,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MoseleyBioinformaticsLab/mwtab"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jupyter-lab",
@@ -17250,7 +17561,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "facundof2016/CCSP2.0"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jupyter-notebook",
@@ -17285,7 +17597,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kevinmildau/msFeaST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "jupyter-notebooks",
@@ -17316,7 +17629,8 @@
    "tsne-embedding-dimensionality-reduction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "jupyter",
@@ -17371,7 +17685,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "griquelme/tidyms"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "kableextra",
@@ -17429,7 +17744,8 @@
    "targeted-peak-integration-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "kaleido",
@@ -17466,7 +17782,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pmartR/PMart_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "kegg-database",
@@ -17512,7 +17829,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "b2slab/mWISE"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "kegg",
@@ -17570,7 +17888,8 @@
   "source_paper_repos": [
    "biodatalab/enrichmet",
    "simeoni-biolab/MetNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "keggrest",
@@ -17586,9 +17905,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "analytical-pipeline-feature-documentation",
    "aromaticity-index-computation",
@@ -17690,11 +18009,12 @@
    "variable-importance-ranking-and-interpretation",
    "volcano-plot-construction-from-fold-change-and-pvalue"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "biodatalab/enrichmet",
    "connor-reid-tiffany/Omu"
-  ]
+  ],
+  "repo_url": "https://github.com/Bioconductor/KEGGREST"
  },
  {
   "slug": "keras-2-2-0",
@@ -17721,7 +18041,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "keras",
@@ -17832,7 +18153,8 @@
    "mwang87/NP-Classifier",
    "slfan2013/SERDA",
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "khipu",
@@ -17983,7 +18305,8 @@
   "source_paper_repos": [
    "shuzhao-li-lab/asari",
    "shuzhao-li-lab/khipu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "knime",
@@ -18038,7 +18361,8 @@
   "source_paper_repos": [
    "MolecularCartography/Optimus",
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "knitr",
@@ -18119,7 +18443,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MRCIEU/metaboprep"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "largemetabo",
@@ -18133,9 +18458,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "abundance-matrix-processing",
    "batch-effect-removal-metabolomic-data",
@@ -18158,10 +18483,11 @@
    "pathway-annotation-database-matching",
    "retention-time-mass-tolerance-calibration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LargeMetabo/LargeMetabo"
-  ]
+  ],
+  "repo_url": "LargeMetabo/LargeMetabo"
  },
  {
   "slug": "latent-dirichlet-allocation-lda",
@@ -18247,7 +18573,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lcmsworld",
@@ -18259,18 +18586,19 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "binary-and-xml-data-deserialization",
    "retention-time-mz-indexing",
    "thermo-raw-format-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "PGB-LIV/lcmsWorld"
-  ]
+  ],
+  "repo_url": "PGB-LIV/lcmsWorld"
  },
  {
   "slug": "lda-latent-dirichlet-allocation",
@@ -18306,7 +18634,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HassounLab/ESP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lib2nist",
@@ -18361,7 +18690,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "lilikoi-v2-0",
@@ -18374,9 +18704,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "classification-performance-metric-evaluation",
    "cox-regression-model-fitting",
@@ -18400,10 +18730,11 @@
    "survival-data-preparation",
    "weka-format-pathway-export"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "lanagarmire/lilikoi2"
-  ]
+  ],
+  "repo_url": "lanagarmire/lilikoi2"
  },
  {
   "slug": "limma",
@@ -18424,9 +18755,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "batch-effect-correction-in-metabolomics",
@@ -18558,14 +18889,15 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "ShinyFabio/ADViSELipidomics",
    "ahmohamed/lipidr",
    "idrblab/NOREVA;",
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/limma"
  },
  {
   "slug": "lipid-map",
@@ -18632,7 +18964,8 @@
    "zero-value-handling-in-mass-spectrometry-data"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "lipid-maps",
@@ -18669,7 +19002,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lipidlynxx",
@@ -18679,9 +19013,9 @@
    "10.1101/2020.04.09.033894"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "cross-database-nomenclature-alignment",
    "identifier-mapping-implementation",
@@ -18690,10 +19024,11 @@
    "oxidized-lipid-nomenclature-conversion",
    "validation-test-design-for-biochemical-identifiers"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "SysMedOs/LipidLynxX"
-  ]
+  ],
+  "repo_url": "SysMedOs/LipidLynxX"
  },
  {
   "slug": "lipidmatch",
@@ -18710,9 +19045,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "CC-BY-4.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "acquisition-mode-enumeration-and-validation",
    "analysis-type-selection",
@@ -18762,11 +19097,12 @@
    "uhplc-hrms-ms-data-matching",
    "version-specific-deployment-configuration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch",
    "InnovativeOmics/Core-Match"
-  ]
+  ],
+  "repo_url": "GarrettLab-UF/LipidMatch"
  },
  {
   "slug": "lipidqmap",
@@ -18808,7 +19144,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "swinnenteam/LipidQMap"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lipidr",
@@ -18821,9 +19158,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "ceramide-name-standardization-with-regex",
    "differential-expression-ranking",
@@ -18846,10 +19183,11 @@
    "sampletype-phenotype-stratified-plotting",
    "volcano-plot-interpretation-cancer-benign"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ahmohamed/lipidr"
-  ]
+  ],
+  "repo_url": "https://github.com/ahmohamed/lipidr"
  },
  {
   "slug": "lipidsearch",
@@ -18886,7 +19224,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lipidspace",
@@ -18896,9 +19235,9 @@
    "10.1021/acs.analchem.3c02449"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "build-artifact-validation",
    "build-system-configuration-identification",
@@ -18912,10 +19251,11 @@
    "source-code-repository-cloning",
    "structural-distance-metric-computation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "lifs-tools/lipidspace"
-  ]
+  ],
+  "repo_url": "lifs-tools/lipidspace"
  },
  {
   "slug": "lipoclean",
@@ -18929,9 +19269,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "command-line-tool-execution",
    "command-line-tool-invocation",
@@ -18946,8 +19286,9 @@
    "toml-configuration-file-preparation",
    "toml-format-validation"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/stavis1/LipoCLEAN"
  },
  {
   "slug": "liquid",
@@ -18984,7 +19325,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ShinyFabio/ADViSELipidomics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lme4",
@@ -19029,7 +19371,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "FrigerioGianfranco/GetFeatistics"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "local-code-artifact",
@@ -19048,7 +19391,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "CNIC-Proteomics/TurboPutative"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lotus-database",
@@ -19101,7 +19445,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lowess",
@@ -19179,7 +19524,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lsg-lipid-spectrum-generator",
@@ -19215,7 +19561,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "98104781/LSG"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "lsg",
@@ -19254,7 +19601,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "98104781/LSG"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "madbyte",
@@ -19266,9 +19614,9 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "heteronuclear-homonuclear-correlation-extraction",
    "nmr-network-visualization-and-interpretation",
@@ -19276,10 +19624,11 @@
    "sample-prioritization-through-structural-clustering",
    "structural-scaffold-feature-identification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "liningtonlab/madbyte"
-  ]
+  ],
+  "repo_url": "liningtonlab/madbyte"
  },
  {
   "slug": "mag-mass2motif-annotation-guidance",
@@ -19364,7 +19713,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mag",
@@ -19448,7 +19798,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "magma",
@@ -19465,9 +19816,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "annotation-pipeline-data-preparation",
    "api-specification-extraction",
@@ -19503,8 +19854,9 @@
    "structured-inventory-compilation",
    "volume-mount-and-persistence-design"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/NLeSC/MAGMa"
  },
  {
   "slug": "magrittr",
@@ -19554,7 +19906,8 @@
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures",
    "krumsieklab/maplet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "make",
@@ -19638,7 +19991,8 @@
   "source_paper_repos": [
    "eugenemel/maven",
    "lotusnprod/lotus-processor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mamsi-mamsistructsearch",
@@ -19698,7 +20052,8 @@
    "structural-cluster-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mamsistructsearch",
@@ -19758,7 +20113,8 @@
    "structural-cluster-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mann-whitney-u-test",
@@ -19826,7 +20182,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "manual-expert-review",
@@ -19907,7 +20264,8 @@
    "yaml-json-structural-parsing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "maplet",
@@ -19917,9 +20275,9 @@
    "10.1093/bioinformatics/btab741"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "maplet-function-composition",
    "metabolomics-data-loading-into-containers",
@@ -19927,10 +20285,11 @@
    "self-contained-pipeline-construction",
    "summarized-experiment-initialization-and-population"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "krumsieklab/maplet"
-  ]
+  ],
+  "repo_url": "krumsieklab/maplet"
  },
  {
   "slug": "margherita",
@@ -19972,7 +20331,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "emosca-cnr/margheRita"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mariadb-10",
@@ -20001,7 +20361,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "marr",
@@ -20014,9 +20375,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "bayesian-dimensionality-reduction-application",
    "feature-table-subsetting-and-export",
@@ -20037,10 +20398,11 @@
    "summarized-experiment-data-structure-handling",
    "summarized-experiment-object-manipulation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "Ghoshlab/marr"
-  ]
+  ],
+  "repo_url": "https://github.com/Ghoshlab/marr"
  },
  {
   "slug": "mascot-generic-format-mgf",
@@ -20062,7 +20424,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "beherasan/MS2Compound"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mass-functions-nn-cluster-by-mz-seeds",
@@ -20141,7 +20504,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mass-query-language-massql",
@@ -20175,7 +20539,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "biorack/chemecho"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mass2adduct",
@@ -20191,9 +20556,9 @@
    "MS-imaging",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-annotation-against-reference-library",
    "adduct-ion-parent-ion-pairing-analysis",
@@ -20228,8 +20593,9 @@
    "spectral-annotation-and-overlay-visualization",
    "spectral-peak-parent-product-pairing"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/kbseah/mass2adduct"
  },
  {
   "slug": "mass2chem",
@@ -20268,7 +20634,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/khipu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massbank-web-validator",
@@ -20295,7 +20662,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MassBank/MassBank-data"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massbank-web",
@@ -20320,7 +20688,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MassBank/MassBank-data"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massbank",
@@ -20378,7 +20747,8 @@
    "daniellyz/meRgeION2",
    "mwang87/MetabolomicsSpectrumResolver",
    "xdomingoal/erah-devel"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "masscube",
@@ -20396,9 +20766,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "noncommercial",
+  "license": "CC-BY-NC-4.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "chromatographic-peak-detection-and-segmentation",
    "chromatographic-resolution-evaluation",
@@ -20421,10 +20791,11 @@
    "signal-to-noise-ratio-computation",
    "spectral-similarity-scoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "huaxuyu/masscube"
-  ]
+  ],
+  "repo_url": "huaxuyu/masscube"
  },
  {
   "slug": "massdash-loaders-resultsloader",
@@ -20472,7 +20843,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massdash-peakpickers-mrmtransitiongrouppicker",
@@ -20520,7 +20892,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massdash-peakpickers-pymrmtransitiongrouppicker",
@@ -20568,7 +20941,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massdash-plotting-interactiveplotter",
@@ -20616,7 +20990,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massdash-structs-featuremap",
@@ -20664,7 +21039,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massdash",
@@ -20677,9 +21053,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "analyte-metadata-hierarchical-indexing",
    "chromatogram-extraction-and-visualization",
@@ -20710,10 +21086,11 @@
    "transition-group-peak-picking",
    "upset-plot-generation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": "https://github.com/Roestlab/massdash"
  },
  {
   "slug": "masshunter-profinder",
@@ -20781,7 +21158,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "massive",
@@ -20827,7 +21205,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/ReDU-MS2-Documentation"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "massql",
@@ -20842,9 +21221,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "abstract-syntax-tree-construction",
    "abstract-syntax-tree-design",
@@ -20942,12 +21321,13 @@
    "topic-modeling-lda",
    "unit-test-validation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "JohnsonDylan/MassQLab",
    "mwang87/MassQueryLanguage",
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": "mwang87/MassQueryLanguage"
  },
  {
   "slug": "massqlab",
@@ -20959,9 +21339,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "data-visualization-from-tabulated-results",
    "file-format-export-and-validation",
@@ -20973,10 +21353,11 @@
    "query-result-tabulation",
    "spectral-data-visualization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "JohnsonDylan/MassQLab"
-  ]
+  ],
+  "repo_url": "JohnsonDylan/MassQLab"
  },
  {
   "slug": "massspecwavelet",
@@ -20989,9 +21370,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chromatographic-alignment-parameter-selection",
    "chromatographic-feature-refinement",
@@ -21036,10 +21417,11 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/zeehio/MassSpecWavelet"
  },
  {
   "slug": "masst",
@@ -21069,7 +21451,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mohimanilab/MASSTplus"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "matchms",
@@ -21093,9 +21476,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "background-ion-blank-comparison",
    "background-ion-contaminant-removal",
@@ -21305,12 +21688,13 @@
    "word2vec-vocabulary-matching-and-unknown-peak-handling",
    "zero-value-handling-in-mass-spectrometry-data"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "matchms/MS2DeepScore",
    "matchms/matchms",
    "tingxiecsu/CSU-MS2"
-  ]
+  ],
+  "repo_url": "https://github.com/matchms/matchms"
  },
  {
   "slug": "math-distance",
@@ -21339,7 +21723,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "YuanyueLi/SpectralEntropy"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "matlab-compiler-runtime-8-3",
@@ -21367,7 +21752,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Viant-Metabolomics/Galaxy-M"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "matlab-r2024a",
@@ -21396,7 +21782,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "matlab",
@@ -21445,7 +21832,8 @@
   "source_paper_repos": [
    "KechrisLab/DisCoPad",
    "dickinsonlab/DIMPLE-code"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "matplotlib-or-seaborn-for-visualization",
@@ -21480,7 +21868,8 @@
    "tensor-encoding-deep-learning"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "matplotlib",
@@ -21886,7 +22275,8 @@
    "ablab/npdtools",
    "chopralab/CLAW",
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "maven-gui",
@@ -21916,7 +22306,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "maxquant",
@@ -21985,7 +22376,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mbpls",
@@ -22043,7 +22435,8 @@
    "structural-cluster-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mcfnmr",
@@ -22055,9 +22448,9 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "compound-abundance-quantification-from-flow",
    "emd-spectral-distance-computation",
@@ -22069,10 +22462,11 @@
    "spectral-mixture-deconvolution",
    "wasserstein-distance-computation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "GeoMetabolomics-ICBM/mcfNMR"
-  ]
+  ],
+  "repo_url": "GeoMetabolomics-ICBM/mcfNMR"
  },
  {
   "slug": "meister",
@@ -22086,9 +22480,9 @@
    "CE-MS",
    "MS-imaging"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "deep-learning-model-training",
    "high-dimensional-signal-enhancement",
@@ -22096,10 +22490,11 @@
    "model-validation-and-performance-evaluation",
    "reconstruction-algorithm-implementation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "richardxie1119/MEISTER"
-  ]
+  ],
+  "repo_url": "richardxie1119/MEISTER"
  },
  {
   "slug": "melonnpan-elastic-net-linear-regression",
@@ -22170,7 +22565,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "melonnpan",
@@ -22245,7 +22641,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "memo-ms",
@@ -22300,7 +22697,8 @@
    "spectrum-normalization-and-standardization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "memo",
@@ -22392,7 +22790,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mergeion2",
@@ -22429,7 +22828,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "daniellyz/meRgeION2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "messes",
@@ -22500,7 +22900,8 @@
    "validation-error-categorization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "metabcombiner",
@@ -22513,9 +22914,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "anchor-feature-pair-selection",
    "combined-table-extraction-and-inspection",
@@ -22539,10 +22940,11 @@
    "retention-time-mapping-spline-fitting",
    "smoothing-spline-basis-selection"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "hhabra/metabCombiner"
-  ]
+  ],
+  "repo_url": "https://www.github.com/hhabra/metabCombiner"
  },
  {
   "slug": "metaboanalyst",
@@ -22701,7 +23103,8 @@
    "13479776/statTarget",
    "cellbiomaths/MInfer",
    "scibiome/meteor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metaboanalystr",
@@ -22716,9 +23119,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "feature-table-generation-from-aligned-spectra",
    "lcms-feature-detection-and-quantification",
@@ -22730,10 +23133,11 @@
    "retention-time-and-mz-based-alignment",
    "spectral-peak-detection-and-deconvolution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "xia-lab/MetaboAnalystR"
-  ]
+  ],
+  "repo_url": "xia-lab/MetaboAnalystR"
  },
  {
   "slug": "metaboannotator",
@@ -22746,9 +23150,9 @@
    "LC-MS",
    "CE-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "aif-spectrum-fragment-database-matching",
    "annotaterc-function-parameterization",
@@ -22784,8 +23188,9 @@
    "xcms-ramclustr-data-object-integration",
    "xcms-ramclustr-object-integration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/gggraca/MetaboAnnotatoR"
  },
  {
   "slug": "metabocoreutils",
@@ -22801,9 +23206,9 @@
    "CE-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "bioconductor-data-import-and-handling",
    "ce-ms-data-import-and-parsing",
@@ -22865,11 +23270,12 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LiesaSalzer/MobilityTransformR",
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/RforMassSpectrometry/MetaboCoreUtils"
  },
  {
   "slug": "metabodiff",
@@ -22913,7 +23319,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "andreasmock/MetaboDiff"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metabodirect",
@@ -22929,9 +23336,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "analytical-pipeline-feature-documentation",
    "aromaticity-index-computation",
@@ -22988,8 +23395,9 @@
    "transformation-network-topology-analysis",
    "unsaturation-degree-quantification"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/Coayala/MetaboDirect"
  },
  {
   "slug": "metabolabpy",
@@ -23001,18 +23409,19 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-or-later",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "command-line-interface-invocation",
    "package-entry-point-verification",
    "python-package-installation-from-source"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ludwigc/metabolabpy"
-  ]
+  ],
+  "repo_url": "https://github.com/ludwigc/metabolabpy"
  },
  {
   "slug": "metabolights",
@@ -23047,7 +23456,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metabolomics-workbench-api",
@@ -23087,7 +23497,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ahmohamed/lipidr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metabolomics-workbench",
@@ -23120,7 +23531,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metaboprep",
@@ -23133,9 +23545,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "cross-table-metadata-harmonization",
    "hierarchical-clustering-dendrogram-construction",
@@ -23156,10 +23568,11 @@
    "sample-quality-assessment-using-pca",
    "tab-delimited-export-formatting-for-metabolomics"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "MRCIEU/metaboprep"
-  ]
+  ],
+  "repo_url": "MRCIEU/metaboprep"
  },
  {
   "slug": "metaboshiny",
@@ -23175,9 +23588,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-mass-shift-calculation",
    "batch-effect-correction-and-adjustment",
@@ -23198,10 +23611,11 @@
    "spectral-peak-intensity-normalization",
    "spectral-similarity-scoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "joannawolthuis/MetaboShiny"
-  ]
+  ],
+  "repo_url": "joannawolthuis/MetaboShiny"
  },
  {
   "slug": "metaclean",
@@ -23239,7 +23653,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "KelseyChetnik/MetaClean"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metadatamasst",
@@ -23297,7 +23712,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metamapr",
@@ -23307,19 +23723,20 @@
    "10.1093/bioinformatics/btv194"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "cytoscape-network-format-export",
    "metabolomic-network-edge-type-prioritization",
    "network-graph-filtering-by-hierarchy",
    "node-pair-edge-deduplication"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "dgrapov/MetaMapR"
-  ]
+  ],
+  "repo_url": "dgrapov/MetaMapR"
  },
  {
   "slug": "metaminer",
@@ -23366,7 +23783,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metams",
@@ -23381,9 +23799,9 @@
    "CE-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "computational-environment-configuration",
    "dependency-requirement-validation",
@@ -23391,10 +23809,11 @@
    "r-package-version-detection",
    "semantic-version-parsing-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "HuanLab/DaDIA"
-  ]
+  ],
+  "repo_url": "https://github.com/yguitton/metaMS"
  },
  {
   "slug": "metanet",
@@ -23406,9 +23825,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "correlation-network-characterization",
    "correlation-network-construction-omics",
@@ -23425,10 +23844,11 @@
    "omics-network-visualization-preparation",
    "scalable-network-inference-high-dimensional"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "Asa12138/MetaNet"
-  ]
+  ],
+  "repo_url": "Asa12138/MetaNet"
  },
  {
   "slug": "metanorm-r-package",
@@ -23458,7 +23878,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "UGent-LIMET/Metanorm"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metanorm",
@@ -23490,7 +23911,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "UGent-LIMET/Metanorm"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metaxtract",
@@ -23502,19 +23924,20 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "mass-spectrometry-data-extraction",
    "python-library-integration",
    "raw-file-format-parsing",
    "tabular-data-export"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "Rappsilber-Laboratory/MetaXtract"
-  ]
+  ],
+  "repo_url": "Rappsilber-Laboratory/MetaXtract"
  },
  {
   "slug": "metcohort",
@@ -23526,9 +23949,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chromatogram-peak-matching-registration",
    "chromatographic-data-visualization",
@@ -23541,10 +23964,11 @@
    "retention-time-alignment-correction",
    "rt-transformation-parameter-calculation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "JunYang2021/MetCohort"
-  ]
+  ],
+  "repo_url": "JunYang2021/MetCohort"
  },
  {
   "slug": "metcorr",
@@ -23586,7 +24010,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "plyush1993/OUKS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metdatamodel",
@@ -23600,9 +24025,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "adduct-mass-offset-assignment",
    "connected-component-decomposition-in-mass-spectrometry",
@@ -23622,10 +24047,11 @@
    "theoretical-mz-grid-generation",
    "tree-structure-optimization-for-metabolite-deconvolution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "shuzhao-li-lab/khipu"
-  ]
+  ],
+  "repo_url": "https://github.com/shuzhao-li/metDataModel"
  },
  {
   "slug": "metdna2-r-package",
@@ -23642,7 +24068,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ZhuMetLab/MetDNA2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "meteor",
@@ -23674,7 +24101,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "scibiome/meteor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "metfrag",
@@ -23694,9 +24122,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-3.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "annotation-candidate-ranking-tp-score",
    "blank-contamination-ratio-evaluation",
@@ -23778,13 +24206,14 @@
    "transformation-product-prediction",
    "web-service-health-verification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "FrigerioGianfranco/GetFeatistics",
    "https://gitlab.com/uniluxembourg/lcsb/eci/shinyscreen.git",
    "rickhelmus/patRoon",
    "zmahnoor14/MAW"
-  ]
+  ],
+  "repo_url": "http://c-ruttkies.github.io/MetFrag/"
  },
  {
   "slug": "metnet",
@@ -23794,9 +24223,9 @@
    "10.1371/journal.pone.0246962"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "cross-organism-network-comparison",
    "functional-level-metabolic-annotation",
@@ -23811,10 +24240,11 @@
    "pathway-function-mapping",
    "structural-level-pathway-topology-modeling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "simeoni-biolab/MetNet"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/MetNet"
  },
  {
   "slug": "metscriber",
@@ -23827,9 +24257,9 @@
    "LC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "interactive-workflow-validation",
    "mass-spectrometry-data-processing",
@@ -23840,10 +24270,11 @@
    "untargeted-metabolomics-annotation",
    "user-interface-integration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ncats/metScribeR"
-  ]
+  ],
+  "repo_url": "ncats/metScribeR"
  },
  {
   "slug": "mgcv",
@@ -23885,7 +24316,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "hhabra/metabCombiner"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mibig",
@@ -23972,7 +24404,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "microbemasst",
@@ -24030,7 +24463,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "microbiomemasst",
@@ -24088,7 +24522,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "microsoft-visual-c-runtime-x64",
@@ -24132,7 +24567,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mimenet",
@@ -24147,9 +24583,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "ablation-study-design-and-interpretation",
    "background-distribution-generation-shuffled-omics",
@@ -24207,8 +24643,9 @@
    "spearman-correlation-statistical-analysis",
    "transformation-method-comparison"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/YDaiLab/MiMeNet"
  },
  {
   "slug": "mimir",
@@ -24237,7 +24674,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DanieleBizzarri/MiMIR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "minems2",
@@ -24263,7 +24701,8 @@
    "precision-recall-optimization-in-spectral-annotation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "minfer",
@@ -24273,9 +24712,9 @@
    "10.1016/j.cmpb.2025.108672"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "covariance-matrix-inversion",
    "directed-edge-weight-encoding",
@@ -24290,10 +24729,11 @@
    "metabolomics-data-normalization",
    "network-layout-algorithm-selection"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "cellbiomaths/MInfer"
-  ]
+  ],
+  "repo_url": "cellbiomaths/MInfer"
  },
  {
   "slug": "miniconda",
@@ -24338,7 +24778,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LabLaskin/MSIGen"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mirador",
@@ -24386,7 +24827,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "missforest",
@@ -24427,7 +24869,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "antonvsdata/notame"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mist-cf",
@@ -24442,9 +24885,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-assignment-accuracy-assessment",
    "adduct-specific-model-fine-tuning",
@@ -24490,8 +24933,9 @@
    "tensor-embedding-design",
    "transformer-input-preprocessing"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/samgoldman97/mist-cf"
  },
  {
   "slug": "mist",
@@ -24566,7 +25010,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/mist"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mixomics",
@@ -24581,9 +25026,9 @@
    "GC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "2d-tic-preprocessing",
    "abundance-matrix-processing",
@@ -24625,11 +25070,12 @@
    "two-dimensional-tic-folding",
    "whittaker-smoother-signal-denoising"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "DanielQuiroz97/RGCxGC",
    "LargeMetabo/LargeMetabo"
-  ]
+  ],
+  "repo_url": "https://github.com/mixOmicsTeam/mixOmics"
  },
  {
   "slug": "mobilipid",
@@ -24667,7 +25113,8 @@
    "u13c-labeled-standard-reference-matching"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mobilitytransformr",
@@ -24680,9 +25127,9 @@
    "LC-MS",
    "CE-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "r-description",
   "used_by_skills": [
    "bioconductor-data-import-and-handling",
    "ce-ms-data-import-and-parsing",
@@ -24702,10 +25149,11 @@
    "r-workflow-scripting-for-analytical-chemistry",
    "unified-mobility-scale-construction-across-polarities"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LiesaSalzer/MobilityTransformR"
-  ]
+  ],
+  "repo_url": "LiesaSalzer/MobilityTransformR"
  },
  {
   "slug": "moccal",
@@ -24719,9 +25167,9 @@
    "CE-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "arrival-time-based-class-assignment",
    "arrival-time-to-ccs-conversion",
@@ -24747,8 +25195,9 @@
    "twim-ms-data-preprocessing",
    "twim-ms-data-processing"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/HinesLab/MOCCal"
  },
  {
   "slug": "mode-shinyapp",
@@ -24770,7 +25219,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pmartR/MODE_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "modifinder",
@@ -24810,7 +25260,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/ModiFinder_base"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "molbar",
@@ -24843,7 +25294,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "grimme-lab/QCxMS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "moldiscovery",
@@ -24868,7 +25320,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mohimanilab/molDiscovery"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "moletrans",
@@ -24882,9 +25335,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chemodiversity-descriptor-calculation",
    "dom-chemodiversity-characterization",
@@ -24897,10 +25350,11 @@
    "molecular-transformation-frequency-filtering",
    "reactomics-annotation-and-clustering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "JibaoLiu/MoleTrans"
-  ]
+  ],
+  "repo_url": "JibaoLiu/MoleTrans"
  },
  {
   "slug": "molmass",
@@ -24949,7 +25403,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "FanzhouKong/spectral_denoising"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "molnotator",
@@ -24961,9 +25416,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "bipartite-network-node-edge-assembly",
    "file-i-o-automation",
@@ -24979,10 +25434,11 @@
    "spectrum-subset-extraction",
    "yaml-configuration-handling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ZzakB/MolNotator"
-  ]
+  ],
+  "repo_url": "ZzakB/MolNotator"
  },
  {
   "slug": "mona",
@@ -25037,7 +25493,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mongodb",
@@ -25087,7 +25544,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "tyo-nu/MINE-Database"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "monte-carlo-dropout",
@@ -25157,7 +25615,8 @@
    "uncertainty-quantification-from-model-predictions"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mordred",
@@ -25195,7 +25654,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HopkinsLaboratory/Graphormer-RT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "motifdb",
@@ -25280,7 +25740,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mozilla-firefox",
@@ -25305,7 +25766,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lidawei1975/colmarvista"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mpactr",
@@ -25364,7 +25826,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BalunasLab/mpact"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mrmquant",
@@ -25387,7 +25850,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kslynn128171/MRMQuant"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mrmtransitiongrouppicker",
@@ -25436,7 +25900,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mrnannoalgo3-metdna3",
@@ -25469,7 +25934,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ZhuMetLab/MrnAnnoAlgo3"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-cleanr",
@@ -25483,9 +25949,9 @@
    "CE-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "annotation-confidence-assessment",
    "background-ion-drift-detection-and-removal",
@@ -25506,10 +25972,11 @@
    "peak-intensity-chromatographic-property-analysis",
    "relative-mass-defect-window-filtering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "eMetaboHUB/MS-CleanR"
-  ]
+  ],
+  "repo_url": "eMetaboHUB/MS-CleanR"
  },
  {
   "slug": "ms-dial-4",
@@ -25541,7 +26008,8 @@
    "toml-format-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "ms-dial-5",
@@ -25573,7 +26041,8 @@
    "toml-format-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "ms-dial-or-higher",
@@ -25609,7 +26078,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eMetaboHUB/MS-CleanR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-dial-v4-00-or-higher",
@@ -25647,7 +26117,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eMetaboHUB/MS-CleanR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-dial",
@@ -25897,7 +26368,8 @@
    "emosca-cnr/margheRita",
    "huaxuyu/bago",
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-distance",
@@ -25928,7 +26400,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "YuanyueLi/SpectralEntropy"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-entropy",
@@ -25940,9 +26413,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "chemical-noise-subformula-loss-filtering",
    "chemical-noise-tagging-and-filtering",
@@ -25974,10 +26447,11 @@
    "subformula-enumeration",
    "subformula-enumeration-and-mass-calculation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "FanzhouKong/spectral_denoising"
-  ]
+  ],
+  "repo_url": "https://github.com/YuanyueLi/MSEntropy"
  },
  {
   "slug": "ms-finder",
@@ -26018,7 +26492,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eMetaboHUB/MS-CleanR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-pred-iceberg",
@@ -26055,7 +26530,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-pred-scarf-model",
@@ -26109,7 +26585,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-pred",
@@ -26149,7 +26626,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "samgoldman97/ms-pred"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-rescore",
@@ -26188,7 +26666,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "compomics/ms2rescore"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms-search",
@@ -26241,7 +26720,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "ms2compound",
@@ -26253,19 +26733,20 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "CC-BY-4.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "compound-identification-from-ms-ms",
    "custom-database-searching",
    "similarity-scoring-for-spectra",
    "spectral-library-matching"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "beherasan/MS2Compound"
-  ]
+  ],
+  "repo_url": "beherasan/MS2Compound"
  },
  {
   "slug": "ms2deepscore",
@@ -26285,9 +26766,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-normalization-implementation",
    "changelog-maintenance-and-documentation",
@@ -26370,10 +26851,11 @@
    "uncertainty-quantification-from-model-predictions",
    "unit-test-design-for-model-parameters"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "matchms/MS2DeepScore"
-  ]
+  ],
+  "repo_url": "https://github.com/matchms/ms2deepscore"
  },
  {
   "slug": "ms2lda-preprocessing-generate-corpus",
@@ -26458,7 +26940,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms2lda-preprocessing-load-and-clean",
@@ -26543,7 +27026,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms2lda",
@@ -26561,9 +27045,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "activity-score-computation-and-reporting",
    "activity-score-robustness-assessment",
@@ -26687,13 +27171,14 @@
    "usi-namespace-parsing",
    "usi-spectrum-identifier-encoding"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "glasgowcompbio/PALS",
    "madeleineernst/pyMolNetEnhancer",
    "mwang87/MetabolomicsSpectrumResolver",
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": "vdhooftcompmet/MS2LDA"
  },
  {
   "slug": "ms2mp",
@@ -26717,7 +27202,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ucasaccn/MS2MP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ms2query",
@@ -26731,9 +27217,9 @@
    "CE-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "analog-search-result-routing",
    "candidate-match-retrieval",
@@ -26778,10 +27264,11 @@
    "workflow-architecture-documentation",
    "workflow-branching-logic-design"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "iomega/ms2query"
-  ]
+  ],
+  "repo_url": "https://github.com/iomega/ms2query"
  },
  {
   "slug": "msbackendmgf",
@@ -26796,9 +27283,9 @@
    "CE-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chromatographic-alignment-parameter-selection",
    "chromatographic-feature-refinement",
@@ -26843,10 +27330,11 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/RforMassSpectrometry/MsBackendMgf"
  },
  {
   "slug": "msbackendmzr",
@@ -26918,7 +27406,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msconvert-proteowizard",
@@ -26977,7 +27466,8 @@
    "targeted-peak-integration-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "msconvert",
@@ -27227,7 +27717,8 @@
    "griquelme/tidyms",
    "guomics-lab/iDIA-QC",
    "xfcui/IsoFusion"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msdata",
@@ -27265,7 +27756,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LiesaSalzer/MobilityTransformR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msdatahub",
@@ -27278,9 +27770,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chromatographic-alignment-parameter-selection",
    "chromatographic-feature-refinement",
@@ -27325,10 +27817,11 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/RforMassSpectrometry/MsDataHub"
  },
  {
   "slug": "msentropy",
@@ -27345,9 +27838,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "algorithm-performance-benchmarking",
    "chemical-noise-subformula-loss-filtering",
@@ -27397,12 +27890,13 @@
    "subformula-enumeration-and-mass-calculation",
    "xenobiotic-metabolite-annotation-from-ms-ms"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN",
    "YuanyueLi/FlashEntropySearch",
    "YuanyueLi/SpectralEntropy"
-  ]
+  ],
+  "repo_url": "https://github.com/YuanyueLi/MSEntropy"
  },
  {
   "slug": "msexperiment",
@@ -27418,9 +27912,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chromatographic-peak-annotation-visualization",
    "chromatographic-peak-characterization",
@@ -27463,8 +27957,9 @@
    "targeted-peak-detection-screening-and-validation",
    "targeted-peak-integration-configuration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/RforMassSpectrometry/MsExperiment"
  },
  {
   "slug": "msfeast",
@@ -27477,9 +27972,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "dashboard-data-loading-and-validation",
    "feature-metadata-annotation",
@@ -27496,10 +27991,11 @@
    "spectral-data-exploration",
    "spectral-data-integration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "kevinmildau/msFeaST"
-  ]
+  ],
+  "repo_url": "kevinmildau/msFeaST"
  },
  {
   "slug": "msfeatures",
@@ -27516,9 +28012,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "chromatographic-alignment-parameter-selection",
    "chromatographic-feature-refinement",
@@ -27563,10 +28059,11 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/RforMassSpectrometry/MsFeatures"
  },
  {
   "slug": "msfiddle",
@@ -27633,7 +28130,8 @@
    "transfer-learning-encoder-freezing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "msfinder",
@@ -27680,7 +28178,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "cbroeckl/RAMClustR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msflo",
@@ -27722,7 +28221,8 @@
    "workflow-reproducibility-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "msfragger",
@@ -27739,7 +28239,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "laurenfields/MSIght"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msgo-model",
@@ -27771,7 +28272,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "aaronma2020/MSGO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mshub",
@@ -27784,9 +28286,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chromatographic-peak-overlap-resolution",
    "chromatographic-peak-resolution",
@@ -27811,10 +28313,11 @@
    "spectral-library-molecular-networking",
    "spectral-similarity-computation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "bittremieux/GNPS_GC"
-  ]
+  ],
+  "repo_url": "bittremieux/GNPS_GC"
  },
  {
   "slug": "msi-explorer",
@@ -27827,9 +28330,9 @@
    "CE-MS",
    "MS-imaging"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "biochemical-annotation-mapping",
    "intensity-normalization-spectra",
@@ -27845,10 +28348,11 @@
    "spectral-library-matching-and-scoring",
    "spectral-noise-reduction-msi"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "MMV-Lab/MSI-Explorer"
-  ]
+  ],
+  "repo_url": "MMV-Lab/MSI-Explorer"
  },
  {
   "slug": "msigen",
@@ -27862,9 +28366,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "bruker-baf-data-import-and-conversion",
    "command-line-software-installation-from-github",
@@ -27890,10 +28394,11 @@
    "total-ion-current-quantification",
    "vendor-file-format-specification-handling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LabLaskin/MSIGen"
-  ]
+  ],
+  "repo_url": "LabLaskin/MSIGen"
  },
  {
   "slug": "msmetaenhancer",
@@ -27906,9 +28411,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "annotation-coverage-statistics-computation",
    "api-error-handling-and-rate-limiting",
@@ -27956,10 +28461,11 @@
    "web-api-service-integration-mapping",
    "web-service-health-monitoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "RECETOX/MSMetaEnhancer"
-  ]
+  ],
+  "repo_url": "https://github.com/RECETOX/MSMetaEnhancer"
  },
  {
   "slug": "msmssim",
@@ -27988,7 +28494,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msnbase",
@@ -28007,9 +28514,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "annotation-scoring-and-ranking",
    "backend-merging-and-concatenation",
@@ -28080,11 +28587,12 @@
    "validity-constraint-enforcement-for-msdata",
    "vectorized-operation-verification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LiesaSalzer/MobilityTransformR",
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": "https://github.com/lgatto/MSnbase"
  },
  {
   "slug": "msnovelist",
@@ -28102,9 +28610,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "api-endpoint-communication",
    "build-badge-verification",
@@ -28138,11 +28646,12 @@
    "vendor-format-to-standard-conversion",
    "web-service-api-integration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "meowcat/MSNovelist",
    "sirius-ms/sirius"
-  ]
+  ],
+  "repo_url": "meowcat/MSNovelist"
  },
  {
   "slug": "mspack",
@@ -28154,9 +28663,9 @@
   "techniques": [
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "api-adapter-layer-design",
    "binary-data-integrity-verification",
@@ -28167,10 +28676,11 @@
    "mass-spectrometry-format-parsing",
    "mzml-mzxml-spectrum-reading"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "fhanau/mspack"
-  ]
+  ],
+  "repo_url": "fhanau/mspack"
  },
  {
   "slug": "mspcompiler",
@@ -28185,9 +28695,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "r-description",
   "used_by_skills": [
    "chemical-structure-smiles-assignment",
    "ei-spectral-library-parsing-and-merging",
@@ -28224,8 +28734,9 @@
    "spectral-library-polarity-separation",
    "tandem-ms-data-reorganization"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/QizhiSu/mspcompiler"
  },
  {
   "slug": "msprep",
@@ -28264,7 +28775,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Ghoshlab/marr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msroiaug",
@@ -28293,7 +28805,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mssearchr",
@@ -28328,7 +28841,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AndreySamokhin/mssearchr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msthunder",
@@ -28358,7 +28872,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LQZ0123/MSThunder"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "msys2",
@@ -28388,7 +28903,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mtbls2",
@@ -28420,7 +28936,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "KujawinskiLaboratory/Autotuner"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "multiabler",
@@ -28448,7 +28965,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "holab-hku/MultiABLER"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "multiassayexperiment",
@@ -28458,9 +28976,9 @@
    "10.1158/0008-5472.can-14-1490"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biweight-midcorrelation-similarity-computation",
    "differential-metabolite-abundance-testing",
@@ -28489,10 +29007,11 @@
    "variance-stabilization-normalization",
    "weighted-correlation-network-module-interpretation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "andreasmock/MetaboDiff"
-  ]
+  ],
+  "repo_url": "https://github.com/waldronlab/MultiAssayExperiment"
  },
  {
   "slug": "multimodalspectraltransformer",
@@ -28523,7 +29042,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mpriessner/MultiModalSpectralTransformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "multiprocessing",
@@ -28565,7 +29085,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "multtest",
@@ -28575,9 +29096,9 @@
    "10.1038/s41596-021-00636-9"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -28600,10 +29121,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/multtest"
  },
  {
   "slug": "mwastools",
@@ -28644,7 +29166,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AndreaRMICL/MWASTools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mwise",
@@ -28656,9 +29179,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "adduct-and-fragment-neutral-mass-calculation",
    "adduct-fragment-table-construction",
@@ -28684,10 +29207,11 @@
    "spectral-feature-clustering-by-intensity-correlation",
    "untargeted-lcms-peak-annotation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "b2slab/mWISE"
-  ]
+  ],
+  "repo_url": "b2slab/mWISE"
  },
  {
   "slug": "mwtab",
@@ -28760,7 +29284,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MoseleyBioinformaticsLab/mwtab"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mysql-8",
@@ -28789,7 +29314,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mza",
@@ -28802,9 +29328,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-2-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "cross-language-data-format-interoperability",
    "file-format-identification-mass-spectrometry",
@@ -28843,10 +29369,11 @@
    "vendor-format-routing-dispatch",
    "vendor-proprietary-format-interoperability"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "PNNL-m-q/mza"
-  ]
+  ],
+  "repo_url": "PNNL-m-q/mza"
  },
  {
   "slug": "mzembed",
@@ -28872,7 +29399,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ReviveMed/mzEmbed"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mzexacto",
@@ -28925,7 +29453,8 @@
    "unique-compound-enumeration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "mzmine-2",
@@ -28944,9 +29473,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-mass-calculation-and-matching",
    "batch-effect-correction-chromatography",
@@ -28989,12 +29518,13 @@
    "signal-to-noise-filtering-for-peak-candidates",
    "spectral-noise-filtering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "YasinEl/mzRAPP",
    "idslme/IDSL.IPA",
    "mzmine/mzmine2"
-  ]
+  ],
+  "repo_url": "mzmine/mzmine2"
  },
  {
   "slug": "mzmine-3",
@@ -29030,7 +29560,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "huaxuyu/bago"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mzmine",
@@ -29058,9 +29589,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "acquisition-mode-enumeration-and-validation",
    "annotation-quality-filtering-by-cosine-similarity",
@@ -29275,14 +29806,15 @@
    "workflow-status-monitoring",
    "yaml-configuration-handling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch",
    "ZzakB/MolNotator",
    "helenamrusso/plantmasst",
    "luigiquiros/inventa",
    "mzmine/mzmine2"
-  ]
+  ],
+  "repo_url": "https://github.com/mzmine/mzmine"
  },
  {
   "slug": "mzmine2",
@@ -29302,9 +29834,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "annotation-quality-filtering-by-cosine-similarity",
    "annotation-table-quality-control",
@@ -29353,12 +29885,13 @@
    "unannotated-feature-characterization",
    "workflow-status-monitoring"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "DorresteinLaboratory/Bioactive_Molecular_Networks",
    "luigiquiros/inventa",
    "mzmine/mzmine2"
-  ]
+  ],
+  "repo_url": "mzmine/mzmine2"
  },
  {
   "slug": "mzmine3",
@@ -29439,7 +29972,8 @@
   "source_paper_repos": [
    "Functional-Metabolomics-Lab/FBMN-STATS",
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mzmldataloader",
@@ -29488,7 +30022,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "mzquality",
@@ -29501,9 +30036,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "assay-ratio-computation-verification",
    "background-contamination-threshold-assessment",
@@ -29548,8 +30083,9 @@
    "summarized-experiment-object-construction",
    "tab-delimited-metabolomics-file-parsing"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/hankemeierlab/mzQuality"
  },
  {
   "slug": "mzr",
@@ -29566,9 +30102,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "charge-state-determination-and-assignment",
    "gc-ci-ms-data-processing",
@@ -29607,11 +30143,12 @@
    "theoretical-to-observed-peak-matching",
    "total-ion-current-calculation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "jcapelladesto/isoSCAN",
    "thepanlab/Aerith"
-  ]
+  ],
+  "repo_url": "https://github.com/sneumann/mzR"
  },
  {
   "slug": "mzrapp",
@@ -29624,9 +30161,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-mass-calculation-and-matching",
    "benchmark-dataset-generation-from-reference-metabolites",
@@ -29649,10 +30186,11 @@
    "peak-shape-correlation-analysis",
    "retention-time-alignment-evaluation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "YasinEl/mzRAPP"
-  ]
+  ],
+  "repo_url": "YasinEl/mzRAPP"
  },
  {
   "slug": "mzrtsim",
@@ -29665,9 +30203,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "assay-matrix-formatting",
    "batch-effect-correction-qc-reference",
@@ -29693,10 +30231,11 @@
    "spectral-peak-shape-modeling",
    "xml-structured-metadata-construction"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "yufree/mzrtsim"
-  ]
+  ],
+  "repo_url": "yufree/mzrtsim"
  },
  {
   "slug": "nanobind",
@@ -29742,7 +30281,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "napari",
@@ -29776,7 +30316,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MMV-Lab/MSI-Explorer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ncbi-e-utilities",
@@ -29803,7 +30344,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mibig-secmet/mibig-json"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ncgtw",
@@ -29816,9 +30358,9 @@
    "LC-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "bandwidth-parameter-effect-comparison",
    "chromatographic-misalignment-detection",
@@ -29838,10 +30380,11 @@
    "xcms-output-replacement-workflow",
    "xcms-profile-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ChiungTingWu/ncGTW"
-  ]
+  ],
+  "repo_url": "https://github.com/ChiungTingWu/ncGTW"
  },
  {
   "slug": "neatms",
@@ -29856,9 +30399,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-construction-parameter-optimization",
    "batch-generation-and-validation",
@@ -29885,8 +30428,9 @@
    "training-validation-test-set-allocation",
    "true-positive-false-positive-rate-calculation"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/bihealth/NeatMS"
  },
  {
   "slug": "ned",
@@ -29960,7 +30504,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "net-6",
@@ -29994,7 +30539,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "net-8-0",
@@ -30066,7 +30612,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "net-framework-4-8",
@@ -30112,7 +30659,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "net-framework",
@@ -30198,7 +30746,8 @@
   "source_paper_repos": [
    "PNNL-Comp-Mass-Spec/PNNL-PreProcessor",
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "net-standard",
@@ -30231,7 +30780,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "netgsa-r-package",
@@ -30253,7 +30803,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Karnovsky-Lab/DNEA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "networkx",
@@ -30361,7 +30912,8 @@
   "source_paper_repos": [
    "ablab/npdtools",
    "shuzhao-li-lab/khipu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "neural-networks-mlpnn-with-relu-activation",
@@ -30432,7 +30984,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "neural-networks",
@@ -30503,7 +31056,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "nextflow-22-10-0",
@@ -30543,7 +31097,8 @@
    "workflow-reproducibility-validation"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "nextflow",
@@ -30561,9 +31116,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -30622,11 +31177,12 @@
    "workflow-output-validation-and-qa",
    "workflow-reproducibility-validation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "Wang-Bioinformatics-Lab/Reverse_metabolomics_library_generation"
-  ]
+  ],
+  "repo_url": "https://github.com/nextflow-io/nextflow"
  },
  {
   "slug": "nist",
@@ -30679,7 +31235,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "nmrbox",
@@ -30707,7 +31264,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "edisonomics/SAND"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "nmrfx",
@@ -30741,7 +31299,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "nanalysis/nmrfx"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "nmrpipe",
@@ -30769,7 +31328,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "edisonomics/SAND"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "noreva",
@@ -30781,9 +31341,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -30806,10 +31366,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "idrblab/NOREVA;"
  },
  {
   "slug": "norine",
@@ -30838,7 +31399,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "normalizemets",
@@ -30850,9 +31412,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "r-description",
   "used_by_skills": [
    "batch-effect-visualization",
    "biomarker-coefficient-extraction",
@@ -30877,10 +31439,11 @@
    "statistical-hypothesis-testing-pvalue-computation",
    "unwanted-variation-removal"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "metabolomicstats/NormalizeMets"
-  ]
+  ],
+  "repo_url": "metabolomicstats/NormalizeMets"
  },
  {
   "slug": "norvisualization",
@@ -30918,7 +31481,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "notame",
@@ -30931,9 +31495,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "connected-component-decomposition-and-pruning",
    "excel-file-parsing-for-metabolomics",
@@ -30957,10 +31521,11 @@
    "robust-statistical-spread-quantification",
    "sample-metadata-integration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "antonvsdata/notame"
-  ]
+  ],
+  "repo_url": "https://github.com/hanhineva-lab/notame"
  },
  {
   "slug": "np-atlas",
@@ -30989,7 +31554,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "npanalyst",
@@ -31003,12 +31569,13 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/liningtonlab/npanalyst"
  },
  {
   "slug": "npclassifier",
@@ -31042,7 +31609,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "zquinlan/concise"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "npdtools-2-5-0",
@@ -31089,7 +31657,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "npdtools",
@@ -31136,7 +31705,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ablab/npdtools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "npfimg",
@@ -31182,7 +31752,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "poomcj/NPFimg"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "nplinker",
@@ -31197,9 +31768,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "antismash-bgc-directory-organization-and-validation",
    "archive-extraction-and-file-mapping",
@@ -31286,10 +31857,11 @@
    "validated-link-ranking-comparison",
    "z-score-normalization-for-cross-dataset-comparison"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": "NPLinker/nplinker"
  },
  {
   "slug": "npm",
@@ -31332,7 +31904,8 @@
    "whitespace-character-detection"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "numba",
@@ -31457,7 +32030,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "sword-nan/SpecEmbedding"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "numpy-1-15-4",
@@ -31486,7 +32060,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "numpy-or-scipy",
@@ -31559,7 +32134,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "numpy",
@@ -32288,7 +32864,8 @@
    "yuxuanliao/PACCS",
    "zsspython/LAGF",
    "zza1211/NMRformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "omu-omu-summary-function",
@@ -32332,7 +32909,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "connor-reid-tiffany/Omu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "onnxruntime",
@@ -32381,7 +32959,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "open-tree-of-life",
@@ -32434,7 +33013,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "openms-topp-tools",
@@ -32476,7 +33056,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "openms",
@@ -32502,9 +33083,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "accurate-mass-database-search",
    "accurate-mass-metabolite-search-against-hmdb",
@@ -32726,13 +33307,14 @@
    "workflow-context-preservation",
    "y-ion-signal-detection-and-noise-assessment"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "AutoFlowResearch/SmartPeak",
    "DorresteinLaboratory/Bioactive_Molecular_Networks",
    "OpenMS/OpenMS",
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": "https://github.com/OpenMS/OpenMS"
  },
  {
   "slug": "opennau",
@@ -32745,9 +33327,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "annotation-table-construction",
    "chemical-identifier-mapping",
@@ -32764,10 +33346,11 @@
    "retention-time-alignment",
    "spectral-metadata-standardization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "zjuRong/openNAU"
-  ]
+  ],
+  "repo_url": "zjuRong/openNAU"
  },
  {
   "slug": "openpyxl",
@@ -32784,9 +33367,9 @@
    "ion-mobility-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "dependency-version-management",
    "entrypoint-verification",
@@ -32798,10 +33381,11 @@
    "spectral-roi-boundary-definition",
    "virtual-environment-configuration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "Leo-Cheng-Lab/ROIAL-NMR"
-  ]
+  ],
+  "repo_url": "http://openpyxl.readthedocs.org"
  },
  {
   "slug": "opentims",
@@ -32814,7 +33398,8 @@
   "license_detection": null,
   "used_by_skills": [],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "opentimspy",
@@ -32827,7 +33412,8 @@
   "license_detection": null,
   "used_by_skills": [],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "optgpsampler-algorithm",
@@ -32895,7 +33481,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "optgpsampler",
@@ -32963,7 +33550,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "optimus",
@@ -33000,7 +33588,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DorresteinLaboratory/Bioactive_Molecular_Networks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "orca",
@@ -33054,7 +33643,8 @@
   "source_paper_repos": [
    "grimme-lab/QCxMS2",
    "pmartR/PMart_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "orgmassspecr",
@@ -33083,7 +33673,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "oswdataaccess",
@@ -33131,7 +33722,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ouks",
@@ -33174,7 +33766,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "plyush1993/OUKS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pacman",
@@ -33204,7 +33797,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pairkat",
@@ -33214,9 +33808,9 @@
    "10.1101/2021.04.23.440821v1"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "genotype-phenotype-data-preparation",
    "pathway-kernel-association-testing",
@@ -33228,10 +33822,11 @@
    "statistical-simulation-execution",
    "type-i-error-computation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "CharlieCarpenter/PaIRKAT"
-  ]
+  ],
+  "repo_url": "https://github.com/Ghoshlab/pairkat"
  },
  {
   "slug": "pals-pathway-activity-level-scoring",
@@ -33275,7 +33870,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "glasgowcompbio/PALS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pals-viewer",
@@ -33319,7 +33915,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "glasgowcompbio/PALS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pals",
@@ -33362,7 +33959,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "glasgowcompbio/PALS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pandas-1-1-1",
@@ -33391,7 +33989,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pandas-for-tabular-data-manipulation-and-aggregation",
@@ -33424,7 +34023,8 @@
    "tensor-encoding-deep-learning"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pandas-or-equivalent-tabular-data-library",
@@ -33451,7 +34051,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mibig-secmet/mibig-json"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pandas",
@@ -34075,7 +34676,8 @@
    "yuxuanliao/PACCS",
    "zsspython/LAGF",
    "zza1211/NMRformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "parallel-computing-toolbox",
@@ -34104,7 +34706,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "parallel",
@@ -34157,7 +34760,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "paramounter",
@@ -34170,9 +34774,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "false-positive-mitigation-tuning",
    "feature-dereplication-mass-tolerance",
@@ -34184,10 +34788,11 @@
    "peak-height-threshold-optimization",
    "retention-time-clustering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "HuanLab/Paramounter"
-  ]
+  ],
+  "repo_url": "HuanLab/Paramounter"
  },
  {
   "slug": "patroon",
@@ -34204,9 +34809,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "annotation-candidate-ranking-tp-score",
    "chemical-identifier-mapping",
@@ -34229,10 +34834,11 @@
    "transformation-product-parent-linkage",
    "transformation-product-prediction"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "rickhelmus/patRoon"
-  ]
+  ],
+  "repo_url": "rickhelmus/patRoon"
  },
  {
   "slug": "pbapply",
@@ -34275,7 +34881,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pcamethods",
@@ -34289,9 +34896,9 @@
    "CE-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -34314,10 +34921,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/hredestig/pcamethods"
  },
  {
   "slug": "pcutils",
@@ -34351,7 +34959,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Asa12138/MetaNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "peakqc",
@@ -34366,9 +34975,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "acquisition-method-overlap-analysis",
    "comparative-omics-report-generation",
@@ -34397,10 +35006,11 @@
    "target-list-coordinate-mapping",
    "targeted-peak-extraction-ms1"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": "https://github.com/loosolab/PEAKQC"
  },
  {
   "slug": "peakquant",
@@ -34448,7 +35058,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "perl-prima",
@@ -34471,7 +35082,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "matteogiulietti/LipidOne"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "perl",
@@ -34494,7 +35106,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "matteogiulietti/LipidOne"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pewlib",
@@ -34542,7 +35155,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "djdt/pewpew"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pewpew",
@@ -34590,7 +35204,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "djdt/pewpew"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pfam",
@@ -34654,7 +35269,8 @@
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "medema-group/bigslice"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pheatmap",
@@ -34729,7 +35345,8 @@
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN",
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "php",
@@ -34758,7 +35375,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pillow",
@@ -34795,7 +35413,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/ModiFinder_base"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pip",
@@ -35022,7 +35641,8 @@
    "pluskal-lab/DreaMS",
    "tingxiecsu/CSU-MS2",
    "yuxuanliao/PACCS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "plage-method-within-pals",
@@ -35062,7 +35682,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "glasgowcompbio/PALS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "plantmasst",
@@ -35120,7 +35741,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "plotly-or-equivalent-interactive-plotting-library",
@@ -35162,7 +35784,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "czbiohub-sf/Rapid-QC-MS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "plotly",
@@ -35250,7 +35873,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Wang-Bioinformatics-Lab/NetworkFamily_MultipleAlignment_Website"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pmartr",
@@ -35346,7 +35970,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pmartR/PMart_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pnnl-preprocessor",
@@ -35391,7 +36016,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "PNNL-Comp-Mass-Spec/PNNL-PreProcessor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "poetry",
@@ -35457,7 +36083,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "poisson-noise-augmentation",
@@ -35505,7 +36132,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "postgresql",
@@ -35592,7 +36220,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "prcomp",
@@ -35619,7 +36248,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BorchLab/CordBat"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "prepare-wikidata-lotus-prefect-py",
@@ -35650,7 +36280,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "corinnabrungs/msn_tree_library"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "prima-panel",
@@ -35683,7 +36314,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "funkam/PRIMA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "probability-product-kernel-ppk",
@@ -35756,7 +36388,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proc",
@@ -35779,7 +36412,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "slfan2013/SERDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proforma-2-0",
@@ -35848,7 +36482,8 @@
    "usi-string-parsing-and-resolution"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "proteomm",
@@ -35861,9 +36496,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -35886,10 +36521,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/ProteoMM"
  },
  {
   "slug": "proteowizard-library-and-tools",
@@ -35916,7 +36552,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ProteoWizard/pwiz"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proteowizard-msconvert",
@@ -36026,7 +36663,8 @@
   "source_paper_repos": [
    "LabLaskin/MSIGen",
    "jcapelladesto/isoSCAN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proteowizard-pwiz-skyline",
@@ -36060,7 +36698,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ComPlat/chem-spectra-app"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proteowizard",
@@ -36304,7 +36943,8 @@
    "griquelme/tidyms",
    "hcji/TarMet",
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "proteoxchange-repository",
@@ -36337,7 +36977,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ps2ms",
@@ -36374,7 +37015,8 @@
    "tensor-encoding-deep-learning"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "psims",
@@ -36386,9 +37028,9 @@
   "techniques": [
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "bioconda-package-installation",
    "conditional-dependency-resolution",
@@ -36412,8 +37054,9 @@
    "python-package-dependency-installation",
    "sequence-to-feature-mapping"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/mobiusklein/psims"
  },
  {
   "slug": "psm-utils",
@@ -36426,9 +37069,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "candidate-psm-cardinality-control",
    "configuration-driven-batch-processing",
@@ -36449,10 +37092,11 @@
    "spectrum-grouping-and-aggregation",
    "spectrum-metadata-title-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "compomics/ms2rescore"
-  ]
+  ],
+  "repo_url": "https://github.com/compomics/psm_utils"
  },
  {
   "slug": "pubchem-standardization",
@@ -36481,7 +37125,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "michaelwitting/RepoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pubchem",
@@ -36674,7 +37319,8 @@
    "rickhelmus/patRoon",
    "samgoldman97/ms-pred",
    "zmahnoor14/MAW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pubchempy",
@@ -36688,9 +37334,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-normalization-implementation",
    "candidate-rank-scoring",
@@ -36757,10 +37403,11 @@
    "tanimoto-similarity-computation",
    "uncertainty-quantification-from-model-predictions"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "zmahnoor14/MAW"
-  ]
+  ],
+  "repo_url": "https://github.com/mcs07/PubChemPy"
  },
  {
   "slug": "punc-data",
@@ -36772,9 +37419,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "column-header-keyword-matching",
    "conditional-threshold-logic-implementation",
@@ -36791,10 +37438,11 @@
    "semantic-role-assignment-for-mass-spectrometry-data",
    "user-override-parameter-management"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "WTVoe/puncdata"
-  ]
+  ],
+  "repo_url": "WTVoe/puncdata"
  },
  {
   "slug": "puncdata",
@@ -36806,9 +37454,9 @@
   "techniques": [
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "license-file",
   "used_by_skills": [
    "column-header-keyword-matching",
    "conditional-threshold-logic-implementation",
@@ -36825,10 +37473,11 @@
    "semantic-role-assignment-for-mass-spectrometry-data",
    "user-override-parameter-management"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "WTVoe/puncdata"
-  ]
+  ],
+  "repo_url": "WTVoe/puncdata"
  },
  {
   "slug": "purrr",
@@ -36854,7 +37503,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pwiz-bindings-cli-dll",
@@ -36900,7 +37550,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pwiz",
@@ -36927,7 +37578,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ProteoWizard/pwiz"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "py4cytoscape",
@@ -37001,7 +37653,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pyarrow",
@@ -37055,7 +37708,8 @@
    "tabular-data-field-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pybaf2sql",
@@ -37100,7 +37754,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LabLaskin/MSIGen"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pycharm",
@@ -37124,7 +37779,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "SysMedOs/LipidLynxX"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pycombat",
@@ -37192,7 +37848,8 @@
    "zero-value-handling-in-mass-spectrometry-data"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pyeva",
@@ -37219,7 +37876,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HuanLab-backup/EVA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pyg",
@@ -37263,7 +37921,8 @@
   "source_paper_repos": [
    "RiverCCC/ABCoRT",
    "yuxuanliao/PACCS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pyhmmer",
@@ -37273,9 +37932,9 @@
    "10.1093/gigascience/giaa154"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "bgc-cluster-export",
    "bgc-feature-vector-normalization",
@@ -37291,10 +37950,11 @@
    "pfam-domain-hit-extraction",
    "tsv-file-generation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "medema-group/bigslice"
-  ]
+  ],
+  "repo_url": "https://github.com/althonos/pyhmmer"
  },
  {
   "slug": "pyineta",
@@ -37306,9 +37966,9 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chemical-shift-coordinate-extraction",
    "clustered-peak-output-formatting",
@@ -37330,10 +37990,11 @@
    "spectral-visualization-and-result-interpretation",
    "threshold-based-match-filtering"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "edisonomics/PyINETA"
-  ]
+  ],
+  "repo_url": "edisonomics/PyINETA"
  },
  {
   "slug": "pymolnetenhancer",
@@ -37375,7 +38036,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "madeleineernst/pyMolNetEnhancer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pymrmtransitiongrouppicker",
@@ -37424,7 +38086,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pymzml",
@@ -37446,9 +38109,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "backend-compatibility-verification-visualization-library",
@@ -37666,11 +38329,12 @@
    "xml-parsing-and-element-tree-serialization",
    "xml-spectrum-element-deserialization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "shuzhao-li-lab/asari",
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": "https://github.com/pymzml/pymzML"
  },
  {
   "slug": "pyopenms-viz",
@@ -37684,9 +38348,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "backend-compatibility-verification-visualization-library",
@@ -37743,8 +38407,9 @@
    "statistical-summary-computation-median-range",
    "visualization-comparative-performance-metrics"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/OpenMS/pyopenms_viz"
  },
  {
   "slug": "pyopenms",
@@ -37767,9 +38432,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "accurate-mass-database-search",
@@ -37942,11 +38607,12 @@
    "visualization-comparative-performance-metrics",
    "workflow-configuration-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "AutoFlowResearch/SmartPeak",
    "huaxuyu/bago"
-  ]
+  ],
+  "repo_url": "https://github.com/OpenMS/OpenMS"
  },
  {
   "slug": "pyqt5",
@@ -37976,7 +38642,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Leo-Cheng-Lab/ROIAL-NMR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pyrwr",
@@ -38001,7 +38668,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "computational-chemical-biology/ChemWalker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pyteomics",
@@ -38019,9 +38687,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "backend-compatibility-verification-visualization-library",
@@ -38150,8 +38818,9 @@
    "usi-string-parsing-and-resolution",
    "visualization-comparative-performance-metrics"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/levitsky/pyteomics"
  },
  {
   "slug": "pytest",
@@ -38392,7 +39061,8 @@
    "lucinamay/biosynfoni",
    "matchms/matchms",
    "tyo-nu/MINE-Database"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-2-7",
@@ -38420,7 +39090,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Viant-Metabolomics/Galaxy-M"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-11-7",
@@ -38447,7 +39118,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HassounLab/MVP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-6-12",
@@ -38476,7 +39148,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-6",
@@ -38498,7 +39171,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Dingxian666/Norm-ISWSVR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-7",
@@ -38533,7 +39207,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "aaronma2020/MSGO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-8-1",
@@ -38566,7 +39241,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LinShuhaiLAB/QuanFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-8-2",
@@ -38590,7 +39266,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-8",
@@ -38657,7 +39334,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wh-xu/Hyper-Spec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-9-0",
@@ -38679,7 +39357,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RaoboXu/Lipidwizard"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3-9",
@@ -38708,7 +39387,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Leo-Cheng-Lab/ROIAL-NMR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-3",
@@ -38853,7 +39533,8 @@
    "shuzhao-li-lab/khipu",
    "yuxuanliao/PACCS",
    "zxguocsu/GCMSFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-deep-learning-framework-pytorch-or-tensorflow",
@@ -38888,7 +39569,8 @@
    "tensor-encoding-deep-learning"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "python-json-module-for-parsing-json-files",
@@ -38915,7 +39597,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mibig-secmet/mibig-json"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-numpy-pandas",
@@ -38990,7 +39673,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "python-numpy-scipy-stats-pandas-matplotlib-seaborn",
@@ -39063,7 +39747,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "NPLinker/nplinker"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-pandas-numpy-scipy",
@@ -39111,7 +39796,8 @@
   "source_paper_repos": [
    "chopralab/CLAW",
    "metabolomicsworkbench/MetENP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "python-scikit-learn-seaborn-or-matplotlib-for-visualization",
@@ -39182,7 +39868,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "python-scikit-learn",
@@ -39253,7 +39940,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "python",
@@ -41483,7 +42171,8 @@
    "zmahnoor14/MAW",
    "zsspython/LAGF",
    "zza1211/NMRformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pytorch-2-2",
@@ -41523,7 +42212,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "zhanghailiangcsu/MSBERT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pytorch-cu118",
@@ -41554,7 +42244,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "yfWang01/FlavorFormer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pytorch-geometric-pyg",
@@ -41597,7 +42288,8 @@
    "smiles-canonicalization-rdkit"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pytorch-geometric",
@@ -41626,7 +42318,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "tingxiecsu/CSU-MS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pytorch-or-equivalent-deep-learning-framework-inferred-from-gnn-contrastive-learning-context",
@@ -41673,7 +42366,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Chen-micslab/QCCAssisted4DSterol"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pytorch-or-tensorflow",
@@ -41719,7 +42413,8 @@
    "smiles-canonicalization-rdkit"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pytorch",
@@ -42094,7 +42789,8 @@
    "zhanghailiangcsu/MWFormer",
    "zxguocsu/GCMSFormer",
    "zza1211/NMRformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "pyvis",
@@ -42153,7 +42849,8 @@
    "structural-cluster-network-construction"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "pyyaml",
@@ -42187,7 +42884,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ZzakB/MolNotator"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "q-exactive-orbitrap",
@@ -42244,7 +42942,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "q2-qemistree",
@@ -42275,7 +42974,8 @@
    "tree-structural-integrity-assessment"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "qcomics",
@@ -42288,9 +42988,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "injection-sequence-annotation",
    "instrumental-drift-detection",
@@ -42307,8 +43007,9 @@
    "signal-trend-assessment-across-injections",
    "tabular-data-parsing-and-structure-conversion"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/ricoderks/QComics"
  },
  {
   "slug": "qcxms2",
@@ -42321,9 +43022,9 @@
    "LC-MS",
    "GC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "automated-reaction-network-exploration",
    "conformer-ensemble-generation-via-crest",
@@ -42338,10 +43039,11 @@
    "shell-scripting-for-program-discovery",
    "system-environment-configuration"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "grimme-lab/QCxMS2"
-  ]
+  ],
+  "repo_url": "grimme-lab/QCxMS2"
  },
  {
   "slug": "qmake",
@@ -42371,7 +43073,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "qr-code-generation-library",
@@ -42404,7 +43107,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MetabolomicsSpectrumResolver"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "qt5",
@@ -42434,7 +43138,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eugenemel/maven"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "quick",
@@ -42478,7 +43183,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DasSusanta/snakemake_ccs"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-3-0-1",
@@ -42506,7 +43212,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Viant-Metabolomics/Galaxy-M"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-4-0-2",
@@ -42579,7 +43286,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "r-4-1-2",
@@ -42620,7 +43328,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "plyush1993/OUKS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-base-stats-tidyverse-or-similar",
@@ -42657,7 +43366,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "chopralab/CLAW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-gui",
@@ -42700,7 +43410,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "YuJenL/SMART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-or-language-used-by-pairkat-scripts",
@@ -42727,7 +43438,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "CharlieCarpenter/PaIRKAT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-package-amanida",
@@ -42752,7 +43464,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mariallr/easy-amanida"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-shiny",
@@ -42805,7 +43518,8 @@
   "source_paper_repos": [
    "Lab-XUE/EISA-EXPOSOME",
    "databio2022/GraphBio"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "r-vegan-package",
@@ -42880,7 +43594,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "r-version-or-higher",
@@ -42932,7 +43647,8 @@
    "xcms-ramclustr-object-integration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "r",
@@ -42973,7 +43689,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LargeMetabo/LargeMetabo"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ramclustr",
@@ -43056,7 +43773,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "cbroeckl/RAMClustR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "random-forest-regression",
@@ -43127,7 +43845,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "random-forest",
@@ -43202,7 +43921,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "random-missing-value-augmentation",
@@ -43250,7 +43970,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "randomforest",
@@ -43296,7 +44017,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "connor-reid-tiffany/Omu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rankprod",
@@ -43345,7 +44067,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rapidmass",
@@ -43384,7 +44107,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Katherine00689/RapidMass"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "raw-file-uploader-rtklab-byu-raw-file-uploader",
@@ -43413,7 +44137,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rawfilereader",
@@ -43486,7 +44211,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rawrr",
@@ -43500,9 +44226,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "assembly-version-string-retrieval",
    "basepeak-intensity-identification",
@@ -43556,10 +44282,11 @@
    "two-layer-architecture-dispatch-testing",
    "y-ion-signal-detection-and-noise-assessment"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": "https://github.com/fgcz/rawrr"
  },
  {
   "slug": "raxport",
@@ -43603,7 +44330,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "thepanlab/Aerith"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rcdk",
@@ -43634,7 +44362,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "michaelwitting/RepoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rdkit-2020-03-4",
@@ -43662,7 +44391,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "chensaian/TransG-Net"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rdkit-or-similar-cheminformatics-library-for-molecular-fingerprint-computation",
@@ -43695,7 +44425,8 @@
    "tensor-encoding-deep-learning"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "rdkit-pypi",
@@ -43731,7 +44462,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "01dadada/RT-Transformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rdkit",
@@ -43778,9 +44510,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "abstract-base-class-implementation",
    "abstract-method-subclassing-filter-base",
@@ -44296,7 +45028,7 @@
    "word2vec-vocabulary-matching-and-unknown-peak-handling",
    "workflow-orchestration-and-parallelization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "DasSusanta/snakemake_ccs",
    "FanzhouKong/spectral_denoising",
@@ -44320,7 +45052,8 @@
    "yuxuanliao/PACCS",
    "zhanghailiangcsu/MWFormer",
    "zmahnoor14/MAW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "reactiveextensions",
@@ -44352,7 +45085,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "reactiveproperty",
@@ -44384,7 +45118,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "readr",
@@ -44457,7 +45192,8 @@
    "BiosystemEngineeringLab-IITB/dures",
    "biodatalab/enrichmet",
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "readxl",
@@ -44508,7 +45244,8 @@
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN",
    "biodatalab/enrichmet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "redis",
@@ -44554,7 +45291,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "redu",
@@ -44600,7 +45338,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/ReDU-MS2-Documentation"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "relu-activation",
@@ -44674,7 +45413,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "reshape2",
@@ -44703,7 +45443,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "resnet18",
@@ -44751,7 +45492,8 @@
    "tensor-shape-validation-and-numerical-correctness-checking"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "rest-client-gem",
@@ -44778,7 +45520,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://bitbucket.org/wishartlab/classyfire_api.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rest-client",
@@ -44805,7 +45548,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://bitbucket.org/wishartlab/classyfire_api.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "resultsloader",
@@ -44853,7 +45597,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "reticulate",
@@ -44879,7 +45624,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "slfan2013/SERDA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "retip",
@@ -44894,19 +45640,20 @@
    "CE-MS",
    "direct-infusion-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "CC-BY-4.0",
+  "license_detection": "r-description",
   "used_by_skills": [
    "machine-learning-model-inference",
    "metabolite-annotation-by-chromatographic-behavior",
    "molecular-descriptor-extraction",
    "retention-time-prediction-modeling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "oloBion/Retip"
-  ]
+  ],
+  "repo_url": "oloBion/Retip"
  },
  {
   "slug": "reverse-search",
@@ -44930,7 +45677,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Philipbear/reverse_search"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rgcxgc",
@@ -44970,7 +45718,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "DanielQuiroz97/RGCxGC"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rhdf5",
@@ -44983,9 +45732,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "cross-language-data-format-interoperability",
    "file-format-identification-mass-spectrometry",
@@ -45024,10 +45773,11 @@
    "vendor-format-routing-dispatch",
    "vendor-proprietary-format-interoperability"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "PNNL-m-q/mza"
-  ]
+  ],
+  "repo_url": "https://github.com/Huber-group-EMBL/rhdf5"
  },
  {
   "slug": "ricoderks-qcomics",
@@ -45057,7 +45807,8 @@
    "tabular-data-parsing-and-structure-conversion"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "riken",
@@ -45111,7 +45862,8 @@
    "tandem-ms-data-reorganization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "rjson",
@@ -45183,7 +45935,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "fgcz/rawrr"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rmarkdown",
@@ -45222,7 +45975,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "MRCIEU/metaboprep"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rmsi",
@@ -45255,7 +46009,8 @@
    "spatial-overlap-analysis-imaging"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "rmsicleanup",
@@ -45288,7 +46043,8 @@
    "spatial-overlap-analysis-imaging"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "rmsiproc",
@@ -45321,7 +46077,8 @@
    "spatial-overlap-analysis-imaging"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "roasmi",
@@ -45333,9 +46090,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "compound-structure-molecular-encoding",
    "ensemble-model-inference",
@@ -45347,10 +46104,11 @@
    "small-molecule-compound-indexing",
    "uncertainty-estimation-across-models"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "FangYuan717/ROASMI"
-  ]
+  ],
+  "repo_url": "FangYuan717/ROASMI"
  },
  {
   "slug": "roipeaks",
@@ -45379,7 +46137,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rpref",
@@ -45422,7 +46181,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rq-redis-queue",
@@ -45464,7 +46224,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "OpenMS/OpenMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rstudio",
@@ -45536,7 +46297,8 @@
    "Fraunhofer-ITMP/alister",
    "HuanLab/ISFrag",
    "metabolomicstats/NormalizeMets"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rtklab-byu-proteomics-data-processor",
@@ -45565,7 +46327,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "rtklab-byu-raw-file-uploader",
@@ -45594,7 +46357,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RTKlab-BYU/MSConnect"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ruby",
@@ -45604,9 +46368,9 @@
    "10.1186/s13321-016-0174-y"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "chemical-structure-web-service-communication",
    "compound-identifier-extraction",
@@ -45618,10 +46382,11 @@
    "smiles-inchi-fasta-format-recognition",
    "structural-representation-format-detection"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "https://bitbucket.org/wishartlab/classyfire_api.git"
-  ]
+  ],
+  "repo_url": "https://www.ruby-lang.org"
  },
  {
   "slug": "rust",
@@ -45675,7 +46440,8 @@
    "tabular-data-field-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "ruv-iii",
@@ -45714,7 +46480,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "SydneyBioX/hRUV"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "s4vectors",
@@ -45728,9 +46495,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "annotation-scoring-and-ranking",
    "backend-merging-and-concatenation",
@@ -45806,11 +46573,12 @@
    "validity-constraint-enforcement-for-msdata",
    "vectorized-operation-verification"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures",
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": "https://github.com/Bioconductor/S4Vectors"
  },
  {
   "slug": "safari",
@@ -45835,7 +46603,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lidawei1975/colmarvista"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "salmon",
@@ -45848,9 +46617,9 @@
    "LC-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -45884,10 +46653,11 @@
    "sra-data-retrieval-and-ingestion",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": "https://github.com/COMBINE-lab/salmon"
  },
  {
   "slug": "sand",
@@ -45899,9 +46669,9 @@
   "techniques": [
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "metabolomics-data-standardization",
    "nmr-peak-deconvolution",
@@ -45912,10 +46682,11 @@
    "nmrbox-environment-management",
    "spectral-peak-deconvolution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "edisonomics/SAND"
-  ]
+  ],
+  "repo_url": "edisonomics/SAND"
  },
  {
   "slug": "scannotation",
@@ -45927,9 +46698,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "license-file",
   "used_by_skills": [
    "isotopic-pattern-matching",
    "mass-error-calculation",
@@ -45938,10 +46709,11 @@
    "neutral-loss-prediction",
    "retention-time-prediction"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "scannotation/Scannotation_software"
-  ]
+  ],
+  "repo_url": "scannotation/Scannotation_software"
  },
  {
   "slug": "scanpy",
@@ -45989,7 +46761,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bioinfo-ibms-pumc/SMART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scarf",
@@ -46054,7 +46827,8 @@
    "transformer-input-preprocessing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "scfba",
@@ -46122,7 +46896,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sciex-multiquant-v3-0-3",
@@ -46154,7 +46929,8 @@
    "tabular-data-parsing-and-structure-conversion"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sciex-multiquant",
@@ -46187,7 +46963,8 @@
    "tabular-data-parsing-and-structure-conversion"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sciex-q-tof-uhplc-hrms-ms",
@@ -46244,7 +47021,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GarrettLab-UF/LipidMatch"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scikit-bio",
@@ -46298,7 +47076,8 @@
    "spectrum-normalization-and-standardization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "scikit-learn-0-23-2",
@@ -46327,7 +47106,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scikit-learn-mlpregressor",
@@ -46401,7 +47181,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "scikit-learn-nearestneighbors-for-knn-index-construction",
@@ -46439,7 +47220,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "WanluLiuLab/SpatialMETA"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scikit-learn-python",
@@ -46513,7 +47295,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "scikit-learn",
@@ -46789,7 +47572,8 @@
    "griquelme/tidyms",
    "huaxuyu/bago",
    "ressomlab/MetFID"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scipy-1-0-0",
@@ -46818,7 +47602,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scipy-scipy-stats-wasserstein-distance-or-scipy-optimize-linprog-for-optimal-transport",
@@ -46847,7 +47632,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GeoMetabolomics-ICBM/mcfNMR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scipy-signal-detrend",
@@ -46927,7 +47713,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scipy-signal-find-peaks",
@@ -47009,7 +47796,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/asari"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "scipy-spearman-correlation",
@@ -47080,7 +47868,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "scipy",
@@ -47318,7 +48107,8 @@
    "shuzhao-li-lab/asari",
    "zsspython/LAGF",
    "zza1211/NMRformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "sdf-file-parser-molecular-structure-library",
@@ -47352,7 +48142,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://gitlab.com/nexs-metabolomics/projects/dna_adductomics_database.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "seaborn-0-9-0",
@@ -47381,7 +48172,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "seaborn-clustermap",
@@ -47452,7 +48244,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "seaborn",
@@ -47657,7 +48450,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "chopralab/CLAW"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "semantic-release",
@@ -47682,7 +48476,8 @@
    "yaml-json-structural-parsing"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "seurat",
@@ -47728,7 +48523,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GenomicsMachineLearning/SpaMTP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "shiny",
@@ -47821,7 +48617,8 @@
    "mariallr/easy-amanida",
    "ncats/metScribeR",
    "pmartR/PMart_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "shinyscreen",
@@ -47848,7 +48645,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "https://gitlab.com/uniluxembourg/lcsb/eci/shinyscreen.git"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "signal-processing-toolbox",
@@ -47877,7 +48675,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "signalp",
@@ -47926,7 +48725,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "simile",
@@ -47941,9 +48741,9 @@
    "CE-MS",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "readme-llm",
   "used_by_skills": [
    "bipartite-graph-maximum-weight-matching",
    "difference-count-table-integration",
@@ -47962,10 +48762,11 @@
    "statistical-significance-estimation-mass-spectrometry",
    "tandem-mass-spectrum-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "biorack/simile"
-  ]
+  ],
+  "repo_url": "biorack/simile"
  },
  {
   "slug": "singularity",
@@ -47981,9 +48782,9 @@
    "CE-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -48050,11 +48851,12 @@
    "workflow-output-validation-and-qa",
    "workflow-reproducibility-validation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "meowcat/MSNovelist"
-  ]
+  ],
+  "repo_url": "http://singularity.lbl.gov"
  },
  {
   "slug": "sirius",
@@ -48082,9 +48884,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "AGPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "adduct-assignment-accuracy-assessment",
    "adduct-specific-model-fine-tuning",
@@ -48262,7 +49064,7 @@
    "workflow-status-monitoring",
    "xcms-object-handling-and-preprocessing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "boecker-lab/sirius",
    "cbroeckl/RAMClustR",
@@ -48272,7 +49074,8 @@
    "sirius-ms/sirius",
    "zmahnoor14/MAW",
    "zquinlan/concise"
-  ]
+  ],
+  "repo_url": "sirius-ms/sirius"
  },
  {
   "slug": "sklearn",
@@ -48300,7 +49103,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "facundof2016/CCSP2.0"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "skyline",
@@ -48429,7 +49233,8 @@
    "ahmohamed/lipidr",
    "fgcz/rawrr",
    "lifs-tools/lipidcreator"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "slack-api",
@@ -48472,7 +49277,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "czbiohub-sf/Rapid-QC-MS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "slaw-grouping-module",
@@ -48515,7 +49321,8 @@
    "spectral-metadata-integration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "slaw",
@@ -48527,9 +49334,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "algorithm-interface-abstraction",
    "chromatographic-alignment-tuning",
@@ -48557,8 +49364,9 @@
    "spectral-feature-standardization",
    "spectral-metadata-integration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/zamboni-lab/SLAW"
  },
  {
   "slug": "slurm",
@@ -48591,7 +49399,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "meowcat/MSNovelist"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "smart",
@@ -48639,7 +49448,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bioinfo-ibms-pumc/SMART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "smartpeak",
@@ -48656,9 +49466,9 @@
    "ion-mobility-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "accurate-mass-database-search",
    "accurate-mass-metabolite-search-against-hmdb",
@@ -48676,10 +49486,11 @@
    "spectral-data-normalization-and-merging",
    "workflow-configuration-parsing"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "AutoFlowResearch/SmartPeak"
-  ]
+  ],
+  "repo_url": "AutoFlowResearch/SmartPeak"
  },
  {
   "slug": "smartpeakcli",
@@ -48719,7 +49530,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AutoFlowResearch/SmartPeak"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "smartpeakgui",
@@ -48757,7 +49569,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AutoFlowResearch/SmartPeak"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "smiter",
@@ -48769,9 +49582,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "github-api",
   "used_by_skills": [
    "csv-to-dictionary-conversion",
    "mass-spectrometry-fragmentation-modeling",
@@ -48788,10 +49601,11 @@
    "synthetic-lcmsms-data-generation",
    "synthetic-spectrum-generation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "LeidelLab/SMITER"
-  ]
+  ],
+  "repo_url": "LeidelLab/SMITER"
  },
  {
   "slug": "snakemake",
@@ -48811,9 +49625,9 @@
    "ion-mobility-MS",
    "NMR"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MIT",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "calibration-coefficient-accuracy-assessment",
    "ccs-calibration-polynomial-fitting",
@@ -48882,12 +49696,13 @@
    "tandem-mass-spectrum-deconvolution-isotope-annotation",
    "workflow-orchestration-and-parallelization"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "DasSusanta/snakemake_ccs",
    "biosustain/snakemake_UmetaFlow",
    "skinniderlab/clm"
-  ]
+  ],
+  "repo_url": "https://github.com/snakemake/snakemake"
  },
  {
   "slug": "spamtp",
@@ -48932,7 +49747,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "GenomicsMachineLearning/SpaMTP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spatialmeta",
@@ -48946,9 +49762,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "BSD-3-Clause",
+  "license_detection": "github-api",
   "used_by_skills": [
    "anndata-object-annotation",
    "anndata-object-initialization-and-structuring",
@@ -48971,10 +49787,11 @@
    "spot-level-intensity-aggregation",
    "variational-autoencoder-training"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "WanluLiuLab/SpatialMETA"
-  ]
+  ],
+  "repo_url": "WanluLiuLab/SpatialMETA"
  },
  {
   "slug": "spec2vec",
@@ -48992,9 +49809,9 @@
    "direct-infusion-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "bag-of-fragments-representation-construction",
    "bag-of-words-document-representation-generation",
@@ -49171,10 +49988,11 @@
    "word2vec-model-inference-unknown-word-handling",
    "word2vec-vocabulary-matching-and-unknown-peak-handling"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "vdhooftcompmet/MS2LDA"
-  ]
+  ],
+  "repo_url": "https://github.com/iomega/spec2vec"
  },
  {
   "slug": "spectra-hash",
@@ -49218,7 +50036,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "eMetaboHUB/FragHub"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spectra",
@@ -49242,9 +50061,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "annotation-scoring-and-ranking",
    "backend-merging-and-concatenation",
@@ -49444,14 +50263,15 @@
    "xcms-parameter-optimization-msw",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures",
    "LiesaSalzer/MobilityTransformR",
    "rformassspectrometry/Spectra",
    "sneumann/xcms",
    "zmahnoor14/MAW"
-  ]
+  ],
+  "repo_url": "https://github.com/RforMassSpectrometry/Spectra"
  },
  {
   "slug": "spectral-denoising",
@@ -49500,7 +50320,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "FanzhouKong/spectral_denoising"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spectral-similarity",
@@ -49531,7 +50352,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "YuanyueLi/SpectralEntropy"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spectralentropy",
@@ -49543,9 +50365,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "algorithm-performance-benchmarking",
    "compound-identification-scoring",
@@ -49559,10 +50381,11 @@
    "spectral-noise-filtering-preprocessing",
    "spectrum-preprocessing-for-similarity-analysis"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "YuanyueLi/SpectralEntropy"
-  ]
+  ],
+  "repo_url": "YuanyueLi/SpectralEntropy"
  },
  {
   "slug": "spectraverse-analysis-repository",
@@ -49588,7 +50411,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "skinniderlab/spectraverse-analysis"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spectripy",
@@ -49601,9 +50425,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "cross-language-function-invocation-and-validation",
    "cross-language-interface-design",
@@ -49619,8 +50443,9 @@
    "spectra-object-serialization-deserialization",
    "spectral-workflow-validation"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/RforMassSpectrometry/SpectriPy"
  },
  {
   "slug": "spectrum-utils-0-3-5",
@@ -49669,7 +50494,8 @@
    "tandem-mass-spectrum-clustering"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "spectrum-utils",
@@ -49686,9 +50512,9 @@
    "ion-mobility-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-timing-analysis",
    "comparative-performance-profiling",
@@ -49742,8 +50568,9 @@
    "usi-spectrum-retrieval-and-loading",
    "usi-string-parsing-and-resolution"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/bittremieux/spectrum_utils"
  },
  {
   "slug": "sphinx",
@@ -49826,7 +50653,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pluskal-lab/DreaMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "spreadout",
@@ -49879,7 +50707,8 @@
    "unique-compound-enumeration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sql",
@@ -49922,7 +50751,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MassQueryLanguage"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "sqlalchemy",
@@ -49963,7 +50793,8 @@
    "sequence-to-feature-mapping"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sqlite",
@@ -49978,7 +50809,8 @@
   "license_detection": null,
   "used_by_skills": [],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sqlite3",
@@ -50044,7 +50876,8 @@
    "xml-spectrum-element-deserialization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "sqmassloader",
@@ -50092,7 +50925,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "sra-toolkit",
@@ -50141,7 +50975,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "stagate",
@@ -50189,7 +51024,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "bioinfo-ibms-pumc/SMART"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "star-aligner-v-2-6-1d",
@@ -50257,7 +51093,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "statistical-analysis-libraries-scipy-stats-for-enrichment-tests",
@@ -50283,7 +51120,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "metabolomicsworkbench/MetENP"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "statistical-total-correlation-spectroscopy-stocsy",
@@ -50324,7 +51162,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AndreaRMICL/MWASTools"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "statistics-and-machine-learning-toolbox",
@@ -50353,7 +51192,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "stats",
@@ -50396,7 +51236,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "BiosystemEngineeringLab-IITB/dures"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "stattarget",
@@ -50411,9 +51252,9 @@
    "MS-imaging",
    "ion-mobility-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "LGPL-3.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "biobase-object-serialization",
    "circular-barplot-generation",
@@ -50436,10 +51277,11 @@
    "r-graphics-customization",
    "sample-label-mapping"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "idrblab/NOREVA;"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/statTarget"
  },
  {
   "slug": "streamlit",
@@ -50514,7 +51356,8 @@
   "source_paper_repos": [
    "OpenMS/OpenMS",
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "stringr",
@@ -50540,7 +51383,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "summarizedexperiment",
@@ -50558,9 +51402,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "assay-matrix-formatting",
    "assay-ratio-computation-verification",
@@ -50649,12 +51493,13 @@
    "tab-delimited-metabolomics-file-parsing",
    "xml-structured-metadata-construction"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "SydneyBioX/hRUV",
    "krumsieklab/maplet",
    "yufree/mzrtsim"
-  ]
+  ],
+  "repo_url": "https://github.com/Bioconductor/SummarizedExperiment"
  },
  {
   "slug": "sva",
@@ -50665,9 +51510,9 @@
    "10.1093/bioadv/vbae175"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Artistic-2.0",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "batch-design-specification",
    "batch-effect-correction-combat-model",
@@ -50718,11 +51563,12 @@
    "technical-variation-assessment",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses",
    "NBDZ/dbnorm"
-  ]
+  ],
+  "repo_url": "https://github.com/bioc/sva"
  },
  {
   "slug": "symfony",
@@ -50751,7 +51597,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "privrja/MassSpecBlocks"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "syncsa",
@@ -50826,7 +51673,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "syrupy",
@@ -50875,7 +51723,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Roestlab/massdash"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "t-sne-t-distributed-stochastic-neighbor-embedding",
@@ -50943,7 +51792,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "t-sne",
@@ -51013,7 +51863,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "tandemmatch",
@@ -51063,7 +51914,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pnnl/IonToolPack"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tardis",
@@ -51076,9 +51928,9 @@
    "LC-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0",
+  "license_detection": "github-api",
   "used_by_skills": [
    "chromatographic-peak-annotation-visualization",
    "chromatographic-peak-characterization",
@@ -51121,8 +51973,9 @@
    "targeted-peak-detection-screening-and-validation",
    "targeted-peak-integration-configuration"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/UGent-LIMET/TARDIS"
  },
  {
   "slug": "tensorflow-1-8-0",
@@ -51149,7 +52002,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tensorflow-2-3-0",
@@ -51192,7 +52046,8 @@
    "tensorflow-serving-layer-inspection"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "tensorflow-or-pytorch",
@@ -51266,7 +52121,8 @@
    "transformation-method-comparison"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "tensorflow-serving",
@@ -51337,7 +52193,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/NP-Classifier"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tensorflow",
@@ -51534,7 +52391,8 @@
    "samgoldman97/ms-pred",
    "volvox292/mass2smiles",
    "wabdelmoula/massNet"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "thermorawfileparser",
@@ -51549,9 +52407,9 @@
    "direct-infusion-MS",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "Apache-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "background-ion-blank-comparison",
    "background-ion-contaminant-removal",
@@ -51602,8 +52460,9 @@
    "tic-based-intensity-scaling",
    "zero-value-handling-in-mass-spectrometry-data"
   ],
-  "license_subject": null,
-  "source_paper_repos": []
+  "license_subject": "tool",
+  "source_paper_repos": [],
+  "repo_url": "https://github.com/compomics/ThermoRawFileParser"
  },
  {
   "slug": "tibble",
@@ -51629,7 +52488,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tidyr",
@@ -51681,7 +52541,8 @@
   "source_paper_repos": [
    "GenomicsMachineLearning/SpaMTP",
    "kilgain/MassSpec"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tidyverse",
@@ -51727,7 +52588,8 @@
   "source_paper_repos": [
    "LeaveMeNotTonight/CMDN",
    "scibiome/meteor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "timar",
@@ -51783,7 +52645,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "luigiquiros/inventa"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tissuemasst",
@@ -51841,7 +52704,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mwang87/MASST"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tomcat",
@@ -51875,7 +52739,8 @@
    "web-service-health-verification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "topncontroller",
@@ -51939,7 +52804,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "torch-1-7-1",
@@ -51974,7 +52840,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "aaronma2020/MSGO"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torch-cluster",
@@ -52021,7 +52888,8 @@
   "source_paper_repos": [
    "01dadada/RT-Transformer",
    "RiverCCC/ABCoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torch-geometric",
@@ -52057,7 +52925,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "01dadada/RT-Transformer"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torch-scatter",
@@ -52104,7 +52973,8 @@
   "source_paper_repos": [
    "01dadada/RT-Transformer",
    "RiverCCC/ABCoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torch-sparse",
@@ -52151,7 +53021,8 @@
   "source_paper_repos": [
    "01dadada/RT-Transformer",
    "RiverCCC/ABCoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torch",
@@ -52216,7 +53087,8 @@
    "01dadada/RT-Transformer",
    "aaronma2020/MSGO",
    "chensaian/TransG-Net"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "torchmetrics",
@@ -52246,7 +53118,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "RiverCCC/ABCoRT"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tqdm-joblib",
@@ -52270,7 +53143,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "tqdm",
@@ -52283,9 +53157,9 @@
   "techniques": [
    "LC-MS"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "MPL-2.0",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "cross-method-chromatographic-scalability",
    "dual-branch-feature-fusion",
@@ -52308,11 +53182,12 @@
    "spectral-feature-extraction-and-annotation",
    "transfer-learning-model-adaptation"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "01dadada/RT-Transformer",
    "zsspython/LAGF"
-  ]
+  ],
+  "repo_url": "https://github.com/tqdm/tqdm"
  },
  {
   "slug": "transformer-architecture",
@@ -52361,7 +53236,8 @@
    "transformer-based-fragment-assembly"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "transformer",
@@ -52442,7 +53318,8 @@
    "HaldamirS/CLERMS",
    "NeoNexusX/HyperCCS",
    "samgoldman97/mist"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "treelib",
@@ -52480,7 +53357,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "shuzhao-li-lab/khipu"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "trelliscope",
@@ -52502,7 +53380,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pmartR/MODE_ShinyApp"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "trfba",
@@ -52570,7 +53449,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "trimgalore",
@@ -52580,9 +53460,9 @@
    "10.1093/bioadv/vbae175"
   ],
   "techniques": [],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-3.0-only",
+  "license_detection": "bioconda-package",
   "used_by_skills": [
    "batch-effect-correction-combat-sva",
    "coding-potential-prediction-and-classification",
@@ -52616,10 +53496,11 @@
    "sra-data-retrieval-and-ingestion",
    "transcript-abundance-quantification-with-salmon"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "ASAGlab/MOI--An-integrated-solution-for-omics-analyses"
-  ]
+  ],
+  "repo_url": "https://github.com/FelixKrueger/TrimGalore"
  },
  {
   "slug": "trove4j",
@@ -52692,7 +53573,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "rformassspectrometry/Spectra"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ubuntu",
@@ -52721,7 +53603,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LQZ0123/MSThunder"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ultramassexplorer",
@@ -52795,7 +53678,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "unimod",
@@ -52865,7 +53749,8 @@
    "usi-string-parsing-and-resolution"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "vegan-r-package",
@@ -52937,7 +53822,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "vegan",
@@ -53012,7 +53898,8 @@
    "unsaturation-degree-quantification"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "vim",
@@ -53044,7 +53931,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "scibiome/meteor"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "vimms",
@@ -53110,7 +53998,8 @@
    "virtual-mass-spectrometer-configuration"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "visual-studio-code",
@@ -53152,7 +54041,8 @@
   "source_paper_repos": [
    "SysMedOs/LipidLynxX",
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "visual-studio",
@@ -53188,7 +54078,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "wavelet-toolbox",
@@ -53217,7 +54108,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "AdrianHaun/AriumMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "webassembly",
@@ -53242,7 +54134,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lidawei1975/colmarvista"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "webchem",
@@ -53322,7 +54215,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "mariallr/amanida"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "webworker",
@@ -53347,7 +54241,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "lidawei1975/colmarvista"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "wgcna",
@@ -53449,7 +54344,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "andreasmock/MetaboDiff"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "windows",
@@ -53479,7 +54375,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "LQZ0123/MSThunder"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "wine",
@@ -53527,7 +54424,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "word2vec",
@@ -53570,7 +54468,8 @@
    "word2vec-vocabulary-matching-and-unknown-peak-handling"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "wpf-windows-presentation-foundation",
@@ -53604,7 +54503,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "systemsomicslab/MsdialWorkbench"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "xcms-centwave",
@@ -53634,7 +54534,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "HuanLab/Paramounter"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "xcms",
@@ -53675,9 +54576,9 @@
    "NMR",
    "mass-spectrometry"
   ],
-  "license_tier": "unknown",
-  "license": null,
-  "license_detection": null,
+  "license_tier": "open",
+  "license": "GPL-2.0-or-later",
+  "license_detection": "bioconductor-package",
   "used_by_skills": [
    "acquisition-mode-enumeration-and-validation",
    "adduct-mass-calculation-and-matching",
@@ -54177,7 +55078,7 @@
    "xcms-ramclustr-object-integration",
    "xcms-workflow-execution"
   ],
-  "license_subject": null,
+  "license_subject": "tool",
   "source_paper_repos": [
    "13479776/statTarget",
    "ChiungTingWu/ncGTW",
@@ -54197,7 +55098,8 @@
    "jcapelladesto/geoRge",
    "poomcj/NPFimg",
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": "https://github.com/sneumann/xcms"
  },
  {
   "slug": "xlsxwriter",
@@ -54228,7 +55130,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "Leo-Cheng-Lab/ROIAL-NMR"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "xml-etree-elementtree",
@@ -54294,7 +55197,8 @@
    "xml-spectrum-element-deserialization"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "xquartz",
@@ -54339,7 +55243,8 @@
    "wine-windows-runtime-initialization-diagnostics"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "xtb",
@@ -54374,7 +55279,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "grimme-lab/QCxMS2"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "ysi2950-bioanalyzer",
@@ -54442,7 +55348,8 @@
    "transcriptomics-reaction-activity-scoring"
   ],
   "license_subject": null,
-  "source_paper_repos": []
+  "source_paper_repos": [],
+  "repo_url": null
  },
  {
   "slug": "zenodo-org-records-10997887",
@@ -54466,7 +55373,8 @@
   "license_subject": null,
   "source_paper_repos": [
    "pluskal-lab/DreaMS"
-  ]
+  ],
+  "repo_url": null
  },
  {
   "slug": "zenodo",
@@ -54617,6 +55525,7 @@
    "MassBank/MassBank-data",
    "matchms/matchms",
    "sneumann/xcms"
-  ]
+  ],
+  "repo_url": null
  }
 ]

--- a/docs-site/search_index.json
+++ b/docs-site/search_index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1",
-  "generated_at": "2026-08-21T16:28:11+00:00",
+  "generated_at": "2026-08-21T17:55:57+00:00",
   "collections": [
     "epigenomics/v1",
     "metabolomics/v1",

--- a/governance/LICENSE_TIERS.md
+++ b/governance/LICENSE_TIERS.md
@@ -102,6 +102,48 @@ did not say whose licence it was.
 evidence about a paper and yields `unknown` on the tool axis. Enforced by
 `scripts/check_tools_index.py`.
 
+### Where a tool licence is allowed to come from
+
+`scripts/resolve_tool_licenses.py` writes `tool_licenses.json`, and that file is the
+only thing `enrich_tools_index.py` will tier a tool from. Two routes, both evidence
+about the tool itself:
+
+| Route | Evidence | Network |
+|---|---|---|
+| `self_published` | The tool is the subject of a paper already in the corpus — matched on exact name equality, never substring — so that paper's repository is the tool's, and the licence already resolved from it is the tool's licence. | no |
+| `registry` | The tool's name matches a package in a curated life-science registry declared in `governance/tool_registries.yaml`. | yes, cached |
+
+Only *curated life-science* registries are consulted, and that restriction is the
+design. An exact name match is not by itself evidence: CRAN carries `AER` (Applied
+Econometrics with R) and `arrow` (Apache Arrow), and PyPI carries a deprecated
+`sklearn` shim. Matching a metabolomics tool name against a general-purpose index
+reproduces the wrong-entity attribution of issue #42 one registry further down. A
+registry that indexes only life-science software carries the domain constraint
+structurally.
+
+That is necessary but still not sufficient, and the measurement says so: of 94
+registry matches reviewed on 2026-08-21, four were different projects sharing a short
+name — `bart`, `grid`, `meteor`, `mist` — plus `ggplot`, where the corpus means the R
+package and the registry has a Python re-implementation. They are recorded as
+reviewed exclusions with reasons in `governance/tool_registries.yaml` rather than
+guessed at by a detector, because no automatic signal separates them yet: requiring
+the tool's own evidence to attest the package rejects 52 of the 94, CAMERA, mzmine,
+rdkit, MSnbase and nextflow among them. Finding one is issue #43, and it is the
+precondition for consulting a general-purpose registry at all.
+
+**Where the routes disagree, the registry wins on the licence string.** A package
+declares its own licence; a repository read infers one from whatever LICENSE file
+sits at the root. `sneumann/xcms` is the case: DESCRIPTION says `GPL (>= 2)`, GitHub
+reports NOASSERTION, and the LICENSE file classifies as LGPL-3.0 because it carries
+terms for a bundled component. The superseded reading is kept on the record. A
+disagreement in *tier*, though, is a contradiction rather than an override — the two
+sources would give a consumer materially different advice — so the tool resolves to
+`unknown` and the conflict is reported.
+
+Every resolved entry records the `repo_url` it came from, so the claim can be
+disputed. `check_tools_index.py` fails if `tools_index.json` drifts from the
+resolution it was derived from, or if a tool carries a tier with no entry behind it.
+
 ## The source-reuse axis
 
 `license_tier` answers *"what may I do with the tool?"*. It does **not** answer

--- a/governance/tool_registries.yaml
+++ b/governance/tool_registries.yaml
@@ -1,0 +1,74 @@
+# Package registries consulted to resolve a TOOL's own licence and repository.
+# Human doc: LICENSE_TIERS.md § "A tool's licence may only come from the tool".
+version: 1
+
+# Only *curated life-science* registries are listed, and that is the whole point.
+# An exact name match is not by itself evidence that a package is the tool a paper
+# meant: CRAN carries `AER` (Applied Econometrics with R) and `arrow` (Apache
+# Arrow), PyPI carries a deprecated `sklearn` shim. Matching a metabolomics tool
+# name against a general-purpose index reproduces the wrong-entity attribution that
+# issue #42 was about, one registry further down. A registry that indexes only
+# life-science software supplies the domain constraint structurally, so the name
+# match carries it. General registries need a corroboration signal that does not
+# exist yet; see issue #43.
+registries:
+  - id: bioconductor
+    detection: bioconductor-package
+    # r-universe mirrors Bioconductor's metadata; bioconductor.org is not reachable
+    # from every network and offers no bulk name list.
+    index_url: https://bioc.r-universe.dev/api/ls
+    index_shape: name_list
+    package_url: https://bioc.r-universe.dev/api/packages/{name}
+    license_field: License
+    license_format: r_description_field
+    repo_fields: [URL, BugReports, RemoteUrl]
+
+  - id: bioconda
+    detection: bioconda-package
+    # channeldata.json carries licence and repository inline for every package, so
+    # the whole registry is one request and matching is offline afterwards.
+    index_url: https://conda.anaconda.org/bioconda/channeldata.json
+    index_shape: packages_map
+    license_field: license
+    license_format: spdx_or_text
+    repo_fields: [dev_url, home]
+
+# ---------------------------------------------------------------------------
+# Reviewed exclusions.
+#
+# Every registry match was checked by hand once, on 2026-08-21, across 94
+# matches. These are the ones where the registry package is a different project
+# that happens to share the tool's name. A collision on a short acronym is not
+# rare in a 12,000-package index.
+#
+# Recorded as reviewed data rather than inferred, because no automatic signal
+# currently separates these from the correct matches: requiring the tool's
+# evidence to attest the package (`library(X)`, `pip install X`, a repository
+# URL) rejects 52 of the 94, including CAMERA, mzmine, rdkit, MSnbase and
+# nextflow, so it trades roughly 48 correct resolutions for these 4. Finding a
+# corroboration signal that separates them is part of issue #43, and is the
+# precondition for consulting general-purpose registries at all.
+#
+# The review does not extend to matches added later. `resolve_tool_licenses.py`
+# reports the registry match count so a maintainer can see it move.
+# ---------------------------------------------------------------------------
+review:
+  date: '2026-08-21'
+  matches_reviewed: 94
+
+excluded_matches:
+  - tool: bart
+    registry: bioconda
+    reason: the corpus tool is MS-BART, a language model over mass spectra; the package is a bacterial read typer
+  - tool: grid
+    registry: bioconda
+    reason: the corpus tool is R's base grid graphics; the package is GRiD, a bacterial growth-rate index
+  - tool: meteor
+    registry: bioconda
+    reason: the corpus tool is MeTEor, an R app for time-series metabolomics; the package is a metagenomics profiler
+  - tool: mist
+    registry: bioconductor
+    reason: the corpus tool is MIST, a mass-spectra annotation model; the package does differential methylation for scDNAm
+  - tool: ggplot
+    registry: bioconda
+    reason: the corpus tool is the R package ggplot2; the package is an unmaintained Python re-implementation

--- a/scripts/check_tools_index.py
+++ b/scripts/check_tools_index.py
@@ -59,6 +59,36 @@ def _licence_provenance_violations(slug, tool, tier) -> list[str]:
     return out
 
 
+def _resolution_drift(collection_dir, tools) -> list[str]:
+    """tools_index must agree with the resolution it was derived from.
+
+    ``tool_licenses.json`` is the evidence; ``tools_index.json`` is derived from it
+    by ``enrich_tools_index.py``. Editing one without re-running the other leaves a
+    licence in the catalogue that no evidence supports, which is the whole failure
+    class this gate exists for. Skipped when no resolution has been run.
+    """
+    path = pathlib.Path(collection_dir) / "tool_licenses.json"
+    if not path.is_file():
+        return []
+    resolved = json.loads(path.read_text(encoding="utf-8"))
+    by_slug = {t.get("slug"): t for t in tools}
+    out = []
+    for slug, evidence in resolved.items():
+        tool = by_slug.get(slug)
+        if tool is None:
+            out.append(f"tool_licenses {slug!r}: no such tool in tools_index")
+        elif tool.get("license") != evidence.get("license"):
+            out.append(
+                f"tools_index {slug!r}: licence {tool.get('license')!r} does not match "
+                f"the resolved {evidence.get('license')!r}; re-run enrich_tools_index"
+            )
+    unbacked = [t.get("slug") for t in tools
+                if t.get("license_tier") != TIER_UNKNOWN and t.get("slug") not in resolved]
+    for slug in unbacked:
+        out.append(f"tools_index {slug!r}: tiered but absent from tool_licenses.json")
+    return out
+
+
 def check_collection(collection_dir) -> list[str]:
     d = pathlib.Path(collection_dir)
     violations: list[str] = []
@@ -88,6 +118,8 @@ def check_collection(collection_dir) -> list[str]:
                 violations.append(
                     f"tools_index {slug!r}: used_by_skills {ref!r} not in skills_index"
                 )
+
+    violations.extend(_resolution_drift(d, tools))
 
     # Per-tool YAML license_tier must equal its tools_index license_tier.
     # Tools that have no tools/<slug>.yaml are skipped (not every tool has one).

--- a/scripts/derive_license_tiers.py
+++ b/scripts/derive_license_tiers.py
@@ -138,9 +138,18 @@ def spdx_from_r_description(text: str, _map=None) -> str | None:
     declares nothing and returns None rather than a guess.
     """
     match = _R_LICENSE_FIELD.search(text or "")
-    if not match:
+    return spdx_from_r_license_field(match.group(1), _map) if match else None
+
+
+def spdx_from_r_license_field(value: str, _map=None) -> str | None:
+    """SPDX id from the *value* of an R `License:` field, or None.
+
+    Split out because registries serve the field on its own -- r-universe returns
+    `GPL (>= 2) + file LICENSE` with no surrounding DESCRIPTION to search.
+    """
+    if not value:
         return None
-    field = _R_FILE_SUFFIX.sub("", match.group(1).strip())
+    field = _R_FILE_SUFFIX.sub("", value.strip())
     qualifier = _R_VERSION_QUALIFIER.search(field)
     declared = _R_VERSION_QUALIFIER.sub("", field).strip()
     if not declared or declared.lower().startswith("file "):

--- a/scripts/enrich_tool_yaml.py
+++ b/scripts/enrich_tool_yaml.py
@@ -23,7 +23,8 @@ import pathlib
 
 import yaml
 
-_LICENSE_KEYS = ("license_tier", "license", "license_detection", "license_subject")
+_LICENSE_KEYS = ("license_tier", "license", "license_detection", "license_subject",
+                 "repo_url")
 
 # Retired keys, stripped on every pass. `canonical_url` was a copy of one arbitrary
 # member of `source_repos` -- a repository belonging to a paper that cites the tool,

--- a/scripts/enrich_tools_index.py
+++ b/scripts/enrich_tools_index.py
@@ -11,7 +11,7 @@ detect_indent from propagate_license_tiers; does not fork the collector.
 
 Writes back, in collection_dir:
 - tools_index.json : + license_tier, license, license_detection, license_subject,
-                     source_paper_repos, used_by_skills  (- canonical_url)
+                     repo_url, source_paper_repos, used_by_skills  (- canonical_url)
 - skills_index.json: + tools_used
 - kb_bundle.json   : + tools_used on each skill record
 """
@@ -48,12 +48,17 @@ def load_tool_evidence(collection_dir) -> dict:
 
 
 def tool_license(tool_evidence) -> tuple:
-    """(tier, license, detection, subject) for a tool, from evidence about the tool.
+    """(tier, license, detection, subject, repo_url) from evidence about the tool.
 
-    ``tool_evidence`` is a ``{license, license_detection}`` mapping resolved from the
-    tool's own repository / DESCRIPTION / LICENSE file, or None when no such lookup
-    has been done. No lookup, or a lookup whose detection is not a tool detection,
-    yields the ``unknown`` tier with no licence recorded.
+    ``tool_evidence`` is a ``{license, license_detection, repo_url}`` mapping
+    resolved from the tool's own repository or package metadata by
+    ``resolve_tool_licenses.py``, or None when no such lookup has been done. No
+    lookup, or a lookup whose detection is not a tool detection, yields the
+    ``unknown`` tier with no licence and no repository recorded.
+
+    ``repo_url`` is recorded so the claim can be disputed. Every licence in the
+    catalogue was previously unauditable because no entry named the repository it
+    came from, which is how a wrong one went unnoticed.
 
     This deliberately has no access to the corpus. Tiers used to be inherited from
     the papers that cite a tool, aggregated most-restrictively, which recorded CAMERA
@@ -66,8 +71,8 @@ def tool_license(tool_evidence) -> tuple:
     det = ev.get("license_detection")
     tier = tool_tier_from_evidence(lic, det)
     if tier == TIER_UNKNOWN:
-        return (TIER_UNKNOWN, None, det if det not in UNESTABLISHED_DETECTIONS else None, None)
-    return (tier, lic, det, SUBJECT_TOOL)
+        return (TIER_UNKNOWN, None, None, None, None)
+    return (tier, lic, det, SUBJECT_TOOL, ev.get("repo_url") or None)
 
 
 def source_paper_repos(tool_slug, tools_dir) -> list:
@@ -127,11 +132,12 @@ def enrich(collection_dir) -> dict:
 
     tool_tiers: dict[str, int] = {}
     for t in tools:
-        tier, lic, det, subject = tool_license(tool_evidence.get(t["slug"]))
+        tier, lic, det, subject, repo = tool_license(tool_evidence.get(t["slug"]))
         t["license_tier"] = tier
         t["license"] = lic
         t["license_detection"] = det
         t["license_subject"] = subject
+        t["repo_url"] = repo
         t["source_paper_repos"] = source_paper_repos(t["slug"], d / "tools")
         # Named a tool's canonical home while holding a citing paper's repository.
         t.pop("canonical_url", None)

--- a/scripts/license_tier.py
+++ b/scripts/license_tier.py
@@ -37,8 +37,12 @@ SUBJECT_PAPER = "paper"
 # source_reuse_for_license() already avoids. See governance/LICENSE_TIERS.md.
 TIER_UNKNOWN = "unknown"
 
-# Detections that read a code repository, and so describe the *tool*.
-TOOL_DETECTIONS = frozenset({"github-api", "license-file", "r-description", "readme-llm"})
+# Detections that read the tool itself -- its repository, or the package metadata
+# it publishes -- and so describe the *tool*. A registry detection is the stronger
+# of the two: it reads what the package declares for itself, where a repository
+# read infers from whatever LICENSE file happens to sit at the root.
+TOOL_DETECTIONS = frozenset({"github-api", "license-file", "r-description", "readme-llm",
+                             "bioconductor-package", "bioconda-package"})
 # `verified_via` markers that identify the subject when the detection cannot:
 # a clone reads the repository, Unpaywall reads the publication.
 TOOL_VERIFICATIONS = frozenset({"git_clone_succeeded_at_build"})

--- a/scripts/resolve_tool_licenses.py
+++ b/scripts/resolve_tool_licenses.py
@@ -1,0 +1,297 @@
+"""Resolve each tool's own licence and repository, and write tool_licenses.json.
+
+`enrich_tools_index.py` reads that file and refuses to tier a tool without it, so
+this script is where a tool's licence is allowed to come from. Two routes, both
+requiring evidence about the tool itself (issue #43):
+
+- `self_published`  the tool is the subject of a paper already in the corpus, so
+                    that paper's repository is the tool's repository and the
+                    licence resolved from it is the tool's licence. Offline.
+- `registry`        the tool's name matches a package in a curated life-science
+                    registry (governance/tool_registries.yaml). Network, cached.
+
+Where both fire they are compared. The registry wins a disagreement over the
+licence string, because a package declares its own licence and a repository read
+only infers one. A disagreement in *tier* is a contradiction rather than an
+override: the tool resolves to nothing and is reported. Anything unresolved stays
+`unknown`, which is a true statement.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import yaml
+# Invoked by path (`python scripts/x.py`), only `scripts/` lands on sys.path, so
+# the repo root has to be added before the sibling package can be imported.
+if __package__ in (None, ""):
+    import os.path as _p
+    import sys as _sys
+
+    _sys.path.insert(0, _p.dirname(_p.dirname(_p.abspath(__file__))))
+
+from scripts.derive_license_tiers import classify_license_text, spdx_from_r_license_field
+from scripts.license_tier import (SUBJECT_TOOL, UNESTABLISHED_DETECTIONS, licence_subject,
+                                  load_map, tier_for_license)
+
+_REGISTRIES = pathlib.Path(__file__).resolve().parent.parent / "governance" / "tool_registries.yaml"
+_USER_AGENT = "asb-skill-collections tool-licence-resolver"
+
+
+def normalize(text) -> str:
+    """Lower-case alphanumerics only: the comparison key for names."""
+    return re.sub(r"[^a-z0-9]", "", str(text or "").lower())
+
+
+def load_registries(path=None) -> list:
+    """Registry definitions from governance/tool_registries.yaml."""
+    return load_registry_config(path).get("registries") or []
+
+
+def load_registry_config(path=None) -> dict:
+    """The whole registry governance document."""
+    return yaml.safe_load(pathlib.Path(path or _REGISTRIES).read_text(encoding="utf-8")) or {}
+
+
+def excluded_pairs(config) -> set:
+    """``{(tool_slug, registry_id)}`` a human reviewed and rejected.
+
+    Name collisions that no current signal separates from correct matches; each
+    carries a reason in governance/tool_registries.yaml. Held as data so the
+    rejection is reviewable and the resolver stays free of tool names.
+    """
+    return {(e.get("tool"), e.get("registry")) for e in (config.get("excluded_matches") or [])}
+
+
+# --------------------------------------------------------------------------- #
+# Route A -- the tool is the subject of a corpus paper                         #
+# --------------------------------------------------------------------------- #
+
+def introducing_paper(tool, papers) -> dict | None:
+    """The corpus paper that introduces this tool, or None.
+
+    Matched on exact normalized name equality, never substring: `XCMS Online` and
+    `XCMS` are different tools, and a substring rule would merge them.
+    """
+    target = normalize(tool.get("name"))
+    if not target:
+        return None
+    for doi in tool.get("dois") or []:
+        paper = papers.get(doi)
+        if paper and normalize(paper.get("name")) == target:
+            return paper
+    return None
+
+
+def self_published_evidence(tool, papers) -> dict | None:
+    """Licence evidence from the repository of the paper that introduces the tool.
+
+    Only accepted when the corpus entry's licence is about the *tool* -- a paper
+    whose licence came from Crossref describes the publication, and inheriting it
+    is the defect issue #42 fixed.
+    """
+    paper = introducing_paper(tool, papers)
+    if not paper or licence_subject(paper) != SUBJECT_TOOL:
+        return None
+    detection = paper.get("license_detection")
+    licence = (paper.get("access") or {}).get("license")
+    if detection in UNESTABLISHED_DETECTIONS or not licence:
+        return None
+    return {"license": licence, "license_detection": detection,
+            "repo_url": paper.get("repo_url"), "route": "self_published",
+            "matched": paper.get("name")}
+
+
+# --------------------------------------------------------------------------- #
+# Route B -- the tool is a package in a curated life-science registry           #
+# --------------------------------------------------------------------------- #
+
+def fetch_json(url, cache_dir, key):
+    """GET url as JSON, memoised on disk so re-runs are offline and deterministic."""
+    cache = pathlib.Path(cache_dir) / f"{key}.json"
+    if cache.is_file():
+        return json.loads(cache.read_text(encoding="utf-8"))
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+        return None
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def registry_names(registry, cache_dir) -> dict:
+    """``{normalized_name: canonical_name}`` for one registry, or {} if unreachable."""
+    payload = fetch_json(registry["index_url"], cache_dir, f"{registry['id']}-index")
+    if payload is None:
+        return {}
+    if registry["index_shape"] == "packages_map":
+        payload = list((payload.get("packages") or {}).keys())
+    return {normalize(n): n for n in payload if normalize(n)}
+
+
+def registry_record(registry, canonical, cache_dir) -> dict | None:
+    """The registry's metadata for one package."""
+    if registry["index_shape"] == "packages_map":
+        index = fetch_json(registry["index_url"], cache_dir, f"{registry['id']}-index") or {}
+        return (index.get("packages") or {}).get(canonical)
+    url = registry["package_url"].format(name=urllib.parse.quote(canonical))
+    return fetch_json(url, cache_dir, f"{registry['id']}-{normalize(canonical)}")
+
+
+def spdx_from_registry(value, license_format, _map=None) -> str | None:
+    """Registry licence string to an SPDX id, or None when it is not recognised.
+
+    None rather than the `restricted` fallback on purpose: a licence we could not
+    read is not a licence we established, and `tier_for_license` would turn LGPL
+    prose into a verdict.
+    """
+    if not value or not str(value).strip():
+        return None
+    if license_format == "r_description_field":
+        return spdx_from_r_license_field(str(value), _map)
+    text = str(value).strip()
+    known = {k.lower(): k for k in ((_map or load_map()).get("spdx") or {})}
+    return known.get(text.lower()) or classify_license_text(text)
+
+
+def candidate_names(tool) -> list:
+    """Names to try against a registry index, most canonical first."""
+    names = [tool.get("slug"), tool.get("name")]
+    return [n for n in names if n]
+
+
+_CODE_HOSTS = ("github.com", "gitlab.com", "bitbucket.org", "codeberg.org")
+_REPO_ROOT = re.compile(
+    r"(https?://(?:www\.)?(?:" + "|".join(h.replace(".", r"\.") for h in _CODE_HOSTS) +
+    r")/[^/\s,;]+/[^/\s,;#?]+?)(?:\.git)?(?:/(?:issues|pulls|tree|blob|wiki)\b.*)?/?$",
+    re.I)
+
+
+def pick_repo_url(values):
+    """The repository among a registry's declared URLs, canonicalised, or None.
+
+    Registries mix a project homepage, an issue tracker and a git remote into the
+    same fields, and the field here is called `repo_url`. CAMERA declares a lab web
+    page as `URL` and `.../CAMERA/issues/new` as `BugReports`; the answer to "where
+    do I read the source" is the second one with its tracker path removed.
+    """
+    for value in values:
+        for candidate in re.split(r"[,\s]+", str(value).strip()):
+            match = _REPO_ROOT.match(candidate.rstrip("/"))
+            if match:
+                return match.group(1)
+    return next((str(v).split(",")[0].strip() for v in values if v), None)
+
+
+def registry_evidence(tool, registries, indexes, cache_dir, _map=None, excluded=()) -> dict | None:
+    """Licence evidence from the first curated registry that carries this package."""
+    for registry in registries:
+        if (tool.get("slug"), registry["id"]) in excluded:
+            continue
+        index = indexes.get(registry["id"]) or {}
+        canonical = next((index[normalize(n)] for n in candidate_names(tool)
+                          if normalize(n) in index), None)
+        if not canonical:
+            continue
+        record = registry_record(registry, canonical, cache_dir) or {}
+        spdx = spdx_from_registry(record.get(registry["license_field"]),
+                                  registry["license_format"], _map)
+        if not spdx:
+            continue
+        values = [record.get(f) for f in registry["repo_fields"] if record.get(f)]
+        return {"license": spdx, "license_detection": registry["detection"],
+                "repo_url": pick_repo_url(values), "route": f"registry:{registry['id']}",
+                "matched": canonical}
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Reconciliation                                                               #
+# --------------------------------------------------------------------------- #
+
+def reconcile(self_published, registry, _map=None) -> tuple:
+    """(evidence, conflict) from the two routes.
+
+    Where both fire, the registry wins. A registry states the licence the package
+    declares for itself; the repository route reads a LICENSE file, and for a
+    packaged tool that file is often narrower than the package. `sneumann/xcms`
+    is the case in point: DESCRIPTION says `GPL (>= 2)`, GitHub reports
+    NOASSERTION, and the LICENSE file classifies as LGPL-3.0 because it carries
+    terms for a bundled component. The same reasoning already sits in
+    governance/license_tiers.yaml, which is why `r_license_aliases` exists.
+
+    A disagreement in *tier* is not an override but a contradiction: the two
+    sources would give a consumer materially different advice, so the tool
+    resolves to nothing and the conflict is reported.
+    """
+    if not self_published or not registry:
+        return self_published or registry, None
+    if tier_for_license(self_published["license"], _map) != \
+            tier_for_license(registry["license"], _map):
+        return None, {"self_published": self_published, "registry": registry}
+    evidence = dict(registry)
+    if not evidence.get("repo_url"):
+        evidence["repo_url"] = self_published.get("repo_url")
+    if self_published["license"] != registry["license"]:
+        evidence["superseded"] = {"license": self_published["license"],
+                                  "license_detection": self_published["license_detection"]}
+    return evidence, None
+
+
+def resolve(collection_dir, cache_dir, registries=None) -> dict:
+    """Write tool_licenses.json for a collection and return a summary."""
+    d = pathlib.Path(collection_dir)
+    tools = json.loads((d / "tools_index.json").read_text(encoding="utf-8"))
+    corpus = yaml.safe_load((d / "corpus.yaml").read_text(encoding="utf-8"))
+    papers = {p["doi"]: p for p in corpus.get("papers", []) if p.get("doi")}
+    config = load_registry_config()
+    registries = registries if registries is not None else (config.get("registries") or [])
+    excluded = excluded_pairs(config)
+    tier_map = load_map()
+    indexes = {r["id"]: registry_names(r, cache_dir) for r in registries}
+
+    resolved, conflicts = {}, {}
+    for tool in tools:
+        evidence, conflict = reconcile(
+            self_published_evidence(tool, papers),
+            registry_evidence(tool, registries, indexes, cache_dir, tier_map, excluded),
+            tier_map)
+        if conflict:
+            conflicts[tool["slug"]] = conflict
+        elif evidence:
+            resolved[tool["slug"]] = evidence
+
+    (d / "tool_licenses.json").write_text(
+        json.dumps(dict(sorted(resolved.items())), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8")
+    routes: dict[str, int] = {}
+    for e in resolved.values():
+        routes[e["route"]] = routes.get(e["route"], 0) + 1
+    return {"tools": len(tools), "resolved": len(resolved),
+            "reviewed_exclusions": len(excluded),
+            "cross_checked": sum(1 for e in resolved.values() if "superseded" in e),
+            "conflicts": conflicts, "routes": dict(sorted(routes.items())),
+            "index_sizes": {k: len(v) for k, v in indexes.items()}}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--collection", required=True,
+                    help="collection dir with tools_index.json and corpus.yaml")
+    ap.add_argument("--cache", default=".cache/tool-registries",
+                    help="where registry responses are memoised (default: .cache/tool-registries)")
+    args = ap.parse_args(argv)
+    print(json.dumps(resolve(args.collection, args.cache), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_enrich_tool_yaml.py
+++ b/tests/test_enrich_tool_yaml.py
@@ -15,7 +15,8 @@ from scripts import enrich_tool_yaml as e
 def test_tier_map_extracts_license_fields():
     tools_index = [
         {"slug": "t_open", "license_tier": "open", "license": "MIT",
-         "license_detection": "github-api", "license_subject": "tool"},
+         "license_detection": "github-api", "license_subject": "tool",
+         "repo_url": "owner/t-open"},
         {"slug": "t_nc", "license_tier": "noncommercial", "license": "CC-BY-NC-4.0",
          "license_detection": "readme-llm", "license_subject": "tool"},
         {"slug": "t_unknown", "license_tier": "unknown", "license": None,
@@ -23,7 +24,8 @@ def test_tier_map_extracts_license_fields():
     ]
     m = e.tier_map(tools_index)
     assert m["t_open"] == {"license_tier": "open", "license": "MIT",
-                           "license_detection": "github-api", "license_subject": "tool"}
+                           "license_detection": "github-api", "license_subject": "tool",
+                           "repo_url": "owner/t-open"}
     assert m["t_nc"]["license_tier"] == "noncommercial"
     assert m["t_unknown"]["license"] is None
     assert m["t_unknown"]["license_subject"] is None
@@ -33,7 +35,8 @@ def test_tier_map_defaults_missing_fields():
     # A tools_index entry that only carries the tier still yields a complete row.
     m = e.tier_map([{"slug": "t1", "license_tier": "open"}])
     assert m["t1"] == {"license_tier": "open", "license": None,
-                       "license_detection": None, "license_subject": None}
+                       "license_detection": None, "license_subject": None,
+                       "repo_url": None}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enrich_tools_index.py
+++ b/tests/test_enrich_tools_index.py
@@ -8,19 +8,27 @@ from scripts import enrich_tools_index as e
 # --------------------------------------------------------------------------- #
 
 def test_a_tool_repository_lookup_yields_a_real_tier():
-    assert e.tool_license({"license": "MIT", "license_detection": "github-api"}) == (
-        "open", "MIT", "github-api", "tool")
+    assert e.tool_license({"license": "MIT", "license_detection": "github-api",
+                           "repo_url": "owner/tool"}) == (
+        "open", "MIT", "github-api", "tool", "owner/tool")
+
+
+def test_the_resolved_repository_is_recorded_so_the_claim_can_be_disputed():
+    """Every licence was previously unauditable: no entry named its source."""
+    *_, repo = e.tool_license({"license": "GPL-2.0-or-later", "repo_url": "sneumann/xcms",
+                               "license_detection": "bioconductor-package"})
+    assert repo == "sneumann/xcms"
 
 
 def test_an_r_description_lookup_yields_a_real_tier():
-    tier, lic, det, subject = e.tool_license(
+    tier, lic, det, subject, _ = e.tool_license(
         {"license": "GPL-3.0-only", "license_detection": "r-description"})
     assert (tier, lic, subject) == ("open", "GPL-3.0-only", "tool")
     assert det == "r-description"
 
 
 def test_a_noncommercial_tool_licence_survives():
-    tier, _, _, subject = e.tool_license(
+    tier, _, _, subject, _repo = e.tool_license(
         {"license": "CC-BY-NC-4.0", "license_detection": "license-file"})
     assert (tier, subject) == ("noncommercial", "tool")
 
@@ -33,7 +41,7 @@ def test_a_citing_papers_licence_is_never_the_tools_licence():
     """
     for detection in ("crossref-paper", "biorxiv_api-paper", "unpaywall-paper"):
         for licence in ("Apache-2.0", "MIT", "CC-BY-4.0", "CC-BY-NC-ND-4.0"):
-            tier, lic, _, subject = e.tool_license(
+            tier, lic, _, subject, _repo = e.tool_license(
                 {"license": licence, "license_detection": detection})
             assert tier == "unknown", f"{detection}/{licence} leaked onto the tool axis"
             assert lic is None and subject is None
@@ -43,9 +51,9 @@ def test_no_evidence_is_unknown_not_restricted():
     """`unknown` is an open question; `restricted` is a verdict. Not the same."""
     for evidence in (None, {}, {"license": None, "license_detection": "none"},
                      {"license": None, "license_detection": "file-present-unclassified"}):
-        tier, lic, det, subject = e.tool_license(evidence)
+        tier, lic, det, subject, repo = e.tool_license(evidence)
         assert tier == "unknown"
-        assert lic is None and det is None and subject is None
+        assert lic is None and det is None and subject is None and repo is None
 
 
 def test_source_paper_repos_reads_the_tool_yaml(tmp_path):
@@ -115,7 +123,8 @@ def _write_collection(tmp_path, with_evidence=True):
         "name: ToolOpen\nsource_repos:\n- some/citing-paper\n")
     if with_evidence:
         (d / "tool_licenses.json").write_text(json.dumps({
-            "t_open": {"license": "GPL-3.0-only", "license_detection": "github-api"}}))
+            "t_open": {"license": "GPL-3.0-only", "license_detection": "github-api",
+                       "repo_url": "https://github.com/x/tool-open"}}))
     return d
 
 
@@ -128,12 +137,14 @@ def test_enrich_writes_back_all_fields(tmp_path):
     assert tools["t_open"]["license_tier"] == "open"
     assert tools["t_open"]["license"] == "GPL-3.0-only"
     assert tools["t_open"]["license_subject"] == "tool"
+    assert tools["t_open"]["repo_url"] == "https://github.com/x/tool-open"
 
     # A tool with no lookup of its own is unknown, however well-licensed its papers.
     for slug in ("t_mix", "t_unmatched"):
         assert tools[slug]["license_tier"] == "unknown"
         assert tools[slug]["license"] is None
         assert tools[slug]["license_subject"] is None
+        assert tools[slug]["repo_url"] is None
 
     # The citing-paper repository is published under a name that says what it is.
     assert tools["t_open"]["source_paper_repos"] == ["some/citing-paper"]

--- a/tests/test_resolve_tool_licenses.py
+++ b/tests/test_resolve_tool_licenses.py
@@ -1,0 +1,240 @@
+"""A tool's licence may only come from the tool. These tests hold that line.
+
+Everything here is offline: registry responses are pre-seeded into the cache
+directory the resolver memoises into, so no test reaches the network.
+"""
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+from scripts import resolve_tool_licenses as r
+
+BIOC = {"id": "bioconductor", "detection": "bioconductor-package",
+        "index_url": "https://example.invalid/ls", "index_shape": "name_list",
+        "package_url": "https://example.invalid/packages/{name}",
+        "license_field": "License", "license_format": "r_description_field",
+        "repo_fields": ["URL", "RemoteUrl"]}
+
+CONDA = {"id": "bioconda", "detection": "bioconda-package",
+         "index_url": "https://example.invalid/channeldata.json",
+         "index_shape": "packages_map", "license_field": "license",
+         "license_format": "spdx_or_text", "repo_fields": ["dev_url", "home"]}
+
+
+@pytest.fixture
+def cache(tmp_path):
+    """A seeded cache: the resolver reads these instead of the network."""
+    d = tmp_path / "cache"
+    d.mkdir()
+    (d / "bioconductor-index.json").write_text(json.dumps(["xcms", "CAMERA", "mist"]))
+    (d / "bioconductor-xcms.json").write_text(json.dumps(
+        {"License": "GPL (>= 2) + file LICENSE", "URL": "https://github.com/sneumann/xcms"}))
+    (d / "bioconductor-camera.json").write_text(json.dumps(
+        {"License": "GPL (>= 2)", "RemoteUrl": "https://github.com/bioc/CAMERA"}))
+    (d / "bioconductor-mist.json").write_text(json.dumps({"License": "MIT + file LICENSE"}))
+    (d / "bioconda-index.json").write_text(json.dumps({"packages": {
+        "mzmine": {"license": "MIT", "dev_url": "https://github.com/mzmine/mzmine"},
+        "vague": {"license": "see the enclosed terms of use"},
+    }}))
+    return d
+
+
+def paper(name, licence, detection, repo="owner/repo"):
+    return {"doi": "10.1/p", "name": name, "repo_url": repo,
+            "license_detection": detection, "access": {"license": licence}}
+
+
+def tool(slug, name, dois=("10.1/p",)):
+    return {"slug": slug, "name": name, "dois": list(dois)}
+
+
+# --------------------------------------------------------------------------- #
+# Route A -- the introducing paper                                            #
+# --------------------------------------------------------------------------- #
+
+def test_the_introducing_papers_repository_licence_is_the_tools():
+    papers = {"10.1/p": paper("ANN-SoLo", "Apache-2.0", "github-api", "bittremieux-lab/ANN-SoLo")}
+    e = r.self_published_evidence(tool("ann-solo", "ANN-SoLo"), papers)
+    assert e["license"] == "Apache-2.0"
+    assert e["repo_url"] == "bittremieux-lab/ANN-SoLo"
+    assert e["route"] == "self_published"
+
+
+def test_a_paper_subject_licence_is_refused_even_from_the_introducing_paper():
+    """The #42 defect. Crossref describes the publication, not the software."""
+    for detection in ("crossref-paper", "biorxiv_api-paper"):
+        papers = {"10.1/p": paper("ANN-SoLo", "CC-BY-4.0", detection)}
+        assert r.self_published_evidence(tool("ann-solo", "ANN-SoLo"), papers) is None
+
+
+def test_a_paper_that_merely_cites_the_tool_is_not_its_introducing_paper():
+    papers = {"10.1/p": paper("LipidIN", "Apache-2.0", "github-api", "LinShuhaiLAB/LipidIN")}
+    assert r.self_published_evidence(tool("camera", "CAMERA"), papers) is None
+
+
+def test_the_name_match_is_exact_not_substring():
+    """`XCMS Online` is a different tool from `XCMS`."""
+    papers = {"10.1/p": paper("XCMS Online", "MIT", "github-api")}
+    assert r.introducing_paper(tool("xcms", "XCMS"), papers) is None
+
+
+def test_an_unresolved_paper_licence_yields_no_evidence():
+    papers = {"10.1/p": paper("Tool", None, "none")}
+    assert r.self_published_evidence(tool("tool", "Tool"), papers) is None
+
+
+# --------------------------------------------------------------------------- #
+# Route B -- curated registries                                               #
+# --------------------------------------------------------------------------- #
+
+def test_a_registry_match_is_case_insensitive(cache):
+    """The catalogue records `XCMS`; Bioconductor names it `xcms`."""
+    indexes = {"bioconductor": r.registry_names(BIOC, cache)}
+    e = r.registry_evidence(tool("xcms", "XCMS"), [BIOC], indexes, cache)
+    assert e["license"] == "GPL-2.0-or-later"
+    assert e["repo_url"] == "https://github.com/sneumann/xcms"
+    assert e["license_detection"] == "bioconductor-package"
+
+
+def test_an_unreadable_registry_licence_resolves_to_nothing(cache):
+    """Rather than the `restricted` fallback: unread is not established."""
+    indexes = {"bioconda": r.registry_names(CONDA, cache)}
+    assert r.registry_evidence(tool("vague", "vague"), [CONDA], indexes, cache) is None
+
+
+def test_a_reviewed_exclusion_blocks_the_match(cache):
+    """A reviewed name collision stays unresolved, per governance data."""
+    indexes = {"bioconductor": r.registry_names(BIOC, cache)}
+    t = tool("mist", "MIST")
+    assert r.registry_evidence(t, [BIOC], indexes, cache) is not None
+    assert r.registry_evidence(t, [BIOC], indexes, cache,
+                               excluded={("mist", "bioconductor")}) is None
+
+
+def test_an_unknown_name_matches_nothing(cache):
+    indexes = {"bioconductor": r.registry_names(BIOC, cache)}
+    assert r.registry_evidence(tool("nosuchtool", "NoSuchTool"), [BIOC], indexes, cache) is None
+
+
+def test_an_unreachable_registry_yields_an_empty_index(tmp_path):
+    """A failed fetch must not look like an empty registry that resolved fine."""
+    assert r.registry_names(BIOC, tmp_path / "empty") == {}
+
+
+# --------------------------------------------------------------------------- #
+# Reconciliation                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_the_registry_supersedes_a_repository_read_of_the_same_tier():
+    """xcms: DESCRIPTION says GPL (>= 2); the LICENSE file classifies as LGPL-3.0."""
+    a = {"license": "LGPL-3.0", "license_detection": "license-file",
+         "repo_url": "sneumann/xcms", "route": "self_published", "matched": "XCMS"}
+    b = {"license": "GPL-2.0-or-later", "license_detection": "bioconductor-package",
+         "repo_url": None, "route": "registry:bioconductor", "matched": "xcms"}
+    evidence, conflict = r.reconcile(a, b)
+    assert conflict is None
+    assert evidence["license"] == "GPL-2.0-or-later"
+    assert evidence["superseded"]["license"] == "LGPL-3.0"
+    # the repository the registry lacked is carried over, not dropped
+    assert evidence["repo_url"] == "sneumann/xcms"
+
+
+def test_a_tier_disagreement_resolves_to_nothing():
+    """Two sources giving materially different advice is not a resolution."""
+    a = {"license": "MIT", "license_detection": "github-api", "route": "self_published"}
+    b = {"license": "CC-BY-NC-4.0", "license_detection": "bioconda-package",
+         "route": "registry:bioconda"}
+    evidence, conflict = r.reconcile(a, b)
+    assert evidence is None
+    assert conflict["self_published"]["license"] == "MIT"
+
+
+def test_one_route_alone_is_used_as_is():
+    a = {"license": "MIT", "license_detection": "github-api", "route": "self_published"}
+    assert r.reconcile(a, None) == (a, None)
+    assert r.reconcile(None, a) == (a, None)
+    assert r.reconcile(None, None) == (None, None)
+
+
+# --------------------------------------------------------------------------- #
+# End to end                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_resolve_writes_only_tool_backed_entries(tmp_path, cache):
+    d = tmp_path / "col"
+    d.mkdir()
+    (d / "tools_index.json").write_text(json.dumps([
+        tool("xcms", "XCMS", ["10.1/xcms"]),
+        tool("camera", "CAMERA", ["10.1/lipidin"]),
+        tool("nothing", "Nothing", ["10.1/lipidin"]),
+    ]))
+    (d / "corpus.yaml").write_text(yaml.safe_dump({"papers": [
+        {"doi": "10.1/xcms", "name": "XCMS", "repo_url": "sneumann/xcms",
+         "license_detection": "license-file", "access": {"license": "LGPL-3.0"}},
+        {"doi": "10.1/lipidin", "name": "LipidIN", "repo_url": "LinShuhaiLAB/LipidIN",
+         "license_detection": "github-api", "access": {"license": "Apache-2.0"}},
+    ]}))
+    summary = r.resolve(str(d), cache, registries=[BIOC, CONDA])
+    out = json.loads((d / "tool_licenses.json").read_text())
+
+    assert summary["conflicts"] == {}
+    # CAMERA is cited by an Apache-2.0 paper and is itself GPL. The registry wins,
+    # and the citing paper never contributes.
+    assert out["camera"]["license"] == "GPL-2.0-or-later"
+    assert out["xcms"]["license"] == "GPL-2.0-or-later"
+    # A tool with neither route resolves to nothing at all.
+    assert "nothing" not in out
+
+
+def test_the_shipped_registry_config_is_well_formed():
+    """Every declared registry and exclusion carries the fields the resolver reads."""
+    config = r.load_registry_config()
+    assert config["registries"], "no registries declared"
+    for reg in config["registries"]:
+        for field in ("id", "detection", "index_url", "index_shape",
+                      "license_field", "license_format", "repo_fields"):
+            assert reg.get(field), f"{reg.get('id')}: missing {field}"
+        if reg["index_shape"] == "name_list":
+            assert reg.get("package_url"), f"{reg['id']}: name_list needs package_url"
+    ids = {reg["id"] for reg in config["registries"]}
+    for excl in config.get("excluded_matches") or []:
+        assert excl.get("tool") and excl.get("reason"), f"incomplete exclusion: {excl}"
+        assert excl["registry"] in ids, f"{excl['tool']}: unknown registry {excl['registry']!r}"
+
+
+def test_every_registry_detection_counts_as_tool_evidence():
+    """A detection the tier resolver does not recognise would silently stay unknown."""
+    from scripts.license_tier import TOOL_DETECTIONS
+    for reg in r.load_registry_config()["registries"]:
+        assert reg["detection"] in TOOL_DETECTIONS, reg["detection"]
+
+
+# --------------------------------------------------------------------------- #
+# Repository URL selection                                                    #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("values,expected", [
+    # CAMERA: a lab homepage in URL, the repository buried in a BugReports path.
+    (["http://msbi.ipb-halle.de/msbi/CAMERA/", "https://github.com/sneumann/CAMERA/issues/new"],
+     "https://github.com/sneumann/CAMERA"),
+    (["https://github.com/lgatto/MSnbase/issues"], "https://github.com/lgatto/MSnbase"),
+    (["https://github.com/mzmine/mzmine"], "https://github.com/mzmine/mzmine"),
+    (["https://github.com/bioc/limma.git"], "https://github.com/bioc/limma"),
+    # Several URLs crammed into one field, comma- and newline-separated.
+    (["https://github.com/hanhineva-lab/notame,\nhttps://hanhineva-lab.github.io/notame/"],
+     "https://github.com/hanhineva-lab/notame"),
+    # No code host: the declared URL is still better than nothing.
+    (["https://www.ruby-lang.org"], "https://www.ruby-lang.org"),
+    ([], None),
+])
+def test_pick_repo_url(values, expected):
+    assert r.pick_repo_url(values) == expected
+
+
+def test_pick_repo_url_prefers_a_code_host_over_an_earlier_homepage():
+    assert r.pick_repo_url(["https://bioinf.wehi.edu.au/limma/",
+                            "https://github.com/bioc/limma"]) == "https://github.com/bioc/limma"


### PR DESCRIPTION
Closes #43.

#44 left every tool `unknown`, which was true but not useful. This resolves 196 of the 909 from evidence about the tool itself, and records where each claim came from.

## Two routes

**`self_published` (107, offline).** A tool is often the subject of a paper already in the corpus. Matched on exact name equality — never substring, so `XCMS Online` stays distinct from `XCMS` — that paper's repository is the tool's repository, and the licence already resolved from it is the tool's licence. Only accepted when `licence_subject` says the corpus entry describes the tool; a Crossref-derived licence describes the publication and is refused.

**`registry` (89, network, cached).** The tool's name matches a package in a curated life-science registry: Bioconductor via `bioc.r-universe.dev`, bioconda via the channel's `channeldata.json`. Both are one bulk fetch, so matching is offline and case-insensitive afterwards — which matters, because the catalogue records `XCMS` and Bioconductor names it `xcms`.

Only *curated life-science* registries are consulted, and that is the design rather than a limitation. An exact name match is not by itself evidence: CRAN carries `AER` (Applied Econometrics with R) and `arrow` (Apache Arrow), PyPI carries a deprecated `sklearn` shim. Matching a metabolomics tool name against a general-purpose index reproduces #42's wrong-entity attribution one registry down. A registry indexing only life-science software carries the domain constraint structurally.

## Where they disagree, the registry wins

A package declares its own licence; a repository read infers one from whatever LICENSE file sits at the root. `sneumann/xcms` is exactly the case #42 reported: DESCRIPTION says `GPL (>= 2)`, GitHub reports NOASSERTION, and the LICENSE file classifies as LGPL-3.0 because it carries terms for a bundled component. The superseded reading stays on the record. This fired on 7 tools.

A disagreement in *tier* is a contradiction rather than an override — the two sources would give a consumer materially different advice — so the tool resolves to `unknown` and the conflict is reported. None occurred.

## The registry route was measured, and it over-fires

Curated-registry membership turned out to be necessary but not sufficient. All 94 matches were reviewed by hand; four are different projects sharing a short name, plus one where the corpus means the R package and the registry has a Python re-implementation:

| tool | corpus | matched package |
| --- | --- | --- |
| `bart` | MS-BART, a language model over mass spectra | a bacterial read typer |
| `grid` | R's base grid graphics | GRiD, a bacterial growth-rate index |
| `meteor` | MeTEor, an R app for time-series metabolomics | a metagenomics profiler |
| `mist` | MIST, a mass-spectra annotation model | differential methylation for scDNAm |
| `ggplot` | the R package ggplot2 | an unmaintained Python re-implementation |

They are recorded as reviewed exclusions with reasons in `governance/tool_registries.yaml`, not inferred by a detector, because no automatic signal separates them yet. Requiring the tool's own evidence to attest the package — `library(X)`, `pip install X`, a repository URL — rejects 52 of the 94, CAMERA, mzmine, rdkit, MSnbase and nextflow among them. That trades roughly 48 correct resolutions for these 4. Finding a signal that does separate them is the precondition for consulting a general-purpose registry; filed as #48 with the 94 reviewed matches as a labelled set to calibrate against, rather than guessed at here.

## What changed in the data

Of the 196 resolved, 79 had a different licence before and 30 a different tier. The four `unknown`-by-default cases from #42 now read correctly: CAMERA and XCMS are `GPL-2.0-or-later`, sourced from Bioconductor, with `https://github.com/sneumann/CAMERA` and `https://github.com/sneumann/xcms` recorded. `ruby`, which the old catalogue called `noncommercial` after inheriting BioTransformer's licence, is `BSD`. `masscube` is the one genuine `noncommercial`, CC-BY-NC-4.0 from its own LICENSE file.

Every entry carries `repo_url`, canonicalised to the repository root: registries mix a homepage, an issue tracker and a git remote into the same fields, and CAMERA's is reachable only by stripping `/issues/new` off its `BugReports`.

Remaining: 713 `unknown`. A large share are not software — instruments, vendor products, language names, and extraction artefacts such as `C++`, `Bioconductor` and `massdash.loaders.ResultsLoader`. At least 54 are detectable by shape alone. That count therefore overstates the licence work left and understates the catalogue cleaning; filed separately as #49.

## Verification

`check_tools_index` now fails if `tools_index.json` drifts from the `tool_licenses.json` it was derived from, or if a tool carries a tier with no entry behind it; confirmed red on a hand-edited licence before being made green. 1,108 tests pass, 2 skipped (was 1,080) — 24 new, all offline against a seeded cache. All four gates OK; `release_gate --strict` unchanged at WARN on three pre-existing PII findings.
