### PR TITLE
Layout and packaging gate; dormant skill-load counter

### DIFF
--- a/asb_skill_collections/asb_mcp_server.py
+++ b/asb_skill_collections/asb_mcp_server.py
@@ -25,10 +25,20 @@ Claude Desktop / Code config (mcpServers):
     }
 
 Requires the `mcp` extra: `pip install "asb-skill-collections[mcp]"`.
+
+Local load counting is **off unless `ASB_SKILLS_USAGE_PATH` is set**, and even
+then it is purely local: it appends nothing to the network, records no user,
+session or host identifier, and never stores a query string. See
+`docs/design/skill-load-telemetry.md`; the network beacon described there stays
+deferred pending the CNRS GDPR audit.
 """
 from __future__ import annotations
 
+import json
+import os
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -44,6 +54,92 @@ except ModuleNotFoundError:  # pragma: no cover - exercised only without the ext
 from . import asb_skill_index as idx
 
 mcp = FastMCP("asb-skills")
+
+
+# --------------------------------------------------------------------------- #
+# Local skill-load counter — dormant by default.                              #
+# --------------------------------------------------------------------------- #
+#: Setting this to a writable path turns the counter on. Unset (or empty), the
+#: server counts nothing and touches no file: `docs/design/skill-load-telemetry.md`
+#: is deferred pending a GDPR audit by CNRS legal counsel, and a telemetry
+#: feature that is on by default while its legal review is open is exactly the
+#: thing that audit exists to prevent.
+USAGE_PATH_ENV = "ASB_SKILLS_USAGE_PATH"
+
+USAGE_SCHEMA_VERSION = "0.1"
+
+#: The whole record. Nothing here identifies a user, a session, a machine or a
+#: query: which skill was loaded, through which tool, how many times, and the
+#: first and last hour it happened. Adding a field to this tuple is a privacy
+#: decision, not a formatting one.
+USAGE_FIELDS = ("skill_slug", "tool_name", "count", "first_seen", "last_seen")
+
+
+def usage_path() -> Path | None:
+    """The counter's output file, or ``None`` when the counter is off."""
+    raw = (os.environ.get(USAGE_PATH_ENV) or "").strip()
+    return Path(raw) if raw else None
+
+
+def _utc_hour() -> str:
+    """Now, truncated to the hour, UTC.
+
+    The telemetry design rounds timestamps to the hour so individual sessions
+    cannot be reconstructed from a sequence of events. The local counter keeps
+    that property, because this file is meant to be handed over as-is when the
+    collection-level rollup is eventually built — a local file that records
+    minute-resolution activity would have to be sanitised first, and the step
+    that has to be remembered is the step that gets forgotten.
+    """
+    return datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0).isoformat()
+
+
+def _read_usage(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def record_skill_load(skill_slug: str, tool_name: str) -> bool:
+    """Count one skill load in the local usage file. Returns whether it counted.
+
+    A no-op returning ``False`` unless ``ASB_SKILLS_USAGE_PATH`` names a file.
+    Read-modify-write of a small JSON document; a corrupt or unwritable file
+    costs the caller nothing, because a counter that can break a skill lookup
+    is worse than no counter.
+    """
+    path = usage_path()
+    if path is None:
+        return False
+    now = _utc_hour()
+    try:
+        doc = _read_usage(path)
+        records = doc.get("records")
+        records = [r for r in records if isinstance(r, dict)] if isinstance(records, list) else []
+        for record in records:
+            if record.get("skill_slug") == skill_slug and record.get("tool_name") == tool_name:
+                count = record.get("count")
+                record["count"] = (count if isinstance(count, int) else 0) + 1
+                record["last_seen"] = now
+                break
+        else:
+            records.append(
+                {
+                    "skill_slug": skill_slug,
+                    "tool_name": tool_name,
+                    "count": 1,
+                    "first_seen": now,
+                    "last_seen": now,
+                }
+            )
+        payload = {"schema_version": USAGE_SCHEMA_VERSION, "records": records}
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError:
+        return False
+    return True
 
 
 @mcp.tool()
@@ -80,14 +176,20 @@ def search_tools(query: str, collection: str | None = None, k: int = 10) -> list
 def get_skill(slug: str, collection: str) -> str:
     """Return the full SKILL.md of one skill. `collection` is 'slug' or 'slug/vN'."""
     text = idx.get_item_text(collection, "skills", slug)
-    return text if text is not None else f"NOT FOUND: skill {slug!r} in {collection!r}"
+    if text is None:
+        return f"NOT FOUND: skill {slug!r} in {collection!r}"
+    record_skill_load(slug, "get_skill")
+    return text
 
 
 @mcp.tool()
 def get_workflow(slug: str, collection: str) -> str:
     """Return the full SKILL.md of one composite workflow super-skill."""
     text = idx.get_item_text(collection, "workflows", slug)
-    return text if text is not None else f"NOT FOUND: workflow {slug!r} in {collection!r}"
+    if text is None:
+        return f"NOT FOUND: workflow {slug!r} in {collection!r}"
+    record_skill_load(slug, "get_workflow")
+    return text
 
 
 def main() -> None:

--- a/docs/design/skill-load-telemetry.md
+++ b/docs/design/skill-load-telemetry.md
@@ -1,8 +1,58 @@
 # Design: opt-in skill-load telemetry
 
-**Status:** design draft (v1.1+).
+**Status:** beacon DEFERRED (P1, blocked); local counter BUILT and dormant.
 **Author:** Holobiomics Lab.
-**Last revised:** 2026-05-25.
+**Last revised:** 2026-09-05.
+
+## Deferral record (2026-09-05)
+
+The **network beacon** described below is deferred at priority P1. It is
+blocked on open question 1: the GDPR compliance audit by CNRS legal counsel.
+Beaconing is a data-transfer event regardless of how little it carries, so no
+endpoint is stood up, no opt-in flag is shipped, and no deployment is enabled
+until that review closes. This is a legal dependency, not an engineering one —
+there is nothing to build faster.
+
+The **local half** is built. `asb_skill_collections/asb_mcp_server.py` counts
+skill loads in process and writes them to the path named by
+`ASB_SKILLS_USAGE_PATH`:
+
+```json
+{
+  "schema_version": "0.1",
+  "records": [
+    {"skill_slug": "<slug>", "tool_name": "get_skill",
+     "count": 3, "first_seen": "2026-09-05T09:00:00+00:00",
+     "last_seen": "2026-09-05T14:00:00+00:00"}
+  ]
+}
+```
+
+Properties, all testable and all tested
+(`tests/test_mcp_usage_counter.py`):
+
+- **Off by default.** With `ASB_SKILLS_USAGE_PATH` unset the server counts
+  nothing and opens no file. It is not enabled on any deployment while the
+  audit is open.
+- **No network.** The counter writes one local file. The server imports no
+  networking module for it, and the test asserts the tools still work with
+  `socket` monkeypatched to fail.
+- **No identifier.** The record carries the skill slug, the tool that fetched
+  it, a count and two timestamps. No user, session, host or process id; no
+  query string, because the only thing distinguishing one search from another
+  is the user's own words.
+- **Hour-resolution timestamps**, as this document's privacy stance requires,
+  so a sequence of records cannot reconstruct a session. The local file is
+  therefore already in the shape the eventual rollup would publish, with no
+  sanitising step to remember.
+- **Loads only.** `get_skill` and `get_workflow` count a *successful* fetch.
+  The three search tools count nothing.
+
+Two knowing differences from the phase-2 aggregation sketched under
+"Aggregation" below, to be reconciled when that job is written: the local file
+is keyed by `(skill_slug, tool_name)` rather than being a flat
+`skill_loads` map, and it counts **calls** rather than open question 3's
+once-per-session event, which an in-process counter has no way to observe.
 
 ## Problem
 
@@ -69,7 +119,7 @@ Published as part of the next routine release. No user-level data ever stored be
 
 ## Open questions
 
-1. **GDPR compliance audit.** CNRS legal counsel review required before launch. Even with IP stripping + no PII, the act of beaconing is a data-transfer event.
+1. **GDPR compliance audit.** CNRS legal counsel review required before launch. Even with IP stripping + no PII, the act of beaconing is a data-transfer event. **OPEN — this is what defers the beacon (see the deferral record above).** The local counter does not depend on it: it transfers nothing.
 2. **Self-hosting vs third-party.** Plausible / Umami / PostHog all have privacy-respecting modes. Self-hosting is full control but full operational burden. Recommendation: start with Plausible.io's hosted free-for-OSS tier in phase 1, migrate to self-hosted if scale demands.
 3. **Granularity of "skill load" event.** Definition: emitted ONCE per Claude Code session when a SKILL.md is fetched, NOT per inference call. This avoids inflating numbers for chatty agents.
 4. **Negative signal.** Do we capture "skill loaded but task failed"? Would help curation but raises the bar for what counts as PII (failure mode might reveal user context). Defer to phase 3.

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -31,6 +31,14 @@ Checks implemented (mapped to the §5 checklist + §6 safety gates):
                                 ``pii_patterns.json``).
   4. PROVENANCE              — gate 8.  Every skill carries a source DOI + a
                                 license tag.
+  5. LAYOUT / PACKAGING      — gate 10.  Every promoted skill directory holds
+                                ``SKILL.md`` and at most a pointer-form
+                                ``skill_kb.json``; the sidecar stays inside a
+                                per-skill and a collection-level byte budget
+                                (both FAIL loudly, neither truncates); and
+                                ``skills_index.json``, when the collection ships
+                                one, reconciles with the leaf directories on
+                                disk.
 
 Enforcement modes (CONTENT_POLICY.md §7):
   * default (advisory, staged-collections PRs): WARNs and FAILs are reported but
@@ -951,6 +959,172 @@ def check_workflows(collection_dir: Path) -> CheckResult:
 
 
 # --------------------------------------------------------------------------- #
+# Layout / packaging (gate 10).                                               #
+# --------------------------------------------------------------------------- #
+#: The only two files a promoted skill directory may hold.  ``SKILL.md`` is the
+#: skill; ``skill_kb.json`` is the pointer-form knowledge-base sidecar written
+#: by ``asb collection promote``.  Everything else — a ``docs/`` tree, a
+#: ``README.md``, a stray ``tools.json`` — is a Tier-1/Tier-2 intermediate that
+#: CONTENT_POLICY.md §5 keeps out of the public collection, so its presence is
+#: a packaging failure rather than a matter of taste.
+_KB_SIDECAR_FILENAME = "skill_kb.json"
+_ALLOWED_SKILL_FILES = frozenset({"SKILL.md", _KB_SIDECAR_FILENAME})
+
+#: Per-skill sidecar budget.  The promoter refuses to write a sidecar over this
+#: size rather than truncating it, and the gate refuses to ship one: a
+#: truncated pointer list is indistinguishable from a short one, which is
+#: exactly the confusion the knowledge-base status enum exists to prevent.
+_KB_SIDECAR_MAX_BYTES = 64 * 1024
+
+#: Collection-level budget over every sidecar in the collection.  The largest
+#: shipped collection holds 5,859 leaves; at the audited p99 sidecar size
+#: (7,446 B) that totals roughly 43 MB, so 64 MiB leaves room to grow while
+#: still refusing a collection whose sidecars have drifted an order of
+#: magnitude past what was measured.
+_COLLECTION_KB_MAX_BYTES = 64 * 1024 * 1024
+
+
+def _index_slugs(index_path: Path) -> tuple[set[str], str | None]:
+    """Slugs declared by ``skills_index.json``, or an error string.
+
+    Tolerates the two shapes the index has worn — a bare list of entries, and
+    an object wrapping one under ``skills`` — and accepts plain strings as
+    slugs.  An entry that declares no slug is drift, not a shape this reads
+    around, so it is reported rather than skipped.
+    """
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return set(), f"unreadable ({exc})"
+    if isinstance(data, dict):
+        data = data.get("skills", [])
+    if not isinstance(data, list):
+        return set(), "not a list of entries"
+    slugs: set[str] = set()
+    for i, entry in enumerate(data):
+        if isinstance(entry, str):
+            slugs.add(entry)
+        elif isinstance(entry, dict) and isinstance(entry.get("slug"), str):
+            slugs.add(entry["slug"])
+        else:
+            return slugs, f"entry {i} declares no slug"
+    return slugs, None
+
+
+def check_layout(
+    collection_dir: Path,
+    per_skill_max_bytes: int = _KB_SIDECAR_MAX_BYTES,
+    collection_max_bytes: int = _COLLECTION_KB_MAX_BYTES,
+) -> CheckResult:
+    """Every shipped skill directory holds ``SKILL.md`` + at most a sidecar.
+
+    Three things nothing checked before this gate existed:
+
+    * **A forbidden-files list.**  The one-file-per-skill invariant was a
+      convention.  A build that leaked a ``docs/`` tree into a promoted bundle
+      would have shipped it.
+    * **A byte budget.**  Both budgets FAIL loudly; neither truncates.  A
+      truncated sidecar still parses, so truncation would ship a knowledge-base
+      manifest that silently understates itself.
+    * **``skills_index.json`` ↔ leaf-directory consistency** (gate 10).  An
+      index entry with no skill on disk is a broken advertisement; a leaf the
+      index never names is unreachable through the router.  The check is
+      inert when the collection ships no index — most do not, and absence is
+      not drift.
+    """
+    res = CheckResult(
+        name="layout_packaging",
+        gates=[10],
+        hard_gate=True,
+        summary=(
+            "Each skill dir holds SKILL.md (+ optional skill_kb.json) within budget; "
+            "skills_index.json matches the leaf directories."
+        ),
+    )
+    n_skills = 0
+    total_kb_bytes = 0
+    for sk_md in _iter_skill_md(collection_dir):
+        skill_dir = sk_md.parent
+        if skill_dir == Path(collection_dir):
+            # `iter_skill_md` falls back to the collection root when no skill
+            # directory exists; the root is not a skill bundle, so the
+            # file-set rule does not apply to it.
+            continue
+        n_skills += 1
+        rel_dir = str(skill_dir.relative_to(collection_dir))
+        for path in sorted(skill_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(skill_dir).as_posix()
+            if rel in _ALLOWED_SKILL_FILES:
+                continue
+            res.add(
+                FAIL,
+                f"{rel_dir}: unexpected file {rel!r} — a promoted skill directory "
+                f"may hold only {sorted(_ALLOWED_SKILL_FILES)}.",
+                file=f"{rel_dir}/{rel}",
+            )
+        sidecar = skill_dir / _KB_SIDECAR_FILENAME
+        if sidecar.is_file():
+            size = sidecar.stat().st_size
+            total_kb_bytes += size
+            if size > per_skill_max_bytes:
+                res.add(
+                    FAIL,
+                    f"{rel_dir}: {_KB_SIDECAR_FILENAME} is {size} B, over the "
+                    f"{per_skill_max_bytes} B per-skill budget — refuse and rebuild "
+                    "it smaller; do not truncate.",
+                    file=f"{rel_dir}/{_KB_SIDECAR_FILENAME}",
+                    bytes=size,
+                    budget=per_skill_max_bytes,
+                )
+    if total_kb_bytes > collection_max_bytes:
+        res.add(
+            FAIL,
+            f"knowledge-base sidecars total {total_kb_bytes} B, over the "
+            f"{collection_max_bytes} B collection budget.",
+            bytes=total_kb_bytes,
+            budget=collection_max_bytes,
+        )
+
+    index_path = Path(collection_dir) / "skills_index.json"
+    if index_path.is_file():
+        indexed, error = _index_slugs(index_path)
+        if error:
+            res.add(FAIL, f"skills_index.json: {error}.", file="skills_index.json")
+        leaves = layout.leaf_dir(collection_dir)
+        on_disk = {
+            d.name
+            for d in (sorted(leaves.iterdir()) if leaves.is_dir() else [])
+            if d.is_dir() and not d.name.startswith("_") and (d / "SKILL.md").is_file()
+        }
+        for slug in sorted(indexed - on_disk):
+            res.add(
+                FAIL,
+                f"skills_index.json names {slug!r}, which has no SKILL.md under "
+                f"{leaves.name}/.",
+                file="skills_index.json",
+                slug=slug,
+            )
+        for slug in sorted(on_disk - indexed):
+            res.add(
+                FAIL,
+                f"{leaves.name}/{slug} is not named in skills_index.json — it cannot "
+                "be reached through the router.",
+                file="skills_index.json",
+                slug=slug,
+            )
+        res.summary = f"{res.summary}  ({len(indexed)} indexed, {len(on_disk)} on disk)"
+    else:
+        res.add(PASS, "No skills_index.json — index consistency is not applicable.")
+
+    res.summary = f"{res.summary}  ({n_skills} skills checked)"
+    if n_skills == 0:
+        res.add(WARN, "No SKILL.md files found in collection.")
+    return res
+
+
+# --------------------------------------------------------------------------- #
 # Corpus / collection loaders.                                                #
 # --------------------------------------------------------------------------- #
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -989,6 +1163,7 @@ def run_gate(
         check_pii_dual_use(collection_dir, collection_meta),
         check_provenance(collection_dir),
         check_workflows(collection_dir),
+        check_layout(collection_dir),
     ]
 
     counts = {PASS: 0, WARN: 0, FAIL: 0}
@@ -997,7 +1172,7 @@ def run_gate(
     overall = FAIL if counts[FAIL] else (WARN if counts[WARN] else PASS)
 
     mode = "strict" if strict else "advisory"
-    # Hard gates (2,5,6,8,15) are never overridable (§8.2); in strict mode any
+    # Hard gates (2,5,6,8,10,15) are never overridable (§8.2); in strict mode any
     # FAIL on these blocks.  In advisory mode (staged PRs) everything is reported
     # but the process exits 0.
     blocking_fail = strict and counts[FAIL] > 0
@@ -1019,12 +1194,15 @@ def run_gate(
             "similarity_ratio_threshold": _SIMILARITY_RATIO_THRESHOLD,
             "pii_config_version": PII_CONFIG["version"],
             "require_open_access": True,
+            "kb_sidecar_max_bytes": _KB_SIDECAR_MAX_BYTES,
+            "collection_kb_max_bytes": _COLLECTION_KB_MAX_BYTES,
+            "allowed_skill_files": sorted(_ALLOWED_SKILL_FILES),
         },
         "overall_status": overall,
         "blocking": blocking_fail,
         "exit_code": 1 if blocking_fail else 0,
         "summary_counts": counts,
-        "hard_gate_ids": [2, 5, 6, 8, 15],
+        "hard_gate_ids": [2, 5, 6, 8, 10, 15],
         "checks": [c.to_dict() for c in checks],
     }
     return report

--- a/tests/test_mcp_usage_counter.py
+++ b/tests/test_mcp_usage_counter.py
@@ -27,6 +27,7 @@ import pytest
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+pytest.importorskip("mcp", reason="the MCP server needs the 'mcp' extra")
 server = pytest.importorskip(
     "asb_skill_collections.asb_mcp_server",
     reason="the MCP server needs the 'mcp' extra",

--- a/tests/test_mcp_usage_counter.py
+++ b/tests/test_mcp_usage_counter.py
@@ -1,0 +1,297 @@
+"""The dormant local skill-load counter (INT-ASB-010, R10).
+
+`docs/design/skill-load-telemetry.md` specifies a network beacon, and that
+beacon is blocked on a GDPR audit by CNRS legal counsel. The audit is the
+reason to be careful, so the half that ships now is the half that transfers
+nothing: an in-process counter that writes one local file, only when
+`ASB_SKILLS_USAGE_PATH` names one.
+
+A telemetry feature is only as trustworthy as the tests that pin what it does
+*not* do, so most of this file is about absences — and an absence proves
+nothing unless the check that looks for it can be shown to fire. Every negative
+here is therefore two-sided: the same detector that finds no username, no
+network call and no query string in the real artefact is run against a
+deliberately contaminated one and must find it there.
+"""
+
+import json
+import os
+import platform
+import re
+import socket
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+server = pytest.importorskip(
+    "asb_skill_collections.asb_mcp_server",
+    reason="the MCP server needs the 'mcp' extra",
+)
+
+SLUG = "placeholder-procedure"
+BODY = "---\nname: placeholder-procedure\n---\n\n# placeholder\n"
+
+
+@pytest.fixture(autouse=True)
+def _counter_off_unless_a_test_turns_it_on(monkeypatch):
+    """No test inherits an enabled counter from the ambient environment."""
+    monkeypatch.delenv(server.USAGE_PATH_ENV, raising=False)
+
+
+@pytest.fixture
+def usage_file(tmp_path, monkeypatch):
+    path = tmp_path / "usage" / "usage.json"
+    monkeypatch.setenv(server.USAGE_PATH_ENV, str(path))
+    return path
+
+
+@pytest.fixture
+def found_skill(monkeypatch):
+    """Serve a placeholder body, so no test depends on a shipped collection."""
+    monkeypatch.setattr(server.idx, "get_item_text", lambda *a, **k: BODY)
+
+
+def _records(path):
+    return json.loads(path.read_text(encoding="utf-8"))["records"]
+
+
+# --------------------------------------------------------------------------- #
+# Off by default.                                                              #
+# --------------------------------------------------------------------------- #
+def test_the_counter_is_off_without_the_environment_variable(tmp_path):
+    assert server.usage_path() is None
+    assert server.record_skill_load(SLUG, "get_skill") is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_an_empty_variable_is_still_off(monkeypatch):
+    """`ASB_SKILLS_USAGE_PATH=` and `= ` are unset, not a file named ''."""
+    for value in ("", "   "):
+        monkeypatch.setenv(server.USAGE_PATH_ENV, value)
+        assert server.usage_path() is None
+        assert server.record_skill_load(SLUG, "get_skill") is False
+
+
+def test_fetching_a_skill_writes_nothing_while_the_counter_is_off(tmp_path, found_skill):
+    assert server.get_skill(SLUG, "placeholder/v1") == BODY
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_the_switch_is_the_only_thing_between_off_and_on(usage_file, found_skill):
+    """Two-sided: the same call that wrote nothing above writes a record here."""
+    server.get_skill(SLUG, "placeholder/v1")
+    assert usage_file.is_file()
+    assert _records(usage_file)[0]["skill_slug"] == SLUG
+
+
+# --------------------------------------------------------------------------- #
+# The designed schema.                                                         #
+# --------------------------------------------------------------------------- #
+def test_a_record_carries_exactly_the_designed_fields(usage_file):
+    assert server.record_skill_load(SLUG, "get_skill") is True
+    doc = json.loads(usage_file.read_text(encoding="utf-8"))
+    assert doc["schema_version"] == server.USAGE_SCHEMA_VERSION
+    assert sorted(doc) == ["records", "schema_version"]
+    (record,) = doc["records"]
+    assert sorted(record) == sorted(server.USAGE_FIELDS)
+    assert record == {
+        "skill_slug": SLUG,
+        "tool_name": "get_skill",
+        "count": 1,
+        "first_seen": record["last_seen"],
+        "last_seen": record["last_seen"],
+    }
+
+
+def test_the_designed_field_list_is_the_five_the_spec_names(usage_file):
+    assert set(server.USAGE_FIELDS) == {
+        "skill_slug",
+        "tool_name",
+        "count",
+        "first_seen",
+        "last_seen",
+    }
+
+
+def test_repeated_loads_increment_one_record_and_move_last_seen(usage_file, monkeypatch):
+    monkeypatch.setattr(server, "_utc_hour", lambda: "2026-09-05T09:00:00+00:00")
+    server.record_skill_load(SLUG, "get_skill")
+    monkeypatch.setattr(server, "_utc_hour", lambda: "2026-09-05T14:00:00+00:00")
+    server.record_skill_load(SLUG, "get_skill")
+
+    (record,) = _records(usage_file)
+    assert record["count"] == 2
+    assert record["first_seen"] == "2026-09-05T09:00:00+00:00"
+    assert record["last_seen"] == "2026-09-05T14:00:00+00:00"
+
+
+def test_records_are_keyed_by_skill_and_tool(usage_file):
+    server.record_skill_load(SLUG, "get_skill")
+    server.record_skill_load(SLUG, "get_workflow")
+    server.record_skill_load("other-procedure", "get_skill")
+    keys = {(r["skill_slug"], r["tool_name"]) for r in _records(usage_file)}
+    assert keys == {
+        (SLUG, "get_skill"),
+        (SLUG, "get_workflow"),
+        ("other-procedure", "get_skill"),
+    }
+
+
+def test_timestamps_are_hour_resolution(usage_file):
+    """The design's privacy stance: a sequence of records must not rebuild a session."""
+    server.record_skill_load(SLUG, "get_skill")
+    (record,) = _records(usage_file)
+    for field in ("first_seen", "last_seen"):
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:00:00\+00:00", record[field]), record[field]
+
+
+# --------------------------------------------------------------------------- #
+# What it counts, and what it refuses to.                                      #
+# --------------------------------------------------------------------------- #
+def test_a_missing_skill_is_not_a_load(usage_file, monkeypatch):
+    monkeypatch.setattr(server.idx, "get_item_text", lambda *a, **k: None)
+    assert server.get_skill(SLUG, "placeholder/v1").startswith("NOT FOUND")
+    assert not usage_file.exists()
+
+
+def test_get_workflow_counts_under_its_own_tool_name(usage_file, found_skill):
+    server.get_workflow(SLUG, "placeholder/v1")
+    (record,) = _records(usage_file)
+    assert record["tool_name"] == "get_workflow"
+
+
+def test_searching_records_nothing(usage_file, monkeypatch):
+    """A search is distinguished only by the user's own words; those are not ours."""
+    monkeypatch.setattr(server.idx, "search", lambda *a, **k: [{"slug": SLUG}])
+    server.search_skills("a query with the user's own words in it")
+    server.search_workflows("another query")
+    server.search_tools("a third")
+    assert not usage_file.exists()
+
+
+# --------------------------------------------------------------------------- #
+# No identifier — and the detector that says so can find one.                  #
+# --------------------------------------------------------------------------- #
+def _identifiers() -> dict:
+    ids = {"pid": str(os.getpid()), "user": os.environ.get("USER") or ""}
+    node = platform.node()
+    if node:
+        ids["host"] = node
+    return {k: v for k, v in ids.items() if v}
+
+
+def test_the_written_file_carries_no_identifier(usage_file, found_skill):
+    server.get_skill(SLUG, "placeholder/v1")
+    text = usage_file.read_text(encoding="utf-8")
+    found = {k: v for k, v in _identifiers().items() if v in text}
+    assert not found, f"the usage file leaks {found}"
+    for banned in ("session", "user", "host", "pid", "ip", "query", "path"):
+        assert banned not in text.lower(), f"the usage file mentions {banned!r}"
+
+
+def test_the_identifier_detector_actually_detects(usage_file):
+    """Two-sided: the same scan run over a contaminated file must fail."""
+    ids = _identifiers()
+    assert ids, "no identifier available to test the detector with"
+    usage_file.parent.mkdir(parents=True, exist_ok=True)
+    usage_file.write_text(json.dumps({"records": [{"host": v} for v in ids.values()]}))
+    text = usage_file.read_text(encoding="utf-8")
+    assert {k: v for k, v in ids.items() if v in text} == ids
+
+
+# --------------------------------------------------------------------------- #
+# No network — with the socket module monkeypatched to fail.                   #
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def no_network(monkeypatch):
+    """Any attempt to reach the network raises, loudly."""
+
+    def _refuse(*args, **kwargs):
+        raise AssertionError("the MCP server must make no network call")
+
+    for name in ("socket", "create_connection", "getaddrinfo", "gethostbyname"):
+        monkeypatch.setattr(socket, name, _refuse, raising=False)
+    return _refuse
+
+
+def test_the_counter_works_with_the_socket_module_broken(usage_file, found_skill, no_network):
+    assert server.get_skill(SLUG, "placeholder/v1") == BODY
+    assert server.record_skill_load(SLUG, "get_workflow") is True
+    assert len(_records(usage_file)) == 2
+
+
+def test_the_server_still_serves_with_the_socket_module_broken(found_skill, no_network):
+    """Off as well as on: neither path reaches for the network."""
+    assert server.get_skill(SLUG, "placeholder/v1") == BODY
+    assert server.get_workflow(SLUG, "placeholder/v1") == BODY
+
+
+def test_the_no_network_fixture_is_not_a_no_op(no_network):
+    """Two-sided: prove the trap is armed before trusting the tests above."""
+    with pytest.raises(AssertionError):
+        socket.create_connection(("127.0.0.1", 9))
+
+
+NETWORK_IMPORTS = ("urllib", "requests", "httpx", "http.client", "socket", "aiohttp")
+
+
+def test_the_server_module_imports_nothing_that_can_reach_the_network():
+    source = pathlib.Path(server.__file__).read_text(encoding="utf-8")
+    imports = re.findall(r"^\s*(?:import|from)\s+([\w.]+)", source, flags=re.MULTILINE)
+    offenders = [m for m in imports if m.split(".")[0] in {n.split(".")[0] for n in NETWORK_IMPORTS}]
+    assert not offenders, f"the server imports {offenders}"
+
+
+def test_the_import_scan_actually_detects(tmp_path):
+    contaminated = "import json\nimport urllib.request\nfrom requests import post\n"
+    imports = re.findall(r"^\s*(?:import|from)\s+([\w.]+)", contaminated, flags=re.MULTILINE)
+    offenders = [m for m in imports if m.split(".")[0] in {n.split(".")[0] for n in NETWORK_IMPORTS}]
+    assert offenders == ["urllib.request", "requests"]
+
+
+URL_RE = re.compile(r"\b(?:https?|ws|wss)://\S+")
+
+
+def test_no_endpoint_url_appears_anywhere_in_the_server():
+    """The beacon is deferred; an endpoint sitting in the source is half of one."""
+    source = pathlib.Path(server.__file__).read_text(encoding="utf-8")
+    assert URL_RE.findall(source) == []
+
+
+def test_the_url_scan_actually_detects():
+    assert URL_RE.findall(
+        "POST https://telemetry.example.invalid/v1/skill-load"
+    ) == ["https://telemetry.example.invalid/v1/skill-load"]
+
+
+# --------------------------------------------------------------------------- #
+# A counter that can break a skill lookup is worse than no counter.            #
+# --------------------------------------------------------------------------- #
+def test_a_corrupt_usage_file_is_replaced_rather_than_raising(usage_file):
+    usage_file.parent.mkdir(parents=True, exist_ok=True)
+    usage_file.write_text("{not json")
+    assert server.record_skill_load(SLUG, "get_skill") is True
+    assert _records(usage_file)[0]["count"] == 1
+
+
+def test_an_unwritable_path_is_reported_not_raised(tmp_path, monkeypatch, found_skill):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    monkeypatch.setenv(server.USAGE_PATH_ENV, str(blocker / "usage.json"))
+    assert server.record_skill_load(SLUG, "get_skill") is False
+    assert server.get_skill(SLUG, "placeholder/v1") == BODY
+
+
+def test_the_design_document_records_the_deferral():
+    doc = (REPO_ROOT / "docs" / "design" / "skill-load-telemetry.md").read_text(encoding="utf-8")
+    assert "DEFERRED" in doc
+    assert "GDPR" in doc and "CNRS legal counsel" in doc
+    assert server.USAGE_PATH_ENV in doc
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_release_gate_layout.py
+++ b/tests/test_release_gate_layout.py
@@ -1,0 +1,263 @@
+"""The layout gate: one file per skill, two at most (INT-ASB-010, R6).
+
+Before this check existed the release gate ran five *content* checks and no
+packaging check at all — no required-files list, no forbidden-files list, no
+byte budget, and nothing reconciling ``skills_index.json`` against the skills
+actually on disk. The one-file-per-skill invariant was a convention, so a build
+that leaked a ``docs/`` tree or a private intermediate into a promoted bundle
+would have shipped it, and an index entry pointing at a skill that was never
+written would have advertised a 404.
+
+The four cases the spec names are pinned below, plus the two things a gate
+like this most easily gets wrong:
+
+* **It must not fail on the tree that is already shipped.** All four published
+  collections hold exactly ``SKILL.md`` in every skill directory, and
+  ``collections/epigenomics/v1`` is driven through ``--strict`` by an existing
+  test that requires exit 0. A gate that reddens the current release is not a
+  gate, it is an outage, so the real collections are asserted to pass.
+* **It must refuse rather than truncate.** Both budgets FAIL. A truncated
+  sidecar still parses, so truncating would ship a knowledge-base manifest that
+  silently understates itself — the exact confusion the status enum exists to
+  prevent.
+"""
+
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from scripts import release_gate  # noqa: E402
+
+CLEAN_BODY = "# skill\nChromatographic separation improved analyte resolution.\n"
+LEAF_FM = {"name": "s1", "derived_from": [{"doi": "10.1/x"}], "license": "CC-BY-4.0"}
+PAPERS = [{"doi": "10.1/x", "status": "included", "access": {"type": "gold-oa"}, "repo_url": ""}]
+
+
+def _collection(tmp_path, slugs=("s1",), leaf_dirname="skills"):
+    """A minimal collection that passes every other check in the gate."""
+    col = tmp_path / "col"
+    (col / leaf_dirname).mkdir(parents=True)
+    (col / "corpus.yaml").write_text(yaml.safe_dump({"papers": PAPERS}))
+    for slug in slugs:
+        d = col / leaf_dirname / slug
+        d.mkdir()
+        fm = dict(LEAF_FM, name=slug)
+        (d / "SKILL.md").write_text("---\n" + yaml.safe_dump(fm) + "---\n" + CLEAN_BODY)
+    return col
+
+
+def _sidecar(n_entries=1):
+    return {
+        "schema_version": 1,
+        "n_entries": n_entries,
+        "total_bytes": 0,
+        "notes": "pointer form",
+        "entries": [
+            {"path": f"e{i}.md", "kind": "readme", "source_url": "", "sha256": "0" * 64, "bytes": 0}
+            for i in range(n_entries)
+        ],
+    }
+
+
+def _layout(col, **kwargs):
+    return release_gate.check_layout(col, **kwargs)
+
+
+def _messages(res):
+    return " | ".join(d["message"] for d in res.details)
+
+
+# --------------------------------------------------------------------------- #
+# The four cases of the spec table.                                            #
+# --------------------------------------------------------------------------- #
+def test_skill_md_alone_passes(tmp_path):
+    res = _layout(_collection(tmp_path))
+    assert res.status == release_gate.PASS, _messages(res)
+
+
+def test_skill_md_plus_sidecar_passes(tmp_path):
+    col = _collection(tmp_path)
+    (col / "skills" / "s1" / "skill_kb.json").write_text(json.dumps(_sidecar()))
+    res = _layout(col)
+    assert res.status == release_gate.PASS, _messages(res)
+
+
+def test_an_extra_file_fails(tmp_path):
+    col = _collection(tmp_path)
+    (col / "skills" / "s1" / "README.md").write_text("# leaked intermediate\n")
+    res = _layout(col)
+    assert res.status == release_gate.FAIL
+    assert "README.md" in _messages(res)
+
+
+def test_a_leaked_docs_tree_fails_by_its_nested_path(tmp_path):
+    """The shape promote now measures and refuses to copy — named, not just counted."""
+    col = _collection(tmp_path)
+    docs = col / "skills" / "s1" / "docs"
+    docs.mkdir()
+    (docs / "page.md").write_text("text\n")
+    res = _layout(col)
+    assert res.status == release_gate.FAIL
+    assert "docs/page.md" in _messages(res)
+
+
+def test_an_over_budget_sidecar_fails(tmp_path):
+    col = _collection(tmp_path)
+    (col / "skills" / "s1" / "skill_kb.json").write_text(json.dumps(_sidecar(2000)))
+    res = _layout(col)
+    assert res.status == release_gate.FAIL
+    over = [d for d in res.details if "per-skill budget" in d["message"]]
+    assert over and over[0]["bytes"] > release_gate._KB_SIDECAR_MAX_BYTES
+    assert over[0]["budget"] == release_gate._KB_SIDECAR_MAX_BYTES
+
+
+def test_the_over_budget_sidecar_is_refused_not_truncated(tmp_path):
+    """The gate reports; it must not rewrite the collection it is inspecting."""
+    col = _collection(tmp_path)
+    sidecar = col / "skills" / "s1" / "skill_kb.json"
+    sidecar.write_text(json.dumps(_sidecar(2000)))
+    before = sidecar.read_bytes()
+    _layout(col)
+    assert sidecar.read_bytes() == before
+    assert "do not truncate" in _messages(_layout(col))
+
+
+def test_index_mismatch_fails_in_both_directions(tmp_path):
+    col = _collection(tmp_path, slugs=("alpha", "beta"), leaf_dirname="leaves")
+    (col / "skills").mkdir()
+    (col / "skills_index.json").write_text(
+        json.dumps([{"slug": "alpha"}, {"slug": "never-written"}])
+    )
+    res = _layout(col)
+    assert res.status == release_gate.FAIL
+    msgs = _messages(res)
+    assert "never-written" in msgs, "an index entry with no skill on disk must fail"
+    assert "leaves/beta" in msgs, "a leaf the index never names must fail"
+    assert "alpha" not in msgs.replace("leaves/beta", ""), "the matching slug must not be flagged"
+
+
+# --------------------------------------------------------------------------- #
+# Boundaries and the two-sided checks.                                         #
+# --------------------------------------------------------------------------- #
+def test_the_budget_boundary_is_the_declared_constant(tmp_path):
+    col = _collection(tmp_path, slugs=("s1", "s2"))
+    exact = col / "skills" / "s1" / "skill_kb.json"
+    exact.write_bytes(b"x" * release_gate._KB_SIDECAR_MAX_BYTES)
+    assert _layout(col).status == release_gate.PASS
+
+    one_over = col / "skills" / "s2" / "skill_kb.json"
+    one_over.write_bytes(b"x" * (release_gate._KB_SIDECAR_MAX_BYTES + 1))
+    assert _layout(col).status == release_gate.FAIL
+
+
+def test_the_collection_budget_fails_even_when_every_sidecar_is_legal(tmp_path):
+    """Two budgets, two failure modes: many small sidecars still add up."""
+    col = _collection(tmp_path, slugs=("s1", "s2", "s3"))
+    for slug in ("s1", "s2", "s3"):
+        (col / "skills" / slug / "skill_kb.json").write_bytes(b"x" * 1000)
+
+    generous = _layout(col, collection_max_bytes=10_000)
+    assert generous.status == release_gate.PASS
+
+    tight = _layout(col, collection_max_bytes=2_500)
+    assert tight.status == release_gate.FAIL
+    total = [d for d in tight.details if "collection budget" in d["message"]]
+    assert total and total[0]["bytes"] == 3000
+    assert not [d for d in tight.details if "per-skill budget" in d["message"]], (
+        "no single sidecar is over its own budget; only the collection total is"
+    )
+
+
+def test_a_collection_without_an_index_is_not_applicable_rather_than_failing(tmp_path):
+    """Three of the four shipped collections have no index; absence is not drift."""
+    res = _layout(_collection(tmp_path))
+    assert res.status == release_gate.PASS
+    assert "not applicable" in _messages(res)
+
+
+def test_an_unreadable_index_fails_rather_than_passing_quietly(tmp_path):
+    col = _collection(tmp_path, slugs=("alpha",), leaf_dirname="leaves")
+    (col / "skills_index.json").write_text("{not json")
+    res = _layout(col)
+    assert res.status == release_gate.FAIL
+    assert "unreadable" in _messages(res)
+
+
+def test_infrastructure_and_workflow_dirs_are_not_leaf_bundles(tmp_path):
+    """`_router` and `workflows/` are composites; the leaf file-set rule is not theirs."""
+    col = _collection(tmp_path, slugs=("s1",), leaf_dirname="leaves")
+    for rel in ("skills/_router", "workflows/a-super-skill"):
+        d = col / rel
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("---\nname: x\n---\n")
+        (d / "workflow.yaml").write_text("steps: []\n")
+    assert _layout(col).status == release_gate.PASS
+
+
+# --------------------------------------------------------------------------- #
+# The gate is wired in, and the shipped collections still pass it.             #
+# --------------------------------------------------------------------------- #
+def test_the_check_runs_as_part_of_the_gate(tmp_path):
+    col = _collection(tmp_path)
+    report = release_gate.run_gate(col, None, strict=True)
+    names = [c["name"] for c in report["checks"]]
+    assert "layout_packaging" in names
+    entry = next(c for c in report["checks"] if c["name"] == "layout_packaging")
+    assert entry["gates"] == [10] and entry["hard_gate"] is True
+    assert 10 in report["hard_gate_ids"]
+    assert report["policy"]["kb_sidecar_max_bytes"] == release_gate._KB_SIDECAR_MAX_BYTES
+    assert report["policy"]["allowed_skill_files"] == ["SKILL.md", "skill_kb.json"]
+
+
+def test_a_layout_failure_blocks_a_strict_promotion(tmp_path):
+    """The gate's promote/block decision is main()'s exit code."""
+    col = _collection(tmp_path)
+    assert release_gate.main([str(col), "--strict", "--report", str(tmp_path / "r1.json")]) == 0
+
+    (col / "skills" / "s1" / "tools.json").write_text("[]")
+    assert release_gate.main([str(col), "--strict", "--report", str(tmp_path / "r2.json")]) == 1
+
+    report = json.loads((tmp_path / "r2.json").read_text())
+    failed = [c["name"] for c in report["checks"] if c["status"] == release_gate.FAIL]
+    assert failed == ["layout_packaging"], f"the layout check must be what blocks, got {failed}"
+
+
+def test_a_layout_failure_is_advisory_without_strict(tmp_path):
+    col = _collection(tmp_path)
+    (col / "skills" / "s1" / "tools.json").write_text("[]")
+    assert release_gate.main([str(col), "--report", str(tmp_path / "r.json")]) == 0
+
+
+SHIPPED = sorted(p.parent for p in REPO_ROOT.glob("collections/*/v*/collection.yaml"))
+
+
+@pytest.mark.parametrize("col", SHIPPED, ids=[f"{p.parent.name}-{p.name}" for p in SHIPPED])
+def test_every_shipped_collection_already_satisfies_the_layout_gate(col):
+    """Read-only over the real tree: a new gate that reddens the release is an outage.
+
+    `test_scripts_are_path_invocable` drives `collections/epigenomics/v1` through
+    `--strict` and requires exit 0, so this is not merely nice to have.
+    """
+    res = _layout(col)
+    assert res.status == release_gate.PASS, _messages(res)
+
+
+def test_the_shipped_set_is_not_empty():
+    """A parametrized guard over an empty list passes for the wrong reason."""
+    assert len(SHIPPED) >= 4
+
+
+def test_the_check_is_not_vacuous_on_the_shipped_tree():
+    """It really walked those skills rather than finding nothing to walk."""
+    counts = [int(_layout(c).summary.split("(")[-1].split()[0]) for c in SHIPPED]
+    assert all(n > 0 for n in counts), counts
+    assert sum(counts) > 1000
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Second half of the corpus-skills promotion hygiene work (INT-ASB-010). The ASB half, which writes the `skill_kb.json` pointer sidecar this gate admits, is on `feat/promotion-hygiene` in AgenticScienceBuilder.

**Release gate: `layout_packaging` (gate 10, hard).** A promoted skill directory may hold `SKILL.md` and, optionally, the `skill_kb.json` pointer sidecar; any other file fails the check by relative path. The sidecar is capped at 64 KiB per skill and at 64 MiB for the collection as a whole (the largest shipped collection holds 5,859 leaves, which at the audited p99 sidecar size of 7,446 bytes totals about 43 MB). When `skills_index.json` is present, its slugs are reconciled both ways against the leaf directories. The check joins `hard_gate_ids` (`[2, 5, 6, 8, 15]` becomes `[2, 5, 6, 8, 10, 15]`), and the policy keys `kb_sidecar_max_bytes`, `collection_kb_max_bytes` and `allowed_skill_files` are recorded in the report. `check_layout` returns PASS on all four shipped collections.

**MCP server: local skill-load counter.** `get_skill` and `get_workflow` count successful fetches into the JSON file named by `ASB_SKILLS_USAGE_PATH` (slug, tool, count, first and last seen at hour resolution; no user, session, host or query). Without the variable the counter is a no-op, and it is enabled on no deployment. It counts calls rather than sessions, which an in-process counter cannot observe; the design document records the difference. The remote beacon proposed there is deferred until the CNRS GDPR audit closes.

Notes for review:
- The tracked `gate_report.json` files under `collections/` predate gate 10 and are not regenerated here; the next promotion run rewrites them.
- The oversized-sidecar case is built inline in the test's temporary directory rather than committed as a 64 KiB fixture.
- `python -m pytest tests/ -q`: 1152 passed, 3 skipped.
